### PR TITLE
DO NOT MERGE: Add support for global data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+New features:
+
+- [#501 Add default session data](https://github.com/alphagov/govuk_prototype_kit/pull/501)
+
 Bug fixes:
 
 - [#491 Remove redundant Google Analytics](https://github.com/alphagov/govuk_prototype_kit/pull/491)

--- a/app/config.js
+++ b/app/config.js
@@ -3,9 +3,6 @@
 // Note: prototype config can be overridden using environment variables (eg on heroku)
 
 module.exports = {
-  // Service name used in header. Eg: 'Renew your passport'
-  serviceName: 'Service name goes here',
-
   // Default port that prototype runs on
   port: '3000',
 
@@ -20,9 +17,6 @@ module.exports = {
 
   // Force HTTP to redirect to HTTPS on production
   useHttps: 'true',
-
-  // Cookie warning - update link to service's cookie page.
-  cookieText: 'GOV.UK uses cookies to make the site simpler. <a href="#">Find out more about cookies</a>',
 
   // Enable or disable Browser Sync
   useBrowserSync: 'true'

--- a/app/data/global-data.js
+++ b/app/data/global-data.js
@@ -1,0 +1,30 @@
+/*
+
+Store global data in this file. These are automatically added
+and available via the globalData object
+
+See /docs/examples/global-data for usage instructions
+
+============================================================================
+
+Example usage:
+
+"serviceName": "Service name goes here",
+
+"options": [ "foo", "bar" ]
+
+============================================================================
+
+*/
+
+module.exports = {
+
+  // Service name used in header. For example: 'Renew your passport'
+  "serviceName" : "Service name goes here",
+
+  // Cookie warning - update link to service's cookie page.
+  "cookieText" : "GOV.UK uses cookies to make the site simpler. <a href='#'>Find out more about cookies</a>"
+
+  // Insert values here
+
+}

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -1,0 +1,24 @@
+/*
+
+Provide default values for user session data. These are automatically added
+via the `autoStoreData` middleware. Values will only be added to the
+session if a value doesn't already exist. This may be useful for testing
+journeys where users are returning or logging in to an existing application.
+
+============================================================================
+
+Example usage:
+
+"full-name": "Sarah Philips",
+
+"options-chosen": [ "foo", "bar" ]
+
+============================================================================
+
+*/
+
+module.exports = {
+
+  // Insert values here
+
+}

--- a/docs/documentation/global-data.md
+++ b/docs/documentation/global-data.md
@@ -1,0 +1,37 @@
+# Storing global data
+
+You can store data globally for use across your app. Unlike session data, global data is shared by all users of your app. This can be useful for things that are repeated in your app such as service name or contact details.
+
+Keep data you want to store globally in:
+
+`/app/data/global-data.js`
+
+Items in this file are imported in to the kit and made available to your views and routes.
+
+> Never store user data to global data.
+
+## How to use
+
+### Using global data in views
+
+Global data is available in the `globalData` object.
+
+You can use a value from global data like this:
+
+`{{ globalData['item'] }}`
+
+### Using global data in routes
+
+Global data is stored in `app.locals`.
+
+You can use a value from global data like this:
+
+`var item = req.app.locals.globalData['item']`
+
+### Writing to global data
+
+#### Storing persistently
+Items you want to store persistently should be added to `/app/data/global-data.js`.
+
+#### Storing non persistently
+Items written to the `globalData` object are available to all users of the app whilst it runs. They will be reset when the app stops or restarts.

--- a/docs/views/examples/pass-data/index.html
+++ b/docs/views/examples/pass-data/index.html
@@ -94,6 +94,18 @@
 </div>
       </pre>
 
+      <h3 class="heading-small">
+        Setting default data
+      </h3>
+
+      <p>You can set default values in this file in your prototype folder:
+      <pre>
+<div class="code">
+  app/data/session-data-defaults.js
+
+</div>
+      </pre>
+
       <h2 class="heading-medium">Advanced features</h2>
 
       <h3 class="heading-small">

--- a/docs/views/tutorials-and-examples.html
+++ b/docs/views/tutorials-and-examples.html
@@ -98,6 +98,9 @@
           <a href="/docs/session">Storing data in session</a>
         </li>
         <li>
+          <a href="/docs/global-data">Storing global data</a>
+        </li>
+        <li>
           <a href="/docs/using-verify">Using GOV.UK Verify</a>
         </li>
 

--- a/lib/template.global-data.js
+++ b/lib/template.global-data.js
@@ -1,0 +1,30 @@
+/*
+
+Store global data in this file. These are automatically added
+and available via the globalData object
+
+See /docs/examples/global-data for usage instructions
+
+============================================================================
+
+Example usage:
+
+"serviceName": "Service name goes here",
+
+"options": [ "foo", "bar" ]
+
+============================================================================
+
+*/
+
+module.exports = {
+
+  // Service name used in header. For example: 'Renew your passport'
+  "serviceName" : "Service name goes here",
+
+  // Cookie warning - update link to service's cookie page.
+  "cookieText" : "GOV.UK uses cookies to make the site simpler. <a href='#'>Find out more about cookies</a>"
+
+  // Insert values here
+
+}

--- a/lib/template.session-data-defaults.js
+++ b/lib/template.session-data-defaults.js
@@ -1,0 +1,24 @@
+/*
+
+Provide default values for user session data. These are automatically added
+via the `autoStoreData` middleware. Values will only be added to the
+session if a value doesn't already exist. This may be useful for testing
+journeys where users are returning or logging in to an existing application.
+
+============================================================================
+
+Example usage:
+
+"full-name": "Sarah Philips",
+
+"options-chosen": [ "foo", "bar" ]
+
+============================================================================
+
+*/
+
+module.exports = {
+
+  // Insert values here
+
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -252,11 +252,24 @@ var storeData = function (input, store) {
   }
 }
 
+// Get session default data from file
+let sessionDataDefaults = {}
+
+const sessionDataDefaultsFile = path.join(__dirname, '/../app/data/session-data-defaults.js')
+
+try {
+  sessionDataDefaults = require(sessionDataDefaultsFile)
+} catch (e) {
+  console.error('Could not load the session data defaults from app/data/session-data-defaults.js. Might be a syntax error?')
+}
+
 // Middleware - store any data sent in session, and pass it to all views
 exports.autoStoreData = function (req, res, next) {
   if (!req.session.data) {
     req.session.data = {}
   }
+
+  req.session.data = Object.assign({}, sessionDataDefaults, req.session.data)
 
   storeData(req.body, req.session)
   storeData(req.query, req.session)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,6 +12,20 @@ const request = require('sync-request')
 // Local dependencies
 const config = require('../app/config.js')
 
+var getDataFromFile = function (filename) {
+  let data = {}
+  const dataFile = path.join(__dirname, '/../app/data/' + filename)
+
+  try {
+    data = require(dataFile)
+  } catch (e) {
+    console.error('Could not load data file from app/data/' + filename + '. Might be a syntax error?')
+  }
+  return data
+}
+
+const sessionDataDefaults = getDataFromFile('session-data-defaults.js')
+
 // Variables
 var releaseUrl = null
 
@@ -252,24 +266,11 @@ var storeData = function (input, store) {
   }
 }
 
-// Get session default data from file
-let sessionDataDefaults = {}
-
-const sessionDataDefaultsFile = path.join(__dirname, '/../app/data/session-data-defaults.js')
-
-try {
-  sessionDataDefaults = require(sessionDataDefaultsFile)
-} catch (e) {
-  console.error('Could not load the session data defaults from app/data/session-data-defaults.js. Might be a syntax error?')
-}
-
 // Middleware - store any data sent in session, and pass it to all views
 exports.autoStoreData = function (req, res, next) {
   if (!req.session.data) {
     req.session.data = {}
   }
-
-  req.session.data = Object.assign({}, sessionDataDefaults, req.session.data)
 
   storeData(req.body, req.session)
   storeData(req.query, req.session)
@@ -281,6 +282,25 @@ exports.autoStoreData = function (req, res, next) {
   for (var j in req.session.data) {
     res.locals.data[j] = req.session.data[j]
   }
+
+  next()
+}
+
+// Import global data to app.locals.globalData
+exports.importGlobalData = function (app) {
+  var globalData = getDataFromFile('global-data.js')
+
+  app.locals.globalData = globalData
+
+  // Explicitly set these values for backwards compatibility
+  app.locals.serviceName = app.locals.globalData.serviceName
+  app.locals.cookieText = app.locals.globalData.cookieText
+}
+
+// Add session defaults to session
+// TODO: this runs with every request - is this correct?
+exports.importSessionDefaults = function (req, res, next) {
+  req.session.data = Object.assign({}, sessionDataDefaults, req.session.data)
 
   next()
 }

--- a/server.js
+++ b/server.js
@@ -112,10 +112,8 @@ app.use(bodyParser.urlencoded({
 app.locals.gtmId = gtmId
 app.locals.asset_path = '/public/'
 app.locals.useAutoStoreData = (useAutoStoreData === 'true')
-app.locals.cookieText = config.cookieText
 app.locals.promoMode = promoMode
 app.locals.releaseVersion = 'v' + releaseVersion
-app.locals.serviceName = config.serviceName
 
 // Support session data
 app.use(session({
@@ -129,6 +127,12 @@ app.use(session({
   saveUninitialized: false,
   secret: crypto.randomBytes(64).toString('hex')
 }))
+
+// Import global data defaults
+utils.importGlobalData(app)
+
+// Import session defaults (needs to be app.use to have access to req.session)
+app.use(utils.importSessionDefaults)
 
 // Automatically store all data users enter
 if (useAutoStoreData === 'true') {

--- a/start.js
+++ b/start.js
@@ -17,6 +17,21 @@ if (!envExists) {
   .pipe(fs.createWriteStream(path.join(__dirname, '/.env')))
 }
 
+// Create template session data defaults file if it doesn't exist
+const dataDirectory = path.join(__dirname, '/app/data')
+const sessionDataDefaultsFile = path.join(dataDirectory, '/session-data-defaults.js')
+const sessionDataDefaultsFileExists = fs.existsSync(sessionDataDefaultsFile)
+
+if (!sessionDataDefaultsFileExists) {
+  console.log('Creating session data defaults file')
+  if (!fs.existsSync(dataDirectory)) {
+    fs.mkdirSync(dataDirectory)
+  }
+
+  fs.createReadStream(path.join(__dirname, '/lib/template.session-data-defaults.js'))
+  .pipe(fs.createWriteStream(sessionDataDefaultsFile))
+}
+
 // Run gulp
 const spawn = require('cross-spawn')
 

--- a/start.js
+++ b/start.js
@@ -17,19 +17,31 @@ if (!envExists) {
   .pipe(fs.createWriteStream(path.join(__dirname, '/.env')))
 }
 
-// Create template session data defaults file if it doesn't exist
+
 const dataDirectory = path.join(__dirname, '/app/data')
+
+// Create template session data defaults file if it doesn't exist
 const sessionDataDefaultsFile = path.join(dataDirectory, '/session-data-defaults.js')
 const sessionDataDefaultsFileExists = fs.existsSync(sessionDataDefaultsFile)
 
+if (!fs.existsSync(dataDirectory)) {
+    fs.mkdirSync(dataDirectory)
+}
+
 if (!sessionDataDefaultsFileExists) {
   console.log('Creating session data defaults file')
-  if (!fs.existsSync(dataDirectory)) {
-    fs.mkdirSync(dataDirectory)
-  }
-
   fs.createReadStream(path.join(__dirname, '/lib/template.session-data-defaults.js'))
   .pipe(fs.createWriteStream(sessionDataDefaultsFile))
+}
+
+// Create global data file if it doesn't exist
+const globalDataFile = path.join(dataDirectory, '/global-data.js')
+const globalDataFileExists = fs.existsSync(globalDataFile)
+
+if (!globalDataFileExists) {
+  console.log('Creating global data file')
+  fs.createReadStream(path.join(__dirname, '/lib/template.global-data.js'))
+  .pipe(fs.createWriteStream(globalDataFile))
 }
 
 // Run gulp


### PR DESCRIPTION
Following on from the work in #501, this does a similar thing to create a `global-data.js` file where users can store global data.

This is similar to the existing `config.js`, except all values are auto-imported. We'll keep `config.js` for more system type config and flags, and things our users might want to set (settings, text snippets) in `global-data.js`.

As part of this, I've moved `serviceName` and `cookieText` to the new file. Those vars are now available under `globalData['serviceName']` but for backwards compatibility with templates, I've also assigned them to the `app.locals` as before.

Changes:
* Creates global data file from template if it doesn't exist
* Refactors importing of data so that this and session data aren't repeating code
* Remove text snippets from `config.js`
* Add new documentation page for global data