### PR TITLE
Add kit version to footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 New Features:
 
 - [Rename and reorganise template pages to be easier to use](https://github.com/alphagov/govuk-prototype-kit/pull/578)
+- [Add kit version and link to footer](https://github.com/alphagov/govuk-prototype-kit/pull/476)
 
 Bug fixes:
 

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -48,7 +48,7 @@
       meta: {
         items: [
           {
-            href: "https://github.com/alphagov/govuk-prototype-kit/releases/tag/" + releaseVersion,
+            href: "https://govuk-prototype-kit.herokuapp.com/",
             text: "GOV.UK Prototype Kit " + releaseVersion
           },
           {

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -48,6 +48,10 @@
       meta: {
         items: [
           {
+            href: "https://github.com/alphagov/govuk-prototype-kit/releases/tag/" + releaseVersion,
+            text: "GOV.UK Prototype Kit " + releaseVersion
+          },
+          {
             href: "/prototype-admin/clear-data",
             text: "Clear data"
           }


### PR DESCRIPTION
This change adds a line to the footer, which states the current version of the prototyping kit being used. Screenshot below.

![footer-prototype-version](https://user-images.githubusercontent.com/7910819/34732992-d06d375c-f55e-11e7-97b1-3f22fcd119f4.png)

This makes it clear to users which version of the kit is being used, as they don't need to check the console or source code for this information when using a prototype.

Resolves #455.