### PR TITLE
Create middleware to send useful variables to views

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -179,6 +179,15 @@ exports.matchMdRoutes = function (req, res) {
   return false
 }
 
+// Store useful variables to locals
+
+exports.pageLocals = function (req, res, next) {
+  res.locals.pagePath = req.path
+  res.locals.pageName = req.path.split('/').pop()
+  res.locals.domain = req.hostname
+  next()
+}
+
 // store data from POST body or GET query in session
 
 var storeData = function (input, store) {

--- a/server.js
+++ b/server.js
@@ -177,6 +177,9 @@ app.use(function (req, res, next) {
   next()
 })
 
+// Send useful variables to all views - such as path and domain
+app.use(utils.pageLocals)
+
 app.get('/robots.txt', function (req, res) {
   res.type('text/plain')
   res.send('User-agent: *\nDisallow: /')


### PR DESCRIPTION
Add middleware to send hostname, path, and page name to all views.

This could be useful for cases where a page may want to know about itself - such as building a menu to check if the current nav item matches the page name.