### PR TITLE
Improve the error message if no auth set up

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -38,11 +38,12 @@ exports.addNunjucksFilters = function (env) {
 exports.basicAuth = function (username, password) {
   return function (req, res, next) {
     if (!username || !password) {
-      var docsUrl = "https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku#6-set-a-username-and-password"
+      var docsUrl = 'https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku#6-set-a-username-and-password'
       console.log('Username or password is not set.')
-      return res.send('<h1>Error: username or password not set.</h1><p>All prototypes should be protected from \
-      accidental discovery by the public when published online.</p><p>You need to set a username and password \
-      to make prototypes visible online.</p><p><a href="' + docsUrl + '">See guidance for doing this</a>.</p>')
+      return res.send('<h1>Error: username or password not set.</h1>' +
+                      '<p>All prototypes should be protected from accidental discovery by the public when published online.</p>' +
+                      '<p>You need to set a username and password to make prototypes visible online.</p>' +
+                      '<p><a href="' + docsUrl + '">See guidance for doing this</a>.</p>')
     }
 
     var user = basicAuth(req)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -38,8 +38,11 @@ exports.addNunjucksFilters = function (env) {
 exports.basicAuth = function (username, password) {
   return function (req, res, next) {
     if (!username || !password) {
+      var docsUrl = "https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku#6-set-a-username-and-password"
       console.log('Username or password is not set.')
-      return res.send('<h1>Error: username or password not set.</h1><p>All prototypes should be protected from accidental discovery by the public when published online.</p> <p>The GOV.UK prototype kit will not make your work visible online until you&apos;ve added a username and password for basic authentication.</p> <p> <a href="https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku#6-set-a-username-and-password">See guidance for doing this</a>.</p>')
+      return res.send('<h1>Error: username or password not set.</h1><p>All prototypes should be protected from \
+      accidental discovery by the public when published online.</p><p>You need to set a username and password \
+      to make prototypes visible online.</p><p><a href="' + docsUrl + '">See guidance for doing this</a>.</p>')
     }
 
     var user = basicAuth(req)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,7 +39,7 @@ exports.basicAuth = function (username, password) {
   return function (req, res, next) {
     if (!username || !password) {
       console.log('Username or password is not set.')
-      return res.send('<h1>Error:</h1><p>Username or password not set. <a href="https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku#5-set-a-username-and-password">See guidance for setting these</a>.</p>')
+      return res.send('<h1>Error: username or password not set.</h1><p>All prototypes should be protected from accidental discovery by the public when published online.</p> <p>The GOV.UK prototype kit will not make your work visible online until you&apos;ve added a username and password for basic authentication.</p> <p> <a href="https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku#6-set-a-username-and-password">See guidance for doing this</a>.</p>')
     }
 
     var user = basicAuth(req)


### PR DESCRIPTION
This pull request contains an improved error message for users who have not set up basic auth on their prototypes. It was done after some PaaS testing in which the previous version caused participants a few issues. 

There were 2 previous PRs opened for this (See #375 and #377) but this is the tidied up version.