### PR TITLE
add a dry route for radio button routing

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -6,6 +6,26 @@ router.get('/', function (req, res) {
   res.render('index')
 })
 
+// Make pages with radio buttons named 'radio-group' route to their 'value' property
+
+router.get('*', function (req, res) {
+
+  //get the answer from the query string (eg. ?over18=false)
+  var radioGroup = req.query['radio-group'];
+
+  if (radioGroup) {
+
+    res.redirect(radioGroup);
+
+  } else {
+
+    // if radio-group is any other value (or is missing) render the page requested
+    var str = req.path;
+    res.render( str.substring(1) );
+
+  }
+});
+
 // add your routes here
 
 module.exports = router


### PR DESCRIPTION
Something I've just put in my prototype which it feels like should just be there by default. Makes radio buttons route to whatever their `value` element says.