### PR TITLE
Add console log on 404s

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -201,6 +201,7 @@ exports.matchRoutes = function (req, res) {
     if (err) {
       res.render(path + '/index', function (err2, html) {
         if (err2) {
+          console.error(`Error: 404 - could not find '${path}'`)
           res.status(404).send(err + '<br>' + err2)
         } else {
           res.end(html)


### PR DESCRIPTION
Add a console log statement when the app cannot resolve a requested route. This adds another source of information on what is happening within the app, which is especially helpful if you only have access to the console and not the client.

Resolves #417