### PR TITLE
Use path to gulp executable for spawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ New features:
 - [Restart the app if environment variables change](https://github.com/alphagov/govuk-prototype-kit/pull/389)
 - [Make it more difficult to accidentally clear the session data](https://github.com/alphagov/govuk-prototype-kit/pull/588)
 
+
+Bug fixes:
+
+- [Use path to gulp executable for spawn](https://github.com/alphagov/govuk-prototype-kit/pull/479)
+
 # 7.1.0
 
 New Features:

--- a/start.js
+++ b/start.js
@@ -71,7 +71,7 @@ function runGulp () {
   const spawn = require('cross-spawn')
 
   process.env['FORCE_COLOR'] = 1
-  var gulp = spawn('gulp')
+  var gulp = spawn('./node_modules/.bin/gulp')
   gulp.stdout.pipe(process.stdout)
   gulp.stderr.pipe(process.stderr)
   process.stdin.pipe(gulp.stdin)


### PR DESCRIPTION
Previously the spawn command just took `gulp` as an argument, which worked when running the app via `npm start`. However, running `node start` would fail because it couldn't find `gulp`. It would look globally, whereas `npm start` would look locally. Referencing the path within `node_modules` directly means both commands can be used to start and run the app.

Resolves #393.