### PR TITLE
Add content type header to matchRoutes

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -203,12 +203,12 @@ exports.matchRoutes = function (req, res) {
         if (err2) {
           res.status(404).send(err + '<br>' + err2)
         } else {
-          res.set({ "Content-type": "text/html; charset=utf-8" });
+          res.set({ 'Content-type': 'text/html; charset=utf-8' })
           res.end(html)
         }
       })
     } else {
-      res.set({ "Content-type": "text/html; charset=utf-8" });
+      res.set({ 'Content-type': 'text/html; charset=utf-8' })
       res.end(html)
     }
   })

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -203,10 +203,12 @@ exports.matchRoutes = function (req, res) {
         if (err2) {
           res.status(404).send(err + '<br>' + err2)
         } else {
+          res.set({ "Content-type": "text/html; charset=utf-8" });
           res.end(html)
         }
       })
     } else {
+      res.set({ "Content-type": "text/html; charset=utf-8" });
       res.end(html)
     }
   })


### PR DESCRIPTION
Set content-type header to text/html, to ensure correct rendering in browsers. This ensures that browsers always render out HTML. Currently, in some cases, content gets interpreted as plain text