### PR TITLE
Add standardjs to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "prompt": "^1.0.0",
     "require-dir": "^1.0.0",
     "run-sequence": "^2.2.1",
-    "standard": "^11.0.1",
     "supertest": "^3.0.0",
     "sync-request": "^6.0.0",
     "universal-analytics": "^0.4.16",
@@ -51,5 +50,8 @@
     "ignore": [
       "nunjucks"
     ]
+  },
+  "devDependencies": {
+    "standard": "^11.0.1"
   }
 }


### PR DESCRIPTION
I understand an app's `dependencies` being anything the app needs to actually run. Anything in `devDependencies` is needed only to develop the app. The advantages of having this distinction vary according to what your build process looks like (if you use webpack, for instance). An advantage is that anyone not interested in developing the app could run it with `npm install --production`, which omits all the modules in `devDependencies`.
People have different opinions about this. A couple of links:
https://stackoverflow.com/questions/18875674/whats-the-difference-between-dependencies-devdependencies-and-peerdependencies
https://github.com/webpack/webpack/issues/520