### PR TITLE
Make Frontend asset path less confusing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Bug fixes:
 - [#532 Update repo links from govuk_prototype_kit to govuk-prototype-kit](https://github.com/alphagov/govuk_prototype_kit/pull/532)
 
+- [#525 Make asset path coming from Frontend less confusing](https://github.com/alphagov/govuk_prototype_kit/pull/531)
+
 # 7.0.0-beta.10
 
 Breaking changes:

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -1,5 +1,6 @@
 // global styles for <a> and <p> tags
 $govuk-global-styles: true;
+$govuk-assets-path: "/govuk-frontend/assets/";
 
 // Import GOV.UK Frontend
 @import "node_modules/govuk-frontend/all";

--- a/docs/assets/sass/docs.scss
+++ b/docs/assets/sass/docs.scss
@@ -1,3 +1,4 @@
+$govuk-assets-path: "/govuk-frontend/assets/";
 @import "node_modules/govuk-frontend/all";
 
 // adjust code block font-size to 19px
@@ -87,7 +88,7 @@
   pre {
     @extend .app-code;
   }
-  
+
   p code {
     border: 1px solid $govuk-border-colour;
     background-color: govuk-colour("grey-4");

--- a/server.js
+++ b/server.js
@@ -90,7 +90,7 @@ app.set('view engine', 'html')
 
 // Middleware to serve static assets
 app.use('/public', express.static(path.join(__dirname, '/public')))
-app.use('/assets', express.static(path.join(__dirname, 'node_modules', 'govuk-frontend', 'assets')))
+app.use('/govuk-frontend/assets', express.static(path.join(__dirname, 'node_modules', 'govuk-frontend', 'assets')))
 
 // Serve govuk-frontend in /public
 app.use('/node_modules/govuk-frontend', express.static(path.join(__dirname, '/node_modules/govuk-frontend')))


### PR DESCRIPTION
Making it clear it's coming from `node_modules`, rather than `app/` or `public/`