### PR TITLE
Add file based session storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ govuk_modules
 node_modules/*
 .tmuxp.*
 package-lock.json
+sessions

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .DS_Store
 .start.pid
 .port.tmp
+.session.name.tmp
+.session.secret.tmp
 public
 lib/govuk_template.html
 govuk_modules

--- a/app/config.js
+++ b/app/config.js
@@ -25,6 +25,9 @@ module.exports = {
   cookieText: 'GOV.UK uses cookies to make the site simpler. <a href="#">Find out more about cookies</a>',
 
   // Enable or disable Browser Sync
-  useBrowserSync: 'true'
+  useBrowserSync: 'true',
+
+  // Activate file-based session store
+  useFileSessionStore: false
 
 }

--- a/lib/template.env
+++ b/lib/template.env
@@ -15,8 +15,5 @@
 #
 # var key = process.env.EXAMPLE_API_KEY
 
-SESSION_NAME=
-SESSION_SECRET=
-
 # =========================================
 # INSERT YOUR DATA HERE:

--- a/lib/template.env
+++ b/lib/template.env
@@ -15,6 +15,8 @@
 #
 # var key = process.env.EXAMPLE_API_KEY
 
+SESSION_NAME=
+SESSION_SECRET=
+
 # =========================================
 # INSERT YOUR DATA HERE:
-

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "require-dir": "^0.3.0",
     "run-sequence": "^1.2.2",
     "serve-favicon": "2.4.2",
+    "session-file-store": "^1.2.0",
     "standard": "^10.0.2",
     "supertest": "^3.0.0",
     "sync-request": "^4.0.3"

--- a/server.js
+++ b/server.js
@@ -127,8 +127,8 @@ let cookie = {
 }
 
 if (config.useFileSessionStore && config.useFileSessionStore === true) {
-  var name;
-  var secret;
+  var name
+  var secret
 
   try {
     name = String(fs.readFileSync(path.join(__dirname, '/.session.name.tmp')))
@@ -174,7 +174,6 @@ if (config.useFileSessionStore && config.useFileSessionStore === true) {
     secret: crypto.randomBytes(64).toString('hex')
   }))
 }
-
 
 // Automatically store all data users enter
 if (useAutoStoreData === 'true') {

--- a/server.js
+++ b/server.js
@@ -120,17 +120,40 @@ app.locals.releaseVersion = 'v' + releaseVersion
 app.locals.serviceName = config.serviceName
 
 // Support session data
-app.use(session({
-  cookie: {
-    maxAge: 1000 * 60 * 60 * 4, // 4 hours
-    secure: isSecure
-  },
-  // use random name to avoid clashes with other prototypes
-  name: 'govuk-prototype-kit-' + crypto.randomBytes(64).toString('hex'),
-  resave: false,
-  saveUninitialized: false,
-  secret: crypto.randomBytes(64).toString('hex')
-}))
+if (config.useFileSessionStore && config.useFileSessionStore === true) {
+  var FileStore = require('session-file-store')(session)
+
+  app.use(session({
+    store: new FileStore({
+      path: './sessions',
+      encrypt: true,
+      reapInterval: 300,
+      secret: 'SuperSecretKey'
+    }),
+    secret: 'SuperSecretKey',
+    name: 'govuk-prototype-kit-session',
+    resave: false,
+    saveUninitialized: false,
+    cookie: {
+      maxAge: 1000 * 60 * 60 * 4, // 4 hours
+      secure: isSecure
+    },
+    unset: 'destroy'
+  }))
+} else {
+  app.use(session({
+    cookie: {
+      maxAge: 1000 * 60 * 60 * 4, // 4 hours
+      secure: isSecure
+    },
+    // use random name to avoid clashes with other prototypes
+    name: 'govuk-prototype-kit-' + crypto.randomBytes(64).toString('hex'),
+    resave: false,
+    saveUninitialized: false,
+    secret: crypto.randomBytes(64).toString('hex')
+  }))
+}
+
 
 // Automatically store all data users enter
 if (useAutoStoreData === 'true') {

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 // Core dependencies
 const crypto = require('crypto')
+const fs = require('fs')
 const path = require('path')
 
 // NPM dependencies
@@ -122,14 +123,25 @@ app.locals.serviceName = config.serviceName
 // Support session data
 if (config.useFileSessionStore && config.useFileSessionStore === true) {
 
-  if (!process.env.SESSION_SECRET || process.env.SESSION_SECRET === '') {
-    console.error('[CONFIG ERROR] You must provide SESSION_SECRET in your `.env` to use file-based session storage.')
-    process.exit(1)
+  var name;
+  var secret;
+
+  try {
+    name = String(fs.readFileSync(path.join(__dirname, '/.session.name.tmp')))
+    console.log(`Got session name from file: "${name}"`)
+  } catch (e) {
+    name = 'govuk-prototype-kit-' + crypto.randomBytes(64).toString('hex')
+    fs.writeFileSync(path.join(__dirname, '/.session.name.tmp'), name)
+    console.log(`Created new session name: "${name}"`)
   }
 
-  if (!process.env.SESSION_NAME || process.env.SESSION_NAME === '') {
-    console.error('[CONFIG ERROR] You must provide SESSION_NAME in your `.env` to use file-based session storage.')
-    process.exit(1)
+  try {
+    secret = String(fs.readFileSync(path.join(__dirname, '/.session.secret.tmp')))
+    console.log(`Got session secret from file: "${secret}"`)
+  } catch (e) {
+    secret = crypto.randomBytes(64).toString('hex')
+    fs.writeFileSync(path.join(__dirname, '/.session.secret.tmp'), secret)
+    console.log(`Created new session secret: "${secret}"`)
   }
 
   var FileStore = require('session-file-store')(session)

--- a/server.js
+++ b/server.js
@@ -121,8 +121,12 @@ app.locals.releaseVersion = 'v' + releaseVersion
 app.locals.serviceName = config.serviceName
 
 // Support session data
-if (config.useFileSessionStore && config.useFileSessionStore === true) {
+let cookie = {
+  maxAge: 1000 * 60 * 60 * 4, // 4 hours
+  secure: isSecure
+}
 
+if (config.useFileSessionStore && config.useFileSessionStore === true) {
   var name;
   var secret;
 
@@ -157,18 +161,12 @@ if (config.useFileSessionStore && config.useFileSessionStore === true) {
     name: name,
     resave: false,
     saveUninitialized: false,
-    cookie: {
-      maxAge: 1000 * 60 * 60 * 4, // 4 hours
-      secure: isSecure
-    },
+    cookie: cookie,
     unset: 'destroy'
   }))
 } else {
   app.use(session({
-    cookie: {
-      maxAge: 1000 * 60 * 60 * 4, // 4 hours
-      secure: isSecure
-    },
+    cookie: cookie,
     // use random name to avoid clashes with other prototypes
     name: 'govuk-prototype-kit-' + crypto.randomBytes(64).toString('hex'),
     resave: false,

--- a/server.js
+++ b/server.js
@@ -121,6 +121,17 @@ app.locals.serviceName = config.serviceName
 
 // Support session data
 if (config.useFileSessionStore && config.useFileSessionStore === true) {
+
+  if (!process.env.SESSION_SECRET || process.env.SESSION_SECRET === '') {
+    console.error('[CONFIG ERROR] You must provide SESSION_SECRET in your `.env` to use file-based session storage.')
+    process.exit(1)
+  }
+
+  if (!process.env.SESSION_NAME || process.env.SESSION_NAME === '') {
+    console.error('[CONFIG ERROR] You must provide SESSION_NAME in your `.env` to use file-based session storage.')
+    process.exit(1)
+  }
+
   var FileStore = require('session-file-store')(session)
 
   app.use(session({
@@ -128,10 +139,10 @@ if (config.useFileSessionStore && config.useFileSessionStore === true) {
       path: './sessions',
       encrypt: true,
       reapInterval: 300,
-      secret: 'SuperSecretKey'
+      secret: process.env.SESSION_SECRET
     }),
-    secret: 'SuperSecretKey',
-    name: 'govuk-prototype-kit-session',
+    secret: process.env.SESSION_SECRET,
+    name: process.env.SESSION_NAME,
     resave: false,
     saveUninitialized: false,
     cookie: {

--- a/server.js
+++ b/server.js
@@ -151,10 +151,10 @@ if (config.useFileSessionStore && config.useFileSessionStore === true) {
       path: './sessions',
       encrypt: true,
       reapInterval: 300,
-      secret: process.env.SESSION_SECRET
+      secret: secret
     }),
-    secret: process.env.SESSION_SECRET,
-    name: process.env.SESSION_NAME,
+    secret: secret,
+    name: name,
     resave: false,
     saveUninitialized: false,
     cookie: {


### PR DESCRIPTION
This pull request adds in the option to use file-based session storage, which is configured via `app/config.js`.

If being used, the app will generate a name and secret for session storage. These are stored in temporary files, so sessions can be reused across app restarts.

Resolves #472