### PR TITLE
Files for deploying to GOVUK PaaS

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,9 @@
+.sass-cache
+.DS_Store
+.start.pid
+.port.tmp
+public
+lib/govuk_template.html
+govuk_modules
+node_modules/*
+.tmuxp.*

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,4 @@
+---
+applications:
+- name: [PUT-PROTOTYPE-NAME-HERE]
+  memory: 128M


### PR DESCRIPTION
We've added 2 files that make it easier to deploy a prototype to the GOVUK PaaS.

.cfignore lists all the files and dirs that don't need to be copied across to the PaaS when deploying. It is a replica of the .gitignore file. This makes deployments quicker for users.

The manifest.yml file contains some config items for a prototype. In particular the name which ends up making up part of the URL. Using a manifest in this way makes it simpler for users to deploy prototypes to the intended location. It reduces the complexity of the `cf push` command and reduces the opportunity to accidentally push a prototype to an incorrect location. Two things noticed during testing.