### PR TITLE
Update repo links from govuk_prototype_kit to govuk-prototype-kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+Bug fixes:
+- [#532 Update repo links from govuk_prototype_kit to govuk-prototype-kit](https://github.com/alphagov/govuk_prototype_kit/pull/532)
+
 # 7.0.0-beta.10
 
 Breaking changes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,14 +53,14 @@ which describes how we prefer git history and commit messages to read.
 
 Checkout a new branch for the release.
 
-Update [CHANGELOG.md](https://github.com/alphagov/govuk_prototype_kit/blob/master/CHANGELOG.md) to summarise the changes made since the last release.
+Update [CHANGELOG.md](https://github.com/alphagov/govuk-prototype-kit/blob/master/CHANGELOG.md) to summarise the changes made since the last release.
 
-To see the commits to be summarised in the changelog since the last release, [compare the latest-release branch with master](https://github.com/alphagov/govuk_prototype_kit/compare/latest-release...master).
+To see the commits to be summarised in the changelog since the last release, [compare the latest-release branch with master](https://github.com/alphagov/govuk-prototype-kit/compare/latest-release...master).
 
-Propose a new version number in [VERSION.txt](https://github.com/alphagov/govuk_prototype_kit/blob/master/VERSION.txt) and update line 4 in [package.json](https://github.com/alphagov/govuk_prototype_kit/blob/master/package.json#L4) with the new version number.
+Propose a new version number in [VERSION.txt](https://github.com/alphagov/govuk-prototype-kit/blob/master/VERSION.txt) and update line 4 in [package.json](https://github.com/alphagov/govuk-prototype-kit/blob/master/package.json#L4) with the new version number.
 
 Open a new pull request with a single commit including the above changes.
 
-[Here is an example for v6.1.0](https://github.com/alphagov/govuk_prototype_kit/commit/53e36d79a994ce3649b53f4008370cd75068c27c).
+[Here is an example for v6.1.0](https://github.com/alphagov/govuk-prototype-kit/commit/53e36d79a994ce3649b53f4008370cd75068c27c).
 
 Once merged into master a new version will be built.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GOV.UK Prototype Kit · [![Greenkeeper badge](https://badges.greenkeeper.io/alphagov/govuk_prototype_kit.svg)](https://greenkeeper.io/)
+# GOV.UK Prototype Kit · [![Greenkeeper badge](https://badges.greenkeeper.io/alphagov/govuk-prototype-kit.svg)](https://greenkeeper.io/)
 
 Go to the [GOV.UK Prototype Kit site](https://govuk-prototype-kit.herokuapp.com/docs) to download the latest version and read the documentation.
 

--- a/create-release.sh
+++ b/create-release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-REPO_PATH='alphagov/govuk_prototype_kit'
+REPO_PATH='alphagov/govuk-prototype-kit'
 
 echo "Add config for alphagov/$REPO_PATH"
 

--- a/docs/documentation/install/install-the-kit.md
+++ b/docs/documentation/install/install-the-kit.md
@@ -20,7 +20,7 @@ Create a folder called `projects` in your `Documents` or `My Documents` folder.
 
 ### Unzip the kit
 
-Unzip the kit you downloaded - you should end up with a folder called `govuk_prototype_kit-3.0.0`
+Unzip the kit you downloaded - you should end up with a folder called `govuk-prototype-kit-3.0.0`
 
 ### Rename the kit
 

--- a/docs/documentation/install/introduction.md
+++ b/docs/documentation/install/introduction.md
@@ -6,7 +6,7 @@ Installation takes up to 30 minutes depending on how much you need to install.
 
 If you’re comfortable using git and the terminal, you may prefer the [developer friendly instructions](developer-install-instructions).
 
-> This guide is a work in progress. Please help [contribute](https://github.com/alphagov/govuk_prototype_kit/blob/master/CONTRIBUTING.md) to make it even better.
+> This guide is a work in progress. Please help [contribute](https://github.com/alphagov/govuk-prototype-kit/blob/master/CONTRIBUTING.md) to make it even better.
 
 ## Introduction
 

--- a/docs/documentation/updating-the-kit.md
+++ b/docs/documentation/updating-the-kit.md
@@ -41,7 +41,7 @@ Updating via the command line involves fetching the latest code from the 'upstre
 Firstly change to the base directory of your prototyping kit in terminal, for example:
 
 ```
-cd ~/sites/govuk_prototype_kit
+cd ~/sites/govuk-prototype-kit
 ```
 
 Once in the directory start by listing the git remote(s) you have referenced from your machine. To do this you type:
@@ -51,8 +51,8 @@ Once in the directory start by listing the git remote(s) you have referenced fro
 This will typically output a list of all the remote git repositories that have the prototype code, for example:
 
 ```
-origin  https://github.com/paulmsmith/govuk_prototype_kit.git (fetch)
-origin  https://github.com/paulmsmith/govuk_prototype_kit.git (push)
+origin  https://github.com/paulmsmith/govuk-prototype-kit.git (fetch)
+origin  https://github.com/paulmsmith/govuk-prototype-kit.git (push)
 ```
 
 So long as you can see a list of repositories as above, we can move on to adding a reference to the original 'alphagov' repository which we will need in order to update.
@@ -62,7 +62,7 @@ So long as you can see a list of repositories as above, we can move on to adding
 To add the alphagov remote repository, type the following command and hit enter:
 
 ```
-git remote add upstream https://github.com/alphagov/govuk_prototype_kit.git
+git remote add upstream https://github.com/alphagov/govuk-prototype-kit.git
 ```
 
 All being well, you will just return to a command prompt, now if you type:
@@ -71,10 +71,10 @@ All being well, you will just return to a command prompt, now if you type:
 You should see an 'upstream' in your list, for example:
 
 ```
-origin	https://github.com/paulmsmith/govuk_prototype_kit.git (fetch)
-origin	https://github.com/paulmsmith/govuk_prototype_kit.git (push)
-upstream	https://github.com/alphagov/govuk_prototype_kit.git (fetch)
-upstream	https://github.com/alphagov/govuk_prototype_kit.git (push)
+origin	https://github.com/paulmsmith/govuk-prototype-kit.git (fetch)
+origin	https://github.com/paulmsmith/govuk-prototype-kit.git (push)
+upstream	https://github.com/alphagov/govuk-prototype-kit.git (fetch)
+upstream	https://github.com/alphagov/govuk-prototype-kit.git (push)
 ```
 
 #### Merging from upstream
@@ -90,7 +90,7 @@ git fetch upstream latest-release
 You will see it output a few lines telling you that was successful, for example:
 
 ```
-From https://github.com/alphagov/govuk_prototype_kit
+From https://github.com/alphagov/govuk-prototype-kit
  * branch            latest-release    -> FETCH_HEAD
 ```
 
@@ -130,4 +130,4 @@ In terminal:
 npm start
 ```
 
-If you still have an error, you can [raise an issue within github](https://github.com/alphagov/govuk_prototype_kit/issues) or ask in the [Slack channel for users of the Prototype Kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit/) by providing as much information as you can about the error and the computer you are attempting to run the prototyping kit on.
+If you still have an error, you can [raise an issue within github](https://github.com/alphagov/govuk-prototype-kit/issues) or ask in the [Slack channel for users of the Prototype Kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit/) by providing as much information as you can about the error and the computer you are attempting to run the prototyping kit on.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -169,7 +169,7 @@ exports.getLatestRelease = function () {
     var options = {
       headers: {'user-agent': 'node.js'}
     }
-    var gitHubUrl = 'https://api.github.com/repos/alphagov/govuk_prototype_kit/releases/latest'
+    var gitHubUrl = 'https://api.github.com/repos/alphagov/govuk-prototype-kit/releases/latest'
     try {
       console.log('Getting latest release from GitHub')
 
@@ -177,7 +177,7 @@ exports.getLatestRelease = function () {
       var data = JSON.parse(res.getBody('utf8'))
       var zipballUrl = data['zipball_url']
       var releaseVersion = zipballUrl.split('/').pop()
-      var urlStart = 'https://github.com/alphagov/govuk_prototype_kit/archive/'
+      var urlStart = 'https://github.com/alphagov/govuk-prototype-kit/archive/'
       var urlEnd = '.zip'
       var zipUrl = urlStart + releaseVersion + urlEnd
 
@@ -185,7 +185,7 @@ exports.getLatestRelease = function () {
       releaseUrl = zipUrl
       url = releaseUrl
     } catch (err) {
-      url = 'https://github.com/alphagov/govuk_prototype_kit/releases/latest'
+      url = 'https://github.com/alphagov/govuk-prototype-kit/releases/latest'
       console.log("Couldn't retrieve release URL")
     }
   }


### PR DESCRIPTION
For consistency, we are renaming the repository so want to avoid redirects.