### PR TITLE
Add step by step navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Unreleased
 
-New features: 
+New features:
 
 - [#628 Update GOV.UK Frontend to v2.3.0](https://github.com/alphagov/govuk-prototype-kit/pull/628)
 
 - [#574 Add Notify integration guidance](https://github.com/alphagov/govuk-prototype-kit/pull/574)
 
 - [Add npm install reminder when prototype crashes](https://github.com/alphagov/govuk-prototype-kit/pull/598)
+
+- [#539 Add step by step navigation](https://github.com/alphagov/govuk-prototype-kit/pull/539)
 
 # 8.2.0
 

--- a/app/assets/javascripts/step-by-step-navigation.js
+++ b/app/assets/javascripts/step-by-step-navigation.js
@@ -1,0 +1,458 @@
+// based on https://github.com/alphagov/govuk_publishing_components/blob/v9.3.6/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
+
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+window.GOVUK.support = window.GOVUK.support || {};
+
+window.GOVUK.support.history = function() {
+  return window.history && window.history.pushState && window.history.replaceState;
+};
+
+window.GOVUK.getCurrentLocation = function(){
+  return window.location;
+};
+
+(function (Modules) {
+  "use strict";
+
+  Modules.StepByStepNavigation = function () {
+
+    var actions = {}; // stores text for JS appended elements 'show' and 'hide' on steps, and 'show/hide all' button
+    var rememberShownStep = false;
+    var stepNavSize;
+    var sessionStoreLink = 'govuk-step-nav-active-link';
+    var activeLinkClass = 'app-step-nav__list-item--active';
+    var activeLinkHref = '#content';
+
+    this.start = function ($element) {
+
+      $(window).unload(storeScrollPosition);
+
+      // Indicate that js has worked
+      $element.addClass('app-step-nav--active');
+
+      // Prevent FOUC, remove class hiding content
+      $element.removeClass('js-hidden');
+
+      rememberShownStep = !!$element.filter('[data-remember]').length;
+      stepNavSize = $element.hasClass('app-step-nav--large') ? 'Big' : 'Small';
+      var $steps = $element.find('.js-step');
+      var $stepHeaders = $element.find('.js-toggle-panel');
+      var totalSteps = $element.find('.js-panel').length;
+      var totalLinks = $element.find('.app-step-nav__link').length;
+
+      var $showOrHideAllButton;
+
+      var uniqueId = $element.data('id') || false;
+      var stepNavTracker = new StepNavTracker(totalSteps, totalLinks, uniqueId);
+
+      getTextForInsertedElements();
+      addButtonstoSteps();
+      addShowHideAllButton();
+      addShowHideToggle();
+      addAriaControlsAttrForShowHideAllButton();
+
+      hideAllSteps();
+      showLinkedStep();
+      ensureOnlyOneActiveLink();
+
+      bindToggleForSteps(stepNavTracker);
+      bindToggleShowHideAllButton(stepNavTracker);
+      bindComponentLinkClicks(stepNavTracker);
+
+      function getTextForInsertedElements() {
+        actions.showText = $element.attr('data-show-text');
+        actions.hideText = $element.attr('data-hide-text');
+        actions.showAllText = $element.attr('data-show-all-text');
+        actions.hideAllText = $element.attr('data-hide-all-text');
+      }
+
+      // When navigating back in browser history to the step nav, the browser will try to be "clever" and return
+      // the user to their previous scroll position. However, since we collapse all but the currently-anchored
+      // step, the content length changes and the user is returned to the wrong position (often the footer).
+      // In order to correct this behaviour, as the user leaves the page, we anticipate the correct height we wish the
+      // user to return to by forcibly scrolling them to that height, which becomes the height the browser will return
+      // them to.
+      // If we can't find an element to return them to, then reset the scroll to the top of the page. This handles
+      // the case where the user has expanded all steps, so they are not returned to a particular step, but
+      // still could have scrolled a long way down the page.
+      function storeScrollPosition() {
+        hideAllSteps();
+        var $step = getStepForAnchor();
+
+        document.body.scrollTop = $step && $step.length
+          ? $step.offset().top
+          : 0;
+      }
+
+      function addShowHideAllButton() {
+        $element.prepend('<div class="app-step-nav__controls"><button aria-expanded="false" class="app-step-nav__button app-step-nav__button--controls js-step-controls-button">' + actions.showAllText + '</button></div>');
+      }
+
+      function addShowHideToggle() {
+        $stepHeaders.each(function() {
+          var linkText = actions.showText;
+
+          if (headerIsOpen($(this))) {
+            linkText = actions.hideText;
+          }
+          if (!$(this).find('.js-toggle-link').length) {
+            $(this).find('.js-step-title-button').append('<span class="app-step-nav__toggle-link js-toggle-link" aria-hidden="true">' + linkText + '</span>');
+          }
+        });
+      }
+
+      function headerIsOpen($stepHeader) {
+        return (typeof $stepHeader.closest('.js-step').data('show') !== 'undefined');
+      }
+
+      function addAriaControlsAttrForShowHideAllButton() {
+        var ariaControlsValue = $element.find('.js-panel').first().attr('id');
+
+        $showOrHideAllButton = $element.find('.js-step-controls-button');
+        $showOrHideAllButton.attr('aria-controls', ariaControlsValue);
+      }
+
+      function hideAllSteps() {
+        setAllStepsShownState(false);
+      }
+
+      function setAllStepsShownState(isShown) {
+        $.each($steps, function () {
+          var stepView = new StepView($(this));
+          stepView.preventHashUpdate();
+          stepView.setIsShown(isShown);
+        });
+      }
+
+      function showLinkedStep() {
+        var $step;
+        if (rememberShownStep) {
+          $step = getStepForAnchor();
+        } else {
+          $step = $steps.filter('[data-show]');
+        }
+
+        if ($step && $step.length) {
+          var stepView = new StepView($step);
+          stepView.show();
+        }
+      }
+
+      function getStepForAnchor() {
+        var anchor = getActiveAnchor();
+
+        return anchor.length
+          ? $element.find('#' + escapeSelector(anchor.substr(1)))
+          : null;
+      }
+
+      function getActiveAnchor() {
+        return GOVUK.getCurrentLocation().hash;
+      }
+
+      function addButtonstoSteps() {
+        $.each($steps, function () {
+          var $step = $(this);
+          var $title = $step.find('.js-step-title');
+          var contentId = $step.find('.js-panel').first().attr('id');
+
+          $title.wrapInner(
+            '<span class="js-step-title-text"></span>'
+          );
+
+          $title.wrapInner(
+            '<button ' +
+            'class="app-step-nav__button app-step-nav__button--title js-step-title-button" ' +
+            'aria-expanded="false" aria-controls="' + contentId + '">' +
+            '</button>'
+          );
+        });
+      }
+
+      function bindToggleForSteps(stepNavTracker) {
+        $element.find('.js-toggle-panel').click(function (event) {
+          var $step = $(this).closest('.js-step');
+
+          var stepView = new StepView($step);
+          stepView.toggle();
+
+          var stepIsOptional = typeof $step.data('optional') !== 'undefined' ? true : false;
+          var toggleClick = new StepToggleClick(event, stepView, $steps, stepNavTracker, stepIsOptional);
+          toggleClick.track();
+
+          setShowHideAllText();
+        });
+      }
+
+      // tracking click events on links in step content
+      function bindComponentLinkClicks(stepNavTracker) {
+        $element.find('.js-link').click(function (event) {
+          var linkClick = new componentLinkClick(event, stepNavTracker, $(this).attr('data-position'));
+          linkClick.track();
+          var thisLinkHref = $(this).attr('href');
+
+          if ($(this).attr('rel') !== 'external') {
+            saveToSessionStorage(sessionStoreLink, $(this).data('position'));
+          }
+
+          if (thisLinkHref == activeLinkHref) {
+            setOnlyThisLinkActive($(this));
+          }
+        });
+      }
+
+      function saveToSessionStorage(key, value) {
+        sessionStorage.setItem(key, value);
+      }
+
+      function loadFromSessionStorage(key) {
+        return sessionStorage.getItem(key);
+      }
+
+      function removeFromSessionStorage(key) {
+        sessionStorage.removeItem(key);
+      }
+
+      function setOnlyThisLinkActive(clicked) {
+        $element.find('.' + activeLinkClass).removeClass(activeLinkClass);
+        clicked.parent().addClass(activeLinkClass);
+      }
+
+      function ensureOnlyOneActiveLink() {
+        var $activeLinks = $element.find('.js-list-item.' + activeLinkClass);
+
+        if ($activeLinks.length <= 1) {
+          return;
+        }
+
+        var lastClicked = loadFromSessionStorage(sessionStoreLink);
+
+        if (lastClicked) {
+          removeActiveStateFromAllButCurrent($activeLinks, lastClicked);
+          removeFromSessionStorage(sessionStoreLink);
+        } else {
+          var activeLinkInActiveStep = $element.find('.app-step-nav__step--active').find('.' + activeLinkClass).first();
+
+          if (activeLinkInActiveStep.length) {
+            $activeLinks.removeClass(activeLinkClass);
+            activeLinkInActiveStep.addClass(activeLinkClass);
+          } else {
+            $activeLinks.slice(1).removeClass(activeLinkClass);
+          }
+        }
+      }
+
+      function removeActiveStateFromAllButCurrent($links, current) {
+        $links.each(function() {
+          if ($(this).find('.js-link').data('position').toString() !== current.toString()) {
+            $(this).removeClass(activeLinkClass);
+          }
+        });
+      }
+
+      function bindToggleShowHideAllButton(stepNavTracker) {
+        $showOrHideAllButton = $element.find('.js-step-controls-button');
+        $showOrHideAllButton.on('click', function () {
+          var shouldshowAll;
+
+          if ($showOrHideAllButton.text() == actions.showAllText) {
+            $showOrHideAllButton.text(actions.hideAllText);
+            $element.find('.js-toggle-link').text(actions.hideText)
+            shouldshowAll = true;
+
+            stepNavTracker.track('pageElementInteraction', 'stepNavAllShown', {
+              label: actions.showAllText + ": " + stepNavSize
+            });
+          } else {
+            $showOrHideAllButton.text(actions.showAllText);
+            $element.find('.js-toggle-link').text(actions.showText);
+            shouldshowAll = false;
+
+            stepNavTracker.track('pageElementInteraction', 'stepNavAllHidden', {
+              label: actions.hideAllText + ": " + stepNavSize
+            });
+          }
+
+          setAllStepsShownState(shouldshowAll);
+          $showOrHideAllButton.attr('aria-expanded', shouldshowAll);
+          setShowHideAllText();
+          setHash(null);
+
+          return false;
+        });
+      }
+
+      function setShowHideAllText() {
+        var shownSteps = $element.find('.step-is-shown').length;
+        // Find out if the number of is-opens == total number of steps
+        if (shownSteps === totalSteps) {
+          $showOrHideAllButton.text(actions.hideAllText);
+        } else {
+          $showOrHideAllButton.text(actions.showAllText);
+        }
+      }
+
+      // Ideally we'd use jQuery.escapeSelector, but this is only available from v3
+      // See https://github.com/jquery/jquery/blob/2d4f53416e5f74fa98e0c1d66b6f3c285a12f0ce/src/selector-native.js#L46
+      function escapeSelector(s) {
+        var cssMatcher = /([\x00-\x1f\x7f]|^-?\d)|^-$|[^\x80-\uFFFF\w-]/g;
+        return s.replace(cssMatcher, "\\$&");
+      }
+    };
+
+    function StepView($stepElement) {
+      var $titleLink = $stepElement.find('.js-step-title-button');
+      var $stepContent = $stepElement.find('.js-panel');
+      var shouldUpdateHash = rememberShownStep;
+
+      this.title = $stepElement.find('.js-step-title-text').text().trim();
+      this.element = $stepElement;
+
+      this.show = show;
+      this.hide = hide;
+      this.toggle = toggle;
+      this.setIsShown = setIsShown;
+      this.isShown = isShown;
+      this.isHidden = isHidden;
+      this.preventHashUpdate = preventHashUpdate;
+      this.numberOfContentItems = numberOfContentItems;
+
+      function show() {
+        setIsShown(true);
+      }
+
+      function hide() {
+        setIsShown(false);
+      }
+
+      function toggle() {
+        setIsShown(isHidden());
+      }
+
+      function setIsShown(isShown) {
+        $stepElement.toggleClass('step-is-shown', isShown);
+        $stepContent.toggleClass('js-hidden', !isShown);
+        $titleLink.attr("aria-expanded", isShown);
+        $stepElement.find('.js-toggle-link').text(isShown ? actions.hideText : actions.showText);
+
+        if (shouldUpdateHash) {
+          updateHash($stepElement);
+        }
+      }
+
+      function isShown() {
+        return $stepElement.hasClass('step-is-shown');
+      }
+
+      function isHidden() {
+        return !isShown();
+      }
+
+      function preventHashUpdate() {
+        shouldUpdateHash = false;
+      }
+
+      function numberOfContentItems() {
+        return $stepContent.find('.js-link').length;
+      }
+    }
+
+    function updateHash($stepElement) {
+      var stepView = new StepView($stepElement);
+      var hash = stepView.isShown() && '#' + $stepElement.attr('id');
+      setHash(hash)
+    }
+
+    // Sets the hash for the page. If a falsy value is provided, the hash is cleared.
+    function setHash(hash) {
+      if (!GOVUK.support.history()) {
+        return;
+      }
+
+      var newLocation = hash || GOVUK.getCurrentLocation().pathname;
+      history.replaceState({}, '', newLocation);
+    }
+
+    function StepToggleClick(event, stepView, $steps, stepNavTracker, stepIsOptional) {
+      this.track = trackClick;
+      var $target = $(event.target);
+
+      function trackClick() {
+        var tracking_options = {label: trackingLabel(), dimension28: stepView.numberOfContentItems().toString()}
+        stepNavTracker.track('pageElementInteraction', trackingAction(), tracking_options);
+      }
+
+      function trackingLabel() {
+        return $target.closest('.js-toggle-panel').attr('data-position') + ' - ' + stepView.title + ' - ' + locateClickElement() + ": " + stepNavSize + isOptional();
+      }
+
+      // returns index of the clicked step in the overall number of steps
+      function stepIndex() {
+        return $steps.index(stepView.element) + 1;
+      }
+
+      function trackingAction() {
+        return (stepView.isHidden() ? 'stepNavHidden' : 'stepNavShown');
+      }
+
+      function locateClickElement() {
+        if (clickedOnIcon()) {
+          return iconType() + ' click';
+        } else if (clickedOnHeading()) {
+          return 'Heading click';
+        } else {
+          return 'Elsewhere click';
+        }
+      }
+
+      function clickedOnIcon() {
+        return $target.hasClass('js-toggle-link');
+      }
+
+      function clickedOnHeading() {
+        return $target.hasClass('js-step-title-text');
+      }
+
+      function iconType() {
+        return (stepView.isHidden() ? 'Minus' : 'Plus');
+      }
+
+      function isOptional() {
+        return (stepIsOptional ? ' ; optional' : '');
+      }
+    }
+
+    function componentLinkClick(event, stepNavTracker, linkPosition) {
+      this.track = trackClick;
+
+      function trackClick() {
+        var tracking_options = {label: $(event.target).attr('href') + " : " + stepNavSize};
+        var dimension28 = $(event.target).closest('.app-step-nav__list').attr('data-length');
+
+        if (dimension28) {
+          tracking_options['dimension28'] = dimension28;
+        }
+
+        stepNavTracker.track('stepNavLinkClicked', linkPosition, tracking_options);
+      }
+    }
+
+    // A helper that sends a custom event request to Google Analytics if
+    // the GOVUK module is setup
+    function StepNavTracker(totalSteps, totalLinks, uniqueId) {
+      this.track = function(category, action, options) {
+        // dimension26 records the total number of expand/collapse steps in this step nav
+        // dimension27 records the total number of links in this step nav
+        // dimension28 records the number of links in the step that was shown/hidden (handled in click event)
+        if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
+          options = options || {};
+          options["dimension26"] = options["dimension26"] || totalSteps.toString();
+          options["dimension27"] = options["dimension27"] || totalLinks.toString();
+          options["dimension96"] = options["dimension96"] || uniqueId;
+          GOVUK.analytics.trackEvent(category, action, options);
+        }
+      }
+    }
+  };
+})(window.GOVUK.Modules);

--- a/app/assets/javascripts/step-by-step-navigation.js
+++ b/app/assets/javascripts/step-by-step-navigation.js
@@ -1,69 +1,64 @@
+/* global $, GOVUK, history, sessionStorage  */
+
 // based on https://github.com/alphagov/govuk_publishing_components/blob/v9.3.6/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js
 
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
-window.GOVUK.support = window.GOVUK.support || {};
+window.GOVUK.support = window.GOVUK.support || {}
 
-window.GOVUK.support.history = function() {
-  return window.history && window.history.pushState && window.history.replaceState;
-};
+window.GOVUK.support.history = function () {
+  return window.history && window.history.pushState && window.history.replaceState
+}
 
-window.GOVUK.getCurrentLocation = function(){
-  return window.location;
+window.GOVUK.getCurrentLocation = function () {
+  return window.location
 };
 
 (function (Modules) {
-  "use strict";
+  'use strict'
 
   Modules.StepByStepNavigation = function () {
-
-    var actions = {}; // stores text for JS appended elements 'show' and 'hide' on steps, and 'show/hide all' button
-    var rememberShownStep = false;
-    var stepNavSize;
-    var sessionStoreLink = 'govuk-step-nav-active-link';
-    var activeLinkClass = 'app-step-nav__list-item--active';
-    var activeLinkHref = '#content';
+    var actions = {} // stores text for JS appended elements 'show' and 'hide' on steps, and 'show/hide all' button
+    var rememberShownStep = false
+    var sessionStoreLink = 'govuk-step-nav-active-link'
+    var activeLinkClass = 'app-step-nav__list-item--active'
+    var activeLinkHref = '#content'
 
     this.start = function ($element) {
-
-      $(window).unload(storeScrollPosition);
+      $(window).unload(storeScrollPosition)
 
       // Indicate that js has worked
-      $element.addClass('app-step-nav--active');
+      $element.addClass('app-step-nav--active')
 
       // Prevent FOUC, remove class hiding content
-      $element.removeClass('js-hidden');
+      $element.removeClass('js-hidden')
 
-      rememberShownStep = !!$element.filter('[data-remember]').length;
-      stepNavSize = $element.hasClass('app-step-nav--large') ? 'Big' : 'Small';
-      var $steps = $element.find('.js-step');
-      var $stepHeaders = $element.find('.js-toggle-panel');
-      var totalSteps = $element.find('.js-panel').length;
-      var totalLinks = $element.find('.app-step-nav__link').length;
+      rememberShownStep = !!$element.filter('[data-remember]').length
+      var $steps = $element.find('.js-step')
+      var $stepHeaders = $element.find('.js-toggle-panel')
+      var totalSteps = $element.find('.js-panel').length
 
-      var $showOrHideAllButton;
+      var $showOrHideAllButton
 
-      var uniqueId = $element.data('id') || false;
+      getTextForInsertedElements()
+      addButtonstoSteps()
+      addShowHideAllButton()
+      addShowHideToggle()
+      addAriaControlsAttrForShowHideAllButton()
 
-      getTextForInsertedElements();
-      addButtonstoSteps();
-      addShowHideAllButton();
-      addShowHideToggle();
-      addAriaControlsAttrForShowHideAllButton();
+      hideAllSteps()
+      showLinkedStep()
+      ensureOnlyOneActiveLink()
 
-      hideAllSteps();
-      showLinkedStep();
-      ensureOnlyOneActiveLink();
+      bindToggleForSteps()
+      bindToggleShowHideAllButton()
+      bindComponentLinkClicks()
 
-      bindToggleForSteps();
-      bindToggleShowHideAllButton();
-      bindComponentLinkClicks();
-
-      function getTextForInsertedElements() {
-        actions.showText = $element.attr('data-show-text');
-        actions.hideText = $element.attr('data-hide-text');
-        actions.showAllText = $element.attr('data-show-all-text');
-        actions.hideAllText = $element.attr('data-hide-all-text');
+      function getTextForInsertedElements () {
+        actions.showText = $element.attr('data-show-text')
+        actions.hideText = $element.attr('data-hide-text')
+        actions.showAllText = $element.attr('data-show-all-text')
+        actions.hideAllText = $element.attr('data-hide-all-text')
       }
 
       // When navigating back in browser history to the step nav, the browser will try to be "clever" and return
@@ -75,292 +70,288 @@ window.GOVUK.getCurrentLocation = function(){
       // If we can't find an element to return them to, then reset the scroll to the top of the page. This handles
       // the case where the user has expanded all steps, so they are not returned to a particular step, but
       // still could have scrolled a long way down the page.
-      function storeScrollPosition() {
-        hideAllSteps();
-        var $step = getStepForAnchor();
+      function storeScrollPosition () {
+        hideAllSteps()
+        var $step = getStepForAnchor()
 
         document.body.scrollTop = $step && $step.length
           ? $step.offset().top
-          : 0;
+          : 0
       }
 
-      function addShowHideAllButton() {
-        $element.prepend('<div class="app-step-nav__controls"><button aria-expanded="false" class="app-step-nav__button app-step-nav__button--controls js-step-controls-button">' + actions.showAllText + '</button></div>');
+      function addShowHideAllButton () {
+        $element.prepend('<div class="app-step-nav__controls"><button aria-expanded="false" class="app-step-nav__button app-step-nav__button--controls js-step-controls-button">' + actions.showAllText + '</button></div>')
       }
 
-      function addShowHideToggle() {
-        $stepHeaders.each(function() {
-          var linkText = actions.showText;
+      function addShowHideToggle () {
+        $stepHeaders.each(function () {
+          var linkText = actions.showText
 
           if (headerIsOpen($(this))) {
-            linkText = actions.hideText;
+            linkText = actions.hideText
           }
           if (!$(this).find('.js-toggle-link').length) {
-            $(this).find('.js-step-title-button').append('<span class="app-step-nav__toggle-link js-toggle-link" aria-hidden="true">' + linkText + '</span>');
+            $(this).find('.js-step-title-button').append('<span class="app-step-nav__toggle-link js-toggle-link" aria-hidden="true">' + linkText + '</span>')
           }
-        });
+        })
       }
 
-      function headerIsOpen($stepHeader) {
-        return (typeof $stepHeader.closest('.js-step').data('show') !== 'undefined');
+      function headerIsOpen ($stepHeader) {
+        return (typeof $stepHeader.closest('.js-step').data('show') !== 'undefined')
       }
 
-      function addAriaControlsAttrForShowHideAllButton() {
-        var ariaControlsValue = $element.find('.js-panel').first().attr('id');
+      function addAriaControlsAttrForShowHideAllButton () {
+        var ariaControlsValue = $element.find('.js-panel').first().attr('id')
 
-        $showOrHideAllButton = $element.find('.js-step-controls-button');
-        $showOrHideAllButton.attr('aria-controls', ariaControlsValue);
+        $showOrHideAllButton = $element.find('.js-step-controls-button')
+        $showOrHideAllButton.attr('aria-controls', ariaControlsValue)
       }
 
-      function hideAllSteps() {
-        setAllStepsShownState(false);
+      function hideAllSteps () {
+        setAllStepsShownState(false)
       }
 
-      function setAllStepsShownState(isShown) {
+      function setAllStepsShownState (isShown) {
         $.each($steps, function () {
-          var stepView = new StepView($(this));
-          stepView.preventHashUpdate();
-          stepView.setIsShown(isShown);
-        });
+          var stepView = new StepView($(this))
+          stepView.preventHashUpdate()
+          stepView.setIsShown(isShown)
+        })
       }
 
-      function showLinkedStep() {
-        var $step;
+      function showLinkedStep () {
+        var $step
         if (rememberShownStep) {
-          $step = getStepForAnchor();
+          $step = getStepForAnchor()
         } else {
-          $step = $steps.filter('[data-show]');
+          $step = $steps.filter('[data-show]')
         }
 
         if ($step && $step.length) {
-          var stepView = new StepView($step);
-          stepView.show();
+          var stepView = new StepView($step)
+          stepView.show()
         }
       }
 
-      function getStepForAnchor() {
-        var anchor = getActiveAnchor();
+      function getStepForAnchor () {
+        var anchor = getActiveAnchor()
 
         return anchor.length
           ? $element.find('#' + escapeSelector(anchor.substr(1)))
-          : null;
+          : null
       }
 
-      function getActiveAnchor() {
-        return GOVUK.getCurrentLocation().hash;
+      function getActiveAnchor () {
+        return GOVUK.getCurrentLocation().hash
       }
 
-      function addButtonstoSteps() {
+      function addButtonstoSteps () {
         $.each($steps, function () {
-          var $step = $(this);
-          var $title = $step.find('.js-step-title');
-          var contentId = $step.find('.js-panel').first().attr('id');
+          var $step = $(this)
+          var $title = $step.find('.js-step-title')
+          var contentId = $step.find('.js-panel').first().attr('id')
 
           $title.wrapInner(
             '<span class="js-step-title-text"></span>'
-          );
+          )
 
           $title.wrapInner(
             '<button ' +
             'class="app-step-nav__button app-step-nav__button--title js-step-title-button" ' +
             'aria-expanded="false" aria-controls="' + contentId + '">' +
             '</button>'
-          );
-        });
+          )
+        })
       }
 
-      function bindToggleForSteps() {
+      function bindToggleForSteps () {
         $element.find('.js-toggle-panel').click(function (event) {
-          var $step = $(this).closest('.js-step');
+          var $step = $(this).closest('.js-step')
 
-          var stepView = new StepView($step);
-          stepView.toggle();
+          var stepView = new StepView($step)
+          stepView.toggle()
 
-          var stepIsOptional = typeof $step.data('optional') !== 'undefined' ? true : false;
-
-          setShowHideAllText();
-        });
+          setShowHideAllText()
+        })
       }
 
       // tracking click events on links in step content
-      function bindComponentLinkClicks() {
+      function bindComponentLinkClicks () {
         $element.find('.js-link').click(function (event) {
-
-          var thisLinkHref = $(this).attr('href');
+          var thisLinkHref = $(this).attr('href')
 
           if ($(this).attr('rel') !== 'external') {
-            saveToSessionStorage(sessionStoreLink, $(this).data('position'));
+            saveToSessionStorage(sessionStoreLink, $(this).data('position'))
           }
 
-          if (thisLinkHref == activeLinkHref) {
-            setOnlyThisLinkActive($(this));
+          if (thisLinkHref === activeLinkHref) {
+            setOnlyThisLinkActive($(this))
           }
-        });
+        })
       }
 
-      function saveToSessionStorage(key, value) {
-        sessionStorage.setItem(key, value);
+      function saveToSessionStorage (key, value) {
+        sessionStorage.setItem(key, value)
       }
 
-      function loadFromSessionStorage(key) {
-        return sessionStorage.getItem(key);
+      function loadFromSessionStorage (key) {
+        return sessionStorage.getItem(key)
       }
 
-      function removeFromSessionStorage(key) {
-        sessionStorage.removeItem(key);
+      function removeFromSessionStorage (key) {
+        sessionStorage.removeItem(key)
       }
 
-      function setOnlyThisLinkActive(clicked) {
-        $element.find('.' + activeLinkClass).removeClass(activeLinkClass);
-        clicked.parent().addClass(activeLinkClass);
+      function setOnlyThisLinkActive (clicked) {
+        $element.find('.' + activeLinkClass).removeClass(activeLinkClass)
+        clicked.parent().addClass(activeLinkClass)
       }
 
-      function ensureOnlyOneActiveLink() {
-        var $activeLinks = $element.find('.js-list-item.' + activeLinkClass);
+      function ensureOnlyOneActiveLink () {
+        var $activeLinks = $element.find('.js-list-item.' + activeLinkClass)
 
         if ($activeLinks.length <= 1) {
-          return;
+          return
         }
 
-        var lastClicked = loadFromSessionStorage(sessionStoreLink);
+        var lastClicked = loadFromSessionStorage(sessionStoreLink)
 
         if (lastClicked) {
-          removeActiveStateFromAllButCurrent($activeLinks, lastClicked);
-          removeFromSessionStorage(sessionStoreLink);
+          removeActiveStateFromAllButCurrent($activeLinks, lastClicked)
+          removeFromSessionStorage(sessionStoreLink)
         } else {
-          var activeLinkInActiveStep = $element.find('.app-step-nav__step--active').find('.' + activeLinkClass).first();
+          var activeLinkInActiveStep = $element.find('.app-step-nav__step--active').find('.' + activeLinkClass).first()
 
           if (activeLinkInActiveStep.length) {
-            $activeLinks.removeClass(activeLinkClass);
-            activeLinkInActiveStep.addClass(activeLinkClass);
+            $activeLinks.removeClass(activeLinkClass)
+            activeLinkInActiveStep.addClass(activeLinkClass)
           } else {
-            $activeLinks.slice(1).removeClass(activeLinkClass);
+            $activeLinks.slice(1).removeClass(activeLinkClass)
           }
         }
       }
 
-      function removeActiveStateFromAllButCurrent($links, current) {
-        $links.each(function() {
+      function removeActiveStateFromAllButCurrent ($links, current) {
+        $links.each(function () {
           if ($(this).find('.js-link').data('position').toString() !== current.toString()) {
-            $(this).removeClass(activeLinkClass);
+            $(this).removeClass(activeLinkClass)
           }
-        });
+        })
       }
 
-      function bindToggleShowHideAllButton() {
-        $showOrHideAllButton = $element.find('.js-step-controls-button');
+      function bindToggleShowHideAllButton () {
+        $showOrHideAllButton = $element.find('.js-step-controls-button')
         $showOrHideAllButton.on('click', function () {
-          var shouldshowAll;
+          var shouldshowAll
 
-          if ($showOrHideAllButton.text() == actions.showAllText) {
-            $showOrHideAllButton.text(actions.hideAllText);
+          if ($showOrHideAllButton.text() === actions.showAllText) {
+            $showOrHideAllButton.text(actions.hideAllText)
             $element.find('.js-toggle-link').text(actions.hideText)
-            shouldshowAll = true;
+            shouldshowAll = true
           } else {
-            $showOrHideAllButton.text(actions.showAllText);
-            $element.find('.js-toggle-link').text(actions.showText);
-            shouldshowAll = false;
+            $showOrHideAllButton.text(actions.showAllText)
+            $element.find('.js-toggle-link').text(actions.showText)
+            shouldshowAll = false
           }
 
-          setAllStepsShownState(shouldshowAll);
-          $showOrHideAllButton.attr('aria-expanded', shouldshowAll);
-          setShowHideAllText();
-          setHash(null);
+          setAllStepsShownState(shouldshowAll)
+          $showOrHideAllButton.attr('aria-expanded', shouldshowAll)
+          setShowHideAllText()
+          setHash(null)
 
-          return false;
-        });
+          return false
+        })
       }
 
-      function setShowHideAllText() {
-        var shownSteps = $element.find('.step-is-shown').length;
+      function setShowHideAllText () {
+        var shownSteps = $element.find('.step-is-shown').length
         // Find out if the number of is-opens == total number of steps
         if (shownSteps === totalSteps) {
-          $showOrHideAllButton.text(actions.hideAllText);
+          $showOrHideAllButton.text(actions.hideAllText)
         } else {
-          $showOrHideAllButton.text(actions.showAllText);
+          $showOrHideAllButton.text(actions.showAllText)
         }
       }
 
       // Ideally we'd use jQuery.escapeSelector, but this is only available from v3
       // See https://github.com/jquery/jquery/blob/2d4f53416e5f74fa98e0c1d66b6f3c285a12f0ce/src/selector-native.js#L46
-      function escapeSelector(s) {
-        var cssMatcher = /([\x00-\x1f\x7f]|^-?\d)|^-$|[^\x80-\uFFFF\w-]/g;
-        return s.replace(cssMatcher, "\\$&");
-      }
-    };
-
-    function StepView($stepElement) {
-      var $titleLink = $stepElement.find('.js-step-title-button');
-      var $stepContent = $stepElement.find('.js-panel');
-      var shouldUpdateHash = rememberShownStep;
-
-      this.title = $stepElement.find('.js-step-title-text').text().trim();
-      this.element = $stepElement;
-
-      this.show = show;
-      this.hide = hide;
-      this.toggle = toggle;
-      this.setIsShown = setIsShown;
-      this.isShown = isShown;
-      this.isHidden = isHidden;
-      this.preventHashUpdate = preventHashUpdate;
-      this.numberOfContentItems = numberOfContentItems;
-
-      function show() {
-        setIsShown(true);
-      }
-
-      function hide() {
-        setIsShown(false);
-      }
-
-      function toggle() {
-        setIsShown(isHidden());
-      }
-
-      function setIsShown(isShown) {
-        $stepElement.toggleClass('step-is-shown', isShown);
-        $stepContent.toggleClass('js-hidden', !isShown);
-        $titleLink.attr("aria-expanded", isShown);
-        $stepElement.find('.js-toggle-link').text(isShown ? actions.hideText : actions.showText);
-
-        if (shouldUpdateHash) {
-          updateHash($stepElement);
-        }
-      }
-
-      function isShown() {
-        return $stepElement.hasClass('step-is-shown');
-      }
-
-      function isHidden() {
-        return !isShown();
-      }
-
-      function preventHashUpdate() {
-        shouldUpdateHash = false;
-      }
-
-      function numberOfContentItems() {
-        return $stepContent.find('.js-link').length;
+      function escapeSelector (s) {
+        var cssMatcher = /([\x00-\x1f\x7f]|^-?\d)|^-$|[^\x80-\uFFFF\w-]/g // eslint-disable-line no-control-regex
+        return s.replace(cssMatcher, '\\$&')
       }
     }
 
-    function updateHash($stepElement) {
-      var stepView = new StepView($stepElement);
-      var hash = stepView.isShown() && '#' + $stepElement.attr('id');
+    function StepView ($stepElement) {
+      var $titleLink = $stepElement.find('.js-step-title-button')
+      var $stepContent = $stepElement.find('.js-panel')
+      var shouldUpdateHash = rememberShownStep
+
+      this.title = $stepElement.find('.js-step-title-text').text().trim()
+      this.element = $stepElement
+
+      this.show = show
+      this.hide = hide
+      this.toggle = toggle
+      this.setIsShown = setIsShown
+      this.isShown = isShown
+      this.isHidden = isHidden
+      this.preventHashUpdate = preventHashUpdate
+      this.numberOfContentItems = numberOfContentItems
+
+      function show () {
+        setIsShown(true)
+      }
+
+      function hide () {
+        setIsShown(false)
+      }
+
+      function toggle () {
+        setIsShown(isHidden())
+      }
+
+      function setIsShown (isShown) {
+        $stepElement.toggleClass('step-is-shown', isShown)
+        $stepContent.toggleClass('js-hidden', !isShown)
+        $titleLink.attr('aria-expanded', isShown)
+        $stepElement.find('.js-toggle-link').text(isShown ? actions.hideText : actions.showText)
+
+        if (shouldUpdateHash) {
+          updateHash($stepElement)
+        }
+      }
+
+      function isShown () {
+        return $stepElement.hasClass('step-is-shown')
+      }
+
+      function isHidden () {
+        return !isShown()
+      }
+
+      function preventHashUpdate () {
+        shouldUpdateHash = false
+      }
+
+      function numberOfContentItems () {
+        return $stepContent.find('.js-link').length
+      }
+    }
+
+    function updateHash ($stepElement) {
+      var stepView = new StepView($stepElement)
+      var hash = stepView.isShown() && '#' + $stepElement.attr('id')
       setHash(hash)
     }
 
     // Sets the hash for the page. If a falsy value is provided, the hash is cleared.
-    function setHash(hash) {
+    function setHash (hash) {
       if (!GOVUK.support.history()) {
-        return;
+        return
       }
 
-      var newLocation = hash || GOVUK.getCurrentLocation().pathname;
-      history.replaceState({}, '', newLocation);
+      var newLocation = hash || GOVUK.getCurrentLocation().pathname
+      history.replaceState({}, '', newLocation)
     }
-
-  };
-})(window.GOVUK.Modules);
+  }
+})(window.GOVUK.Modules)

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -6,6 +6,7 @@ $govuk-global-styles: true;
 
 // Patterns that aren't in Frontend
 @import "patterns/check-your-answers";
+@import "patterns/step-by-step-navigation";
 @import "patterns/task-list";
 @import "patterns/related-items";
 

--- a/app/assets/sass/patterns/_step-by-step-navigation.scss
+++ b/app/assets/sass/patterns/_step-by-step-navigation.scss
@@ -1,0 +1,661 @@
+// Based on https://github.com/alphagov/govuk_publishing_components/blob/v9.3.6/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
+
+.app-step-nav {
+  @include govuk-font($size: 19);
+  margin-bottom: 30px;
+}
+@media (min-width: 641px) {
+  .app-step-nav.app-step-nav--large {
+    margin-bottom: 60px;
+  }
+}
+
+.app-step-nav-header {
+  position: relative;
+  padding: 10px;
+  background: #f8f8f8;
+  border-top: solid 1px #bfc1c3;
+  border-bottom: solid 1px #bfc1c3;
+}
+@media (min-width: 641px) {
+  .app-step-nav-header {
+    padding: 15px;
+  }
+}
+
+.app-step-nav-header__part-of {
+  font-family: "nta", Arial, sans-serif;
+  font-weight: 700;
+  text-transform: none;
+  font-size: 14px;
+  line-height: 1.1428571429;
+  display: block;
+  padding-bottom: 0.2em;
+}
+@media (min-width: 641px) {
+  .app-step-nav-header__part-of {
+    font-size: 16px;
+    line-height: 1.25;
+  }
+}
+
+.app-step-nav-header__title {
+  font-family: "nta", Arial, sans-serif;
+  font-weight: 700;
+  text-transform: none;
+  font-size: 18px;
+  line-height: 1.2;
+}
+@media (min-width: 641px) {
+  .app-step-nav-header__title {
+    font-size: 24px;
+    line-height: 1.25;
+  }
+}
+
+.app-step-nav-related {
+  border-top: 2px solid #005ea5;
+  margin-bottom: 45px;
+}
+
+.app-step-nav-related__heading {
+  margin-top: 15px;
+  margin-bottom: 10px;
+  font-family: "nta", Arial, sans-serif;
+  font-weight: 700;
+  text-transform: none;
+  font-size: 16px;
+  line-height: 1.25;
+}
+@media (min-width: 641px) {
+  .app-step-nav-related__heading {
+    font-size: 19px;
+    line-height: 1.3157894737;
+  }
+}
+
+.app-step-nav-related__links {
+  font-family: "nta", Arial, sans-serif;
+  font-weight: 700;
+  text-transform: none;
+  font-size: 14px;
+  line-height: 1.1428571429;
+  margin: 0;
+  padding: 0;
+}
+@media (min-width: 641px) {
+  .app-step-nav-related__links {
+    font-size: 16px;
+    line-height: 1.25;
+  }
+}
+
+.app-step-nav-related__pretitle {
+  display: block;
+  margin-bottom: 15px;
+}
+@media (min-width: 641px) {
+  .app-step-nav-related__pretitle {
+    margin-bottom: 5px;
+  }
+}
+
+.app-step-nav-related__links {
+  list-style: none;
+}
+
+.app-step-nav-related__link-item {
+  margin-top: 15px;
+}
+@media (min-width: 641px) {
+  .app-step-nav-related__link-item {
+    margin-top: 5px;
+  }
+}
+
+.app-step-nav__controls {
+  padding: 3px 3px 0 0;
+  text-align: right;
+}
+
+.app-step-nav__button {
+  color: #005ea5;
+  cursor: pointer;
+  background: none;
+  border: 0;
+  margin: 0;
+}
+
+.app-step-nav__button::-moz-focus-inner {
+  border: 0;
+}
+
+.app-step-nav__button--title {
+  font-family: "nta", Arial, sans-serif;
+  font-weight: bold;
+  text-transform: none;
+  font-size: 19px;
+  line-height: 1.4;
+  display: inline-block;
+  padding: 0;
+  text-align: left;
+  color: #0b0c0c;
+}
+@media (min-width: 641px) {
+  .app-step-nav__button--title {
+    font-size: 19px;
+    line-height: 1.4;
+  }
+}
+
+.app-step-nav--large .app-step-nav__button--title {
+  font-family: "nta", Arial, sans-serif;
+  font-weight: bold;
+  text-transform: none;
+  font-size: 19px;
+  line-height: 1.4;
+}
+@media (min-width: 641px) {
+  .app-step-nav--large .app-step-nav__button--title {
+    font-size: 24px;
+    line-height: 1.4;
+  }
+}
+
+.app-step-nav__button--controls {
+  font-family: "nta", Arial, sans-serif;
+  font-weight: 400;
+  text-transform: none;
+  font-size: 14px;
+  line-height: 1;
+  position: relative;
+  z-index: 1;
+  padding: 0.5em 0;
+  text-decoration: underline;
+}
+@media (min-width: 641px) {
+  .app-step-nav__button--controls {
+    font-size: 14px;
+    line-height: 1;
+  }
+}
+
+.app-step-nav__button--controls:hover {
+  color: #2b8cc4;
+}
+
+.app-step-nav--large .app-step-nav__button--controls {
+  font-family: "nta", Arial, sans-serif;
+  font-weight: 400;
+  text-transform: none;
+  font-size: 14px;
+  line-height: 1;
+}
+@media (min-width: 641px) {
+  .app-step-nav--large .app-step-nav__button--controls {
+    font-size: 16px;
+    line-height: 1;
+  }
+}
+
+.app-step-nav__steps {
+  padding: 0;
+  margin: 0;
+}
+
+.app-step-nav__step {
+  position: relative;
+  padding-left: 45px;
+  list-style: none;
+}
+
+.app-step-nav__step:after {
+  content: "";
+  position: absolute;
+  z-index: 2;
+  width: 0;
+  height: 100%;
+  border-left: solid 2px #bfc1c3;
+  background: #fff;
+  left: 0;
+  margin-left: 12px;
+  top: 15px;
+}
+@media (min-width: 641px) {
+  .app-step-nav--large .app-step-nav__step {
+    padding-left: 60px;
+  }
+
+  .app-step-nav--large .app-step-nav__step:after {
+    left: 0;
+    margin-left: 16px;
+    border-width: 3px;
+    top: 30px;
+  }
+}
+
+.app-step-nav__step:last-child:before {
+  content: "";
+  position: absolute;
+  z-index: 6;
+  bottom: 0;
+  left: 0;
+  margin-left: 6.5px;
+  width: 13px;
+  height: 0;
+  border-bottom: solid 2px #bfc1c3;
+}
+
+.app-step-nav__step:last-child:after {
+  height: -webkit-calc(100% - 15px);
+  height: calc(100% - 15px);
+}
+
+.app-step-nav__step:last-child .app-step-nav__help:after {
+  height: 100%;
+}
+@media (min-width: 641px) {
+  .app-step-nav--large .app-step-nav__step:last-child:before {
+    margin-left: 8.75px;
+    width: 17.5px;
+    border-width: 3px;
+  }
+
+  .app-step-nav--large .app-step-nav__step:last-child:after {
+    height: calc(100% - 30px);
+  }
+}
+
+.app-step-nav__step--active .app-step-nav__circle--number,
+.app-step-nav__step--active .app-step-nav__help:after,
+.app-step-nav__step--active .app-step-nav__substep:after,
+.app-step-nav__step--active:after,
+.app-step-nav__step--active:last-child:before {
+  border-color: #0b0c0c;
+}
+
+.app-step-nav__circle {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  position: absolute;
+  z-index: 5;
+  top: 15px;
+  left: 0;
+  width: 26px;
+  height: 26px;
+  color: #0b0c0c;
+  background: #fff;
+  border-radius: 100px;
+  text-align: center;
+}
+@media (min-width: 641px) {
+  .app-step-nav--large .app-step-nav__circle {
+    top: 30px;
+    width: 35px;
+    height: 35px;
+  }
+}
+
+.app-step-nav__circle--number {
+  font-family: "nta", Arial, sans-serif;
+  font-weight: bold;
+  text-transform: none;
+  font-size: 16px;
+  line-height: 23px;
+  border: solid 2px #bfc1c3;
+}
+@media (min-width: 641px) {
+  .app-step-nav__circle--number {
+    font-size: 16px;
+    line-height: 23px;
+  }
+}
+
+.app-step-nav--large .app-step-nav__circle--number {
+  font-family: "nta", Arial, sans-serif;
+  font-weight: bold;
+  text-transform: none;
+  font-size: 16px;
+  line-height: 23px;
+}
+@media (min-width: 641px) {
+  .app-step-nav--large .app-step-nav__circle--number {
+    font-size: 19px;
+    line-height: 30px;
+  }
+}
+@media (min-width: 641px) {
+  .app-step-nav--large .app-step-nav__circle--number {
+    border-width: 3px;
+  }
+}
+
+.app-step-nav__circle--logic {
+  font-family: "nta", Arial, sans-serif;
+  font-weight: bold;
+  text-transform: none;
+  font-size: 16px;
+  line-height: 28px;
+}
+@media (min-width: 641px) {
+  .app-step-nav__circle--logic {
+    font-size: 16px;
+    line-height: 28px;
+  }
+}
+
+.app-step-nav--large .app-step-nav__circle--logic {
+  font-family: "nta", Arial, sans-serif;
+  font-weight: bold;
+  text-transform: none;
+  font-size: 16px;
+  line-height: 28px;
+}
+@media (min-width: 641px) {
+  .app-step-nav--large .app-step-nav__circle--logic {
+    font-size: 19px;
+    line-height: 34px;
+  }
+}
+
+.app-step-nav__circle-inner {
+  float: right;
+  min-width: 100%;
+}
+
+.app-step-nav__circle-background {
+  text-shadow: 0 -0.1em 0 #fff, 0.1em 0 0 #fff, 0 0.1em 0 #fff, -0.1em 0 0 #fff;
+}
+
+.app-step-nav__header {
+  padding: 15px 0;
+  border-top: solid 2px #dee0e2;
+}
+
+.app-step-nav--active .app-step-nav__header {
+  cursor: pointer;
+}
+
+.app-step-nav__header:hover .app-step-nav__button,
+.app-step-nav__header:hover .app-step-nav__circle {
+  color: #005ea5;
+}
+
+.app-step-nav__header:hover .app-step-nav__toggle-link {
+  text-decoration: underline;
+}
+@media (min-width: 641px) {
+  .app-step-nav--large .app-step-nav__header {
+    padding: 30px 0;
+  }
+}
+
+.app-step-nav__title {
+  font-family: "nta", Arial, sans-serif;
+  font-weight: bold;
+  text-transform: none;
+  font-size: 19px;
+  line-height: 1.4;
+  margin: 0;
+}
+@media (min-width: 641px) {
+  .app-step-nav__title {
+    font-size: 19px;
+    line-height: 1.4;
+  }
+}
+
+.app-step-nav--large .app-step-nav__title {
+  font-family: "nta", Arial, sans-serif;
+  font-weight: bold;
+  text-transform: none;
+  font-size: 19px;
+  line-height: 1.4;
+}
+@media (min-width: 641px) {
+  .app-step-nav--large .app-step-nav__title {
+    font-size: 24px;
+    line-height: 1.4;
+  }
+}
+
+.app-step-nav__toggle-link {
+  font-family: "nta", Arial, sans-serif;
+  font-weight: 400;
+  text-transform: none;
+  font-size: 14px;
+  line-height: 1.2;
+  display: block;
+  color: #005ea5;
+}
+@media (min-width: 641px) {
+  .app-step-nav__toggle-link {
+    font-size: 14px;
+    line-height: 1.2;
+  }
+}
+
+.app-step-nav--large .app-step-nav__toggle-link {
+  font-family: "nta", Arial, sans-serif;
+  font-weight: 400;
+  text-transform: none;
+  font-size: 14px;
+  line-height: 1.2;
+}
+@media (min-width: 641px) {
+  .app-step-nav--large .app-step-nav__toggle-link {
+    font-size: 16px;
+    line-height: 1.2;
+  }
+}
+
+.app-step-nav__panel {
+  font-family: "nta", Arial, sans-serif;
+  font-weight: 400;
+  text-transform: none;
+  font-size: 16px;
+  line-height: 1.25;
+}
+@media (min-width: 641px) {
+  .app-step-nav__panel {
+    font-size: 16px;
+    line-height: 1.3157894737;
+  }
+}
+
+.app-step-nav--large .app-step-nav__panel {
+  font-family: "nta", Arial, sans-serif;
+  font-weight: 400;
+  text-transform: none;
+  font-size: 16px;
+  line-height: 1.25;
+}
+@media (min-width: 641px) {
+  .app-step-nav--large .app-step-nav__panel {
+    font-size: 19px;
+    line-height: 1.3157894737;
+  }
+}
+
+.app-step-nav__heading,
+.app-step-nav__paragraph {
+  padding-bottom: 15px;
+  margin: 0;
+  font-size: inherit;
+}
+
+.app-step-nav__heading + .app-step-nav__list,
+.app-step-nav__paragraph + .app-step-nav__list {
+  margin-top: -5px;
+}
+@media (min-width: 641px) {
+  .app-step-nav--large .app-step-nav__heading + .app-step-nav__list,
+  .app-step-nav--large .app-step-nav__paragraph + .app-step-nav__list {
+    margin-top: -15px;
+  }
+}
+@media (min-width: 641px) {
+  .app-step-nav--large .app-step-nav__heading,
+  .app-step-nav--large .app-step-nav__paragraph {
+    padding-bottom: 30px;
+  }
+}
+
+.app-step-nav__heading {
+  font-weight: bold;
+}
+
+.app-step-nav__list {
+  padding: 0 0 10px;
+}
+@media (min-width: 641px) {
+  .app-step-nav--large .app-step-nav__list {
+    padding-bottom: 20px;
+  }
+}
+
+.app-step-nav__list--choice {
+  margin-left: 20px;
+  list-style: disc;
+}
+
+.app-step-nav__list--choice .app-step-nav__list-item--active:before {
+  left: -65px;
+}
+@media (min-width: 641px) {
+  .app-step-nav--large .app-step-nav__list--choice .app-step-nav__list-item--active:before {
+    left: -80px;
+  }
+}
+
+.app-step-nav__list-item {
+  list-style: none;
+  margin-bottom: 10px;
+}
+
+.app-step-nav__list-item--active {
+  position: relative;
+}
+
+.app-step-nav__list-item--active:before {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  content: "";
+  position: absolute;
+  z-index: 5;
+  top: 0.6em;
+  left: -45px;
+  margin-left: 5px;
+  width: 16px;
+  height: 16px;
+  margin-top: -8px;
+  background: #0b0c0c;
+  border: solid 2px #fff;
+  border-radius: 100px;
+}
+@media (min-width: 641px) {
+  .app-step-nav--large .app-step-nav__list-item--active:before {
+    left: -60px;
+    margin-left: 9.5px;
+  }
+}
+
+.app-step-nav__list-item--active .app-step-nav__link {
+  color: #0b0c0c;
+  text-decoration: none;
+}
+
+.app-step-nav__list-item--active .app-step-nav__link:active,
+.app-step-nav__list-item--active .app-step-nav__link:link,
+.app-step-nav__list-item--active .app-step-nav__link:visited {
+  color: #0b0c0c;
+}
+
+.app-step-nav__context {
+  display: inline-block;
+  font-weight: normal;
+  color: #6f777b;
+}
+
+.app-step-nav__context:before {
+  content: " \2013\00a0";
+}
+
+.app-step-nav__help {
+  position: relative;
+  padding: 15px 0;
+  border-top: solid 2px #dee0e2;
+}
+
+.app-step-nav__help:after {
+  content: "";
+  position: absolute;
+  z-index: 2;
+  width: 0;
+  height: 100%;
+  border-left: dotted 2px #bfc1c3;
+  background: #fff;
+  left: 0;
+  margin-left: 12px;
+  z-index: 3;
+  top: 0;
+  left: -45px;
+  height: calc(100% + 30px);
+}
+@media (min-width: 641px) {
+  .app-step-nav--large .app-step-nav__help:after {
+    left: 0;
+    margin-left: 16px;
+    border-width: 3px;
+    left: -60px;
+    height: calc(100% + 30px + 15px);
+  }
+}
+
+.app-step-nav__help-link {
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.app-step-nav__help-link:hover {
+  text-decoration: underline;
+}
+
+.app-step-nav__substep {
+  position: relative;
+  padding-top: 15px;
+  border-top: solid 2px #dee0e2;
+}
+
+.app-step-nav__substep:after {
+  content: "";
+  position: absolute;
+  z-index: 2;
+  width: 0;
+  height: 100%;
+  border-left: solid 2px #bfc1c3;
+  background: #fff;
+  left: 0;
+  margin-left: 12px;
+  z-index: 3;
+  top: 0;
+  left: -45px;
+}
+@media (min-width: 641px) {
+  .app-step-nav--large .app-step-nav__substep {
+    padding-top: 30px;
+  }
+
+  .app-step-nav--large .app-step-nav__substep:after {
+    left: 0;
+    margin-left: 16px;
+    border-width: 3px;
+    left: -60px;
+  }
+}
+
+.app-step-nav__substep--optional:after {
+  border-left-style: dotted;
+}

--- a/app/assets/sass/patterns/_step-by-step-navigation.scss
+++ b/app/assets/sass/patterns/_step-by-step-navigation.scss
@@ -1,101 +1,62 @@
 // Based on https://github.com/alphagov/govuk_publishing_components/blob/v9.3.6/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss
-
-.app-step-nav {
-  @include govuk-font($size: 19);
-  margin-bottom: 30px;
-}
-@media (min-width: 641px) {
-  .app-step-nav.app-step-nav--large {
-    margin-bottom: 60px;
-  }
-}
+// Note - this code for prototype purposes only. It is not production code,
+// nor an example of the best way to use GOV.UK Frontend
 
 .app-step-nav-header {
   position: relative;
   padding: 10px;
-  background: #f8f8f8;
-  border-top: solid 1px #bfc1c3;
-  border-bottom: solid 1px #bfc1c3;
-}
-@media (min-width: 641px) {
-  .app-step-nav-header {
+  background: govuk-colour("grey-4");
+  border-top: solid 1px $govuk-border-colour;
+  border-bottom: solid 1px $govuk-border-colour;
+  @include govuk-media-query($from: tablet) {
     padding: 15px;
   }
 }
 
 .app-step-nav-header__part-of {
-  font-family: "nta", Arial, sans-serif;
-  font-weight: 700;
-  text-transform: none;
-  font-size: 14px;
-  line-height: 1.1428571429;
+  @include govuk-font(16, $weight: bold)
   display: block;
   padding-bottom: 0.2em;
 }
-@media (min-width: 641px) {
-  .app-step-nav-header__part-of {
-    font-size: 16px;
-    line-height: 1.25;
-  }
-}
 
 .app-step-nav-header__title {
-  font-family: "nta", Arial, sans-serif;
-  font-weight: 700;
-  text-transform: none;
-  font-size: 18px;
-  line-height: 1.2;
-}
-@media (min-width: 641px) {
-  .app-step-nav-header__title {
-    font-size: 24px;
-    line-height: 1.25;
-  }
+  @include govuk-font(24, $weight: bold)
 }
 
 .app-step-nav-related {
-  border-top: 2px solid #005ea5;
-  margin-bottom: 45px;
+  border-top: 2px solid $govuk-link-colour;
+  margin-bottom: 30px;
 }
 
 .app-step-nav-related__heading {
+  @include govuk-font(19, $weight: bold)
   margin-top: 15px;
   margin-bottom: 10px;
-  font-family: "nta", Arial, sans-serif;
-  font-weight: 700;
-  text-transform: none;
-  font-size: 16px;
-  line-height: 1.25;
-}
-@media (min-width: 641px) {
-  .app-step-nav-related__heading {
-    font-size: 19px;
-    line-height: 1.3157894737;
-  }
 }
 
 .app-step-nav-related__links {
-  font-family: "nta", Arial, sans-serif;
-  font-weight: 700;
-  text-transform: none;
-  font-size: 14px;
-  line-height: 1.1428571429;
+  @include govuk-font(16, $weight: bold)
   margin: 0;
   padding: 0;
 }
-@media (min-width: 641px) {
-  .app-step-nav-related__links {
-    font-size: 16px;
-    line-height: 1.25;
+
+.app-step-nav-related--singular {
+  margin-bottom: 13px;
+
+  .app-step-nav-related__heading {
+    @include govuk-font(19, $weight: bold)
+    margin-top: 20px;
+  }
+
+  .app-step-nav-related__pretitle {
+    margin-bottom: 5px;
   }
 }
 
 .app-step-nav-related__pretitle {
   display: block;
   margin-bottom: 15px;
-}
-@media (min-width: 641px) {
-  .app-step-nav-related__pretitle {
+  @include govuk-media-query($from: tablet) {
     margin-bottom: 5px;
   }
 }
@@ -106,10 +67,18 @@
 
 .app-step-nav-related__link-item {
   margin-top: 15px;
-}
-@media (min-width: 641px) {
-  .app-step-nav-related__link-item {
+  @include govuk-media-query($from: tablet) {
     margin-top: 5px;
+  }
+}
+
+.app-step-nav {
+  @include govuk-font(19);
+  margin-bottom: 30px;
+  &.app-step-nav--large {
+    @include govuk-media-query($from: tablet) {
+      margin-bottom: 60px;
+    }
   }
 }
 
@@ -119,82 +88,45 @@
 }
 
 .app-step-nav__button {
-  color: #005ea5;
+  color: $govuk-link-colour;
   cursor: pointer;
   background: none;
   border: 0;
   margin: 0;
 }
 
+// removes extra dotted outline from buttons in Firefox
+// on focus (standard yellow outline unaffected)
 .app-step-nav__button::-moz-focus-inner {
   border: 0;
 }
 
 .app-step-nav__button--title {
-  font-family: "nta", Arial, sans-serif;
-  font-weight: bold;
-  text-transform: none;
-  font-size: 19px;
-  line-height: 1.4;
+  @include govuk-font(19, $weight: bold)
   display: inline-block;
   padding: 0;
   text-align: left;
-  color: #0b0c0c;
-}
-@media (min-width: 641px) {
-  .app-step-nav__button--title {
-    font-size: 19px;
-    line-height: 1.4;
-  }
-}
+  color: govuk-colour("black");
 
-.app-step-nav--large .app-step-nav__button--title {
-  font-family: "nta", Arial, sans-serif;
-  font-weight: bold;
-  text-transform: none;
-  font-size: 19px;
-  line-height: 1.4;
-}
-@media (min-width: 641px) {
-  .app-step-nav--large .app-step-nav__button--title {
-    font-size: 24px;
-    line-height: 1.4;
+  .app-step-nav--large & {
+    @include govuk-font(24, $weight: bold)
   }
+
 }
 
 .app-step-nav__button--controls {
-  font-family: "nta", Arial, sans-serif;
-  font-weight: 400;
-  text-transform: none;
-  font-size: 14px;
-  line-height: 1;
+  @include govuk-font(14)
   position: relative;
-  z-index: 1;
+  z-index: 1; // this and relative position stops focus outline underlap with border of accordion
   padding: 0.5em 0;
   text-decoration: underline;
-}
-@media (min-width: 641px) {
-  .app-step-nav__button--controls {
-    font-size: 14px;
-    line-height: 1;
+
+  &:hover {
+    color: $govuk-link-hover-colour;
   }
-}
 
-.app-step-nav__button--controls:hover {
-  color: #2b8cc4;
-}
-
-.app-step-nav--large .app-step-nav__button--controls {
-  font-family: "nta", Arial, sans-serif;
-  font-weight: 400;
-  text-transform: none;
-  font-size: 14px;
-  line-height: 1;
-}
-@media (min-width: 641px) {
-  .app-step-nav--large .app-step-nav__button--controls {
-    font-size: 16px;
-    line-height: 1;
+  .app-step-nav--large & {
+    @include govuk-font(16)
   }
 }
 
@@ -215,13 +147,14 @@
   z-index: 2;
   width: 0;
   height: 100%;
-  border-left: solid 2px #bfc1c3;
+  border-left: solid 2px $govuk-border-colour;
   background: #fff;
   left: 0;
   margin-left: 12px;
   top: 15px;
 }
-@media (min-width: 641px) {
+
+@include govuk-media-query($from: tablet) {
   .app-step-nav--large .app-step-nav__step {
     padding-left: 60px;
   }
@@ -243,7 +176,7 @@
   margin-left: 6.5px;
   width: 13px;
   height: 0;
-  border-bottom: solid 2px #bfc1c3;
+  border-bottom: solid 2px $govuk-border-colour;
 }
 
 .app-step-nav__step:last-child:after {
@@ -254,7 +187,8 @@
 .app-step-nav__step:last-child .app-step-nav__help:after {
   height: 100%;
 }
-@media (min-width: 641px) {
+
+@include govuk-media-query($from: tablet) {
   .app-step-nav--large .app-step-nav__step:last-child:before {
     margin-left: 8.75px;
     width: 17.5px;
@@ -271,7 +205,7 @@
 .app-step-nav__step--active .app-step-nav__substep:after,
 .app-step-nav__step--active:after,
 .app-step-nav__step--active:last-child:before {
-  border-color: #0b0c0c;
+  border-color: govuk-colour("black");
 }
 
 .app-step-nav__circle {
@@ -284,12 +218,13 @@
   left: 0;
   width: 26px;
   height: 26px;
-  color: #0b0c0c;
+  color: govuk-colour("black");
   background: #fff;
   border-radius: 100px;
   text-align: center;
 }
-@media (min-width: 641px) {
+
+@include govuk-media-query($from: tablet) {
   .app-step-nav--large .app-step-nav__circle {
     top: 30px;
     width: 35px;
@@ -298,14 +233,12 @@
 }
 
 .app-step-nav__circle--number {
-  font-family: "nta", Arial, sans-serif;
-  font-weight: bold;
-  text-transform: none;
-  font-size: 16px;
+  @include govuk-font(16, $weight: bold)
   line-height: 23px;
-  border: solid 2px #bfc1c3;
+  border: solid 2px $govuk-border-colour;
 }
-@media (min-width: 641px) {
+
+@include govuk-media-query($from: tablet) {
   .app-step-nav__circle--number {
     font-size: 16px;
     line-height: 23px;
@@ -313,32 +246,28 @@
 }
 
 .app-step-nav--large .app-step-nav__circle--number {
-  font-family: "nta", Arial, sans-serif;
-  font-weight: bold;
-  text-transform: none;
-  font-size: 16px;
+  @include govuk-font(16, $weight: bold)
   line-height: 23px;
 }
-@media (min-width: 641px) {
+
+@include govuk-media-query($from: tablet) {
   .app-step-nav--large .app-step-nav__circle--number {
     font-size: 19px;
     line-height: 30px;
   }
 }
-@media (min-width: 641px) {
+
+@include govuk-media-query($from: tablet) {
   .app-step-nav--large .app-step-nav__circle--number {
     border-width: 3px;
   }
 }
 
 .app-step-nav__circle--logic {
-  font-family: "nta", Arial, sans-serif;
-  font-weight: bold;
-  text-transform: none;
-  font-size: 16px;
+  @include govuk-font(16, $weight: bold)
   line-height: 28px;
 }
-@media (min-width: 641px) {
+@include govuk-media-query($from: tablet) {
   .app-step-nav__circle--logic {
     font-size: 16px;
     line-height: 28px;
@@ -346,13 +275,11 @@
 }
 
 .app-step-nav--large .app-step-nav__circle--logic {
-  font-family: "nta", Arial, sans-serif;
-  font-weight: bold;
-  text-transform: none;
-  font-size: 16px;
+  @include govuk-font(16, $weight: bold)
   line-height: 28px;
 }
-@media (min-width: 641px) {
+
+@include govuk-media-query($from: tablet) {
   .app-step-nav--large .app-step-nav__circle--logic {
     font-size: 19px;
     line-height: 34px;
@@ -370,7 +297,7 @@
 
 .app-step-nav__header {
   padding: 15px 0;
-  border-top: solid 2px #dee0e2;
+  border-top: solid 2px govuk-colour("grey-3");
 }
 
 .app-step-nav--active .app-step-nav__header {
@@ -379,27 +306,26 @@
 
 .app-step-nav__header:hover .app-step-nav__button,
 .app-step-nav__header:hover .app-step-nav__circle {
-  color: #005ea5;
+  color: $govuk-link-colour;
 }
 
 .app-step-nav__header:hover .app-step-nav__toggle-link {
   text-decoration: underline;
 }
-@media (min-width: 641px) {
+
+@include govuk-media-query($from: tablet) {
   .app-step-nav--large .app-step-nav__header {
     padding: 30px 0;
   }
 }
 
 .app-step-nav__title {
-  font-family: "nta", Arial, sans-serif;
-  font-weight: bold;
-  text-transform: none;
-  font-size: 19px;
+  @include govuk-font(19, $weight: bold)
   line-height: 1.4;
   margin: 0;
 }
-@media (min-width: 641px) {
+
+@include govuk-media-query($from: tablet) {
   .app-step-nav__title {
     font-size: 19px;
     line-height: 1.4;
@@ -407,13 +333,11 @@
 }
 
 .app-step-nav--large .app-step-nav__title {
-  font-family: "nta", Arial, sans-serif;
-  font-weight: bold;
-  text-transform: none;
-  font-size: 19px;
+  @include govuk-font(19, $weight: bold)
   line-height: 1.4;
 }
-@media (min-width: 641px) {
+
+@include govuk-media-query($from: tablet) {
   .app-step-nav--large .app-step-nav__title {
     font-size: 24px;
     line-height: 1.4;
@@ -421,29 +345,18 @@
 }
 
 .app-step-nav__toggle-link {
-  font-family: "nta", Arial, sans-serif;
-  font-weight: 400;
-  text-transform: none;
-  font-size: 14px;
+  @include govuk-font(16)
   line-height: 1.2;
   display: block;
-  color: #005ea5;
-}
-@media (min-width: 641px) {
-  .app-step-nav__toggle-link {
-    font-size: 14px;
-    line-height: 1.2;
-  }
+  color: $govuk-link-colour;
 }
 
 .app-step-nav--large .app-step-nav__toggle-link {
-  font-family: "nta", Arial, sans-serif;
-  font-weight: 400;
-  text-transform: none;
-  font-size: 14px;
+  @include govuk-font(16)
   line-height: 1.2;
 }
-@media (min-width: 641px) {
+
+@include govuk-media-query($from: tablet) {
   .app-step-nav--large .app-step-nav__toggle-link {
     font-size: 16px;
     line-height: 1.2;
@@ -451,31 +364,21 @@
 }
 
 .app-step-nav__panel {
-  font-family: "nta", Arial, sans-serif;
-  font-weight: 400;
-  text-transform: none;
-  font-size: 16px;
+  @include govuk-font(16)
   line-height: 1.25;
+  .js-enabled &.js-hidden {
+    display: none;
+  }
 }
-@media (min-width: 641px) {
+
+@include govuk-media-query($from: tablet) {
   .app-step-nav__panel {
     font-size: 16px;
-    line-height: 1.3157894737;
   }
 }
 
 .app-step-nav--large .app-step-nav__panel {
-  font-family: "nta", Arial, sans-serif;
-  font-weight: 400;
-  text-transform: none;
-  font-size: 16px;
-  line-height: 1.25;
-}
-@media (min-width: 641px) {
-  .app-step-nav--large .app-step-nav__panel {
-    font-size: 19px;
-    line-height: 1.3157894737;
-  }
+  @include govuk-font(19)
 }
 
 .app-step-nav__heading,
@@ -489,13 +392,15 @@
 .app-step-nav__paragraph + .app-step-nav__list {
   margin-top: -5px;
 }
-@media (min-width: 641px) {
+
+@include govuk-media-query($from: tablet) {
   .app-step-nav--large .app-step-nav__heading + .app-step-nav__list,
   .app-step-nav--large .app-step-nav__paragraph + .app-step-nav__list {
     margin-top: -15px;
   }
 }
-@media (min-width: 641px) {
+
+@include govuk-media-query($from: tablet) {
   .app-step-nav--large .app-step-nav__heading,
   .app-step-nav--large .app-step-nav__paragraph {
     padding-bottom: 30px;
@@ -509,7 +414,7 @@
 .app-step-nav__list {
   padding: 0 0 10px;
 }
-@media (min-width: 641px) {
+@include govuk-media-query($from: tablet) {
   .app-step-nav--large .app-step-nav__list {
     padding-bottom: 20px;
   }
@@ -521,9 +426,9 @@
 }
 
 .app-step-nav__list--choice .app-step-nav__list-item--active:before {
-  left: -65px;
+  left: -45px;
 }
-@media (min-width: 641px) {
+@include govuk-media-query($from: tablet) {
   .app-step-nav--large .app-step-nav__list--choice .app-step-nav__list-item--active:before {
     left: -80px;
   }
@@ -551,11 +456,11 @@
   width: 16px;
   height: 16px;
   margin-top: -8px;
-  background: #0b0c0c;
+  background: govuk-colour("black");
   border: solid 2px #fff;
   border-radius: 100px;
 }
-@media (min-width: 641px) {
+@include govuk-media-query($from: tablet) {
   .app-step-nav--large .app-step-nav__list-item--active:before {
     left: -60px;
     margin-left: 9.5px;
@@ -563,20 +468,20 @@
 }
 
 .app-step-nav__list-item--active .app-step-nav__link {
-  color: #0b0c0c;
+  color: govuk-colour("black");
   text-decoration: none;
 }
 
 .app-step-nav__list-item--active .app-step-nav__link:active,
 .app-step-nav__list-item--active .app-step-nav__link:link,
 .app-step-nav__list-item--active .app-step-nav__link:visited {
-  color: #0b0c0c;
+  color: govuk-colour("black");
 }
 
 .app-step-nav__context {
   display: inline-block;
   font-weight: normal;
-  color: #6f777b;
+  color: $govuk-secondary-text-colour;
 }
 
 .app-step-nav__context:before {
@@ -586,7 +491,7 @@
 .app-step-nav__help {
   position: relative;
   padding: 15px 0;
-  border-top: solid 2px #dee0e2;
+  border-top: solid 2px govuk-colour("grey-3");
 }
 
 .app-step-nav__help:after {
@@ -595,7 +500,7 @@
   z-index: 2;
   width: 0;
   height: 100%;
-  border-left: dotted 2px #bfc1c3;
+  border-left: dotted 2px $govuk-border-colour;
   background: #fff;
   left: 0;
   margin-left: 12px;
@@ -604,7 +509,8 @@
   left: -45px;
   height: calc(100% + 30px);
 }
-@media (min-width: 641px) {
+
+@include govuk-media-query($from: tablet) {
   .app-step-nav--large .app-step-nav__help:after {
     left: 0;
     margin-left: 16px;
@@ -626,7 +532,7 @@
 .app-step-nav__substep {
   position: relative;
   padding-top: 15px;
-  border-top: solid 2px #dee0e2;
+  border-top: solid 2px govuk-colour("grey-3");
 }
 
 .app-step-nav__substep:after {
@@ -635,7 +541,7 @@
   z-index: 2;
   width: 0;
   height: 100%;
-  border-left: solid 2px #bfc1c3;
+  border-left: solid 2px $govuk-border-colour;
   background: #fff;
   left: 0;
   margin-left: 12px;
@@ -643,7 +549,8 @@
   top: 0;
   left: -45px;
 }
-@media (min-width: 641px) {
+
+@include govuk-media-query($from: tablet) {
   .app-step-nav--large .app-step-nav__substep {
     padding-top: 30px;
   }

--- a/docs/views/layout.html
+++ b/docs/views/layout.html
@@ -91,6 +91,8 @@
 {% endblock %}
 
 {% block bodyEnd %}
-  {% include "includes/scripts.html" %}
-  <!-- GOV.UK Prototype Kit {{releaseVersion}} -->
+  {% block scripts %}
+    {% include "includes/scripts.html" %}
+    {% block pageScripts %}{% endblock %}
+  {% endblock %}
 {% endblock %}

--- a/docs/views/templates/start-with-step-by-step.html
+++ b/docs/views/templates/start-with-step-by-step.html
@@ -1,0 +1,317 @@
+{% extends "layout.html" %} {% block pageTitle %} Start page example {% endblock %} {% block header %}
+<!-- Blank header with no service name for the start page -->
+{{ govukHeader() }} {% endblock %} {% block pageScripts %}
+<script src="/public/javascripts/step-by-step-navigation.js"></script>
+<script type="text/javascript">
+  var $element = $('#step-by-step-navigation')
+  var stepByStepNavigation = new GOVUK.Modules.StepByStepNavigation()
+  stepByStepNavigation.start($element)
+</script>
+{% endblock %} {% block beforeContent %}
+<div class="app-step-nav-header">
+  <span class="app-step-nav-header__part-of">Part of</span>
+  <a class="app-step-nav-header__title" href="#">
+    Learn to drive a car: step by step
+  </a>
+</div>
+{% endblock %} {% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl">
+      Check what age you can drive
+    </h1>
+
+    <p>Use this service to:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>do something</li>
+      <li>update your name, address or other details</li>
+      <li>do something else</li>
+    </ul>
+
+    <a href="#" role="button" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8">Start now</a>
+
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+
+    <div class="app-step-nav-related app-step-nav-related--singular">
+      <h2 class="app-step-nav-related__heading">
+        <span class="app-step-nav-related__pretitle">Part of</span>
+        <a href="#">
+          Learn to drive a car: step by step
+        </a>
+      </h2>
+    </div>
+
+    <div id="step-by-step-navigation" data-module="gemstepnav" class="app-step-nav js-hidden " data-id="e01e924b-9c7c-4c71-8241-66a575c2f61f" data-show-text="show" data-hide-text="hide" data-show-all-text="Show all" data-hide-all-text="Hide all">
+      <ol class="app-step-nav__steps">
+        <li class="app-step-nav__step js-step app-step-nav__step--active" aria-current="step" data-show id="check-youre-allowed-to-drive" >
+          <div class="app-step-nav__header js-toggle-panel" data-position="1">
+            <h3 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--number">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    <span class="app-step-nav__circle-step-label govuk-visually-hidden">Step</span> 1
+                    <span class="app-step-nav__circle-step-colon govuk-visually-hidden" aria-hidden="true">:</span>
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title">
+                Check you're allowed to drive
+              </span>
+            </h3>
+          </div>
+
+          <div class="app-step-nav__panel js-panel" id="step-panel-check-youre-allowed-to-drive-1">
+            <p class="app-step-nav__paragraph">Most people can start learning to drive when they’re 17.</p>
+
+            <ol class="app-step-nav__list " data-length="3">
+              <li class="app-step-nav__list-item js-list-item app-step-nav__list-item--active">
+                <a data-position="1.1" class="app-step-nav__link js-link" href="#content">
+                  <span class="app-step-nav__link-active-context govuk-visually-hidden">You are currently viewing: </span>Check what age you can drive </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="1.2" class="app-step-nav__link js-link" href="#">Requirements for driving legally </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="1.3" class="app-step-nav__link js-link" href="#">Driving eyesight rules </a>
+              </li>
+            </ol>
+
+          </div>
+
+        </li>
+        <li class="app-step-nav__step js-step" id="get-a-provisional-licence" >
+          <div class="app-step-nav__header js-toggle-panel" data-position="2">
+            <h3 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--number">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    <span class="app-step-nav__circle-step-label govuk-visually-hidden">Step</span> 2
+                    <span class="app-step-nav__circle-step-colon govuk-visually-hidden" aria-hidden="true">:</span>
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title">
+                Get a provisional licence
+              </span>
+            </h3>
+          </div>
+
+          <div class="app-step-nav__panel js-panel" id="step-panel-get-a-provisional-licence-2">
+            <ol class="app-step-nav__list " data-length="1">
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="2.1" class="app-step-nav__link js-link" href="#">£34 to £43</span>
+                </a>
+              </li>
+            </ol>
+
+          </div>
+
+        </li>
+        <li class="app-step-nav__step js-step" id="driving-lessons-and-practice" >
+          <div class="app-step-nav__header js-toggle-panel" data-position="3">
+            <h3 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--number">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    <span class="app-step-nav__circle-step-label govuk-visually-hidden">Step</span> 3
+                    <span class="app-step-nav__circle-step-colon govuk-visually-hidden" aria-hidden="true">:</span>
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title">
+                Driving lessons and practice
+              </span>
+            </h3>
+          </div>
+
+          <div class="app-step-nav__panel js-panel" id="step-panel-driving-lessons-and-practice-3">
+            <p class="app-step-nav__paragraph">You need a provisional driving licence to take lessons or practice.</p>
+
+            <ol class="app-step-nav__list " data-length="4">
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="3.1" class="app-step-nav__link js-link" href="#">The Highway Code </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="3.2" class="app-step-nav__link js-link" href="#">Taking driving lessons </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="3.3" class="app-step-nav__link js-link" href="#">Find driving schools, lessons and instructors </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="3.4" class="app-step-nav__link js-link" href="#">Practise vehicle safety questions </a>
+              </li>
+            </ol>
+
+          </div>
+
+        </li>
+        <li class="app-step-nav__step js-step" id="prepare-for-your-theory-test" >
+          <div class="app-step-nav__header js-toggle-panel" data-position="4">
+            <h3 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--logic">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    and
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title">
+                Prepare for your theory test
+              </span>
+            </h3>
+          </div>
+
+          <div class="app-step-nav__panel js-panel" id="step-panel-prepare-for-your-theory-test-4">
+            <ol class="app-step-nav__list " data-length="3">
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="4.1" class="app-step-nav__link js-link" href="#">Theory test revision and practice </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="4.2" class="app-step-nav__link js-link" href="#">Take a practice theory test </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a rel="external" data-position="4.3" class="app-step-nav__link js-link" href="https://www.safedrivingforlife.info/shop/product/official-dvsa-theory-test-kit-app-app">Theory and hazard perception test app </a>
+              </li>
+            </ol>
+
+          </div>
+
+        </li>
+        <li class="app-step-nav__step js-step" id="book-and-manage-your-theory-test" >
+          <div class="app-step-nav__header js-toggle-panel" data-position="5">
+            <h3 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--number">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    <span class="app-step-nav__circle-step-label govuk-visually-hidden">Step</span> 4
+                    <span class="app-step-nav__circle-step-colon govuk-visually-hidden" aria-hidden="true">:</span>
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title">
+                Book and manage your theory test
+              </span>
+            </h3>
+          </div>
+
+          <div class="app-step-nav__panel js-panel" id="step-panel-book-and-manage-your-theory-test-5">
+            <p class="app-step-nav__paragraph">You need a provisional driving licence to book your theory test.</p>
+
+            <ol class="app-step-nav__list " data-length="5">
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="5.1" class="app-step-nav__link js-link" href="#">£23</span>
+                </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="5.2" class="app-step-nav__link js-link" href="#">What to take to your test </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="5.3" class="app-step-nav__link js-link" href="#">Change your theory test appointment </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="5.4" class="app-step-nav__link js-link" href="#">Check your theory test appointment details </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="5.5" class="app-step-nav__link js-link" href="#">Cancel your theory test </a>
+              </li>
+            </ol>
+
+          </div>
+
+        </li>
+        <li class="app-step-nav__step js-step" id="book-and-manage-your-driving-test" >
+          <div class="app-step-nav__header js-toggle-panel" data-position="6">
+            <h3 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--number">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    <span class="app-step-nav__circle-step-label govuk-visually-hidden">Step</span> 5
+                    <span class="app-step-nav__circle-step-colon govuk-visually-hidden" aria-hidden="true">:</span>
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title">
+                Book and manage your driving test
+              </span>
+            </h3>
+          </div>
+
+          <div class="app-step-nav__panel js-panel" id="step-panel-book-and-manage-your-driving-test-6">
+            <p class="app-step-nav__paragraph">You must pass your theory test before you can book your driving test.</p>
+
+            <ol class="app-step-nav__list " data-length="5">
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="6.1" class="app-step-nav__link js-link" href="#">£62 to £75</span>
+                </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="6.2" class="app-step-nav__link js-link" href="#">What to take to your test </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="6.3" class="app-step-nav__link js-link" href="#">Change your driving test appointment </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="6.4" class="app-step-nav__link js-link" href="#">Check your driving test appointment details </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="6.5" class="app-step-nav__link js-link" href="#">Cancel your driving test </a>
+              </li>
+            </ol>
+
+          </div>
+
+        </li>
+        <li class="app-step-nav__step js-step" id="when-you-pass" >
+          <div class="app-step-nav__header js-toggle-panel" data-position="7">
+            <h3 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--number">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    <span class="app-step-nav__circle-step-label govuk-visually-hidden">Step</span> 6
+                    <span class="app-step-nav__circle-step-colon govuk-visually-hidden" aria-hidden="true">:</span>
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title">
+                When you pass
+              </span>
+            </h3>
+          </div>
+
+          <div class="app-step-nav__panel js-panel" id="step-panel-when-you-pass-7">
+            <p class="app-step-nav__paragraph">You can start driving as soon as you pass your driving test.</p>
+
+            <p class="app-step-nav__paragraph">You must have an insurance policy that allows you to drive without supervision.</p>
+
+            <ol class="app-step-nav__list " data-length="1">
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="7.1" class="app-step-nav__link js-link" href="#">Find out about Pass Plus training courses </a>
+              </li>
+            </ol>
+
+          </div>
+
+        </li>
+      </ol>
+    </div>
+
+
+  </div>
+
+</div>
+
+
+</div>
+</div>
+{% endblock %}

--- a/docs/views/templates/step-by-step-navigation.html
+++ b/docs/views/templates/step-by-step-navigation.html
@@ -44,7 +44,7 @@
 
     <div id="step-by-step-navigation" class="app-step-nav app-step-nav--large app-step-nav--active" data-show-text="Show" data-hide-text="Hide" data-show-all-text="Show all" data-hide-all-text="Hide all">
       <ol class="app-step-nav__steps">
-        <li class="app-step-nav__step js-step" id="check-youre-allowed-to-drive" data-track-count="stepNavSection">
+        <li class="app-step-nav__step js-step" id="check-youre-allowed-to-drive" >
           <div class="app-step-nav__header js-toggle-panel" data-position="1">
             <h2 class="app-step-nav__title">
               <span class="app-step-nav__circle app-step-nav__circle--number">
@@ -84,7 +84,7 @@
 
         </li>
 
-        <li class="app-step-nav__step js-step" id="get-a-provisional-licence" data-track-count="stepNavSection">
+        <li class="app-step-nav__step js-step" id="get-a-provisional-licence" >
           <div class="app-step-nav__header js-toggle-panel" data-position="2">
             <h2 class="app-step-nav__title">
               <span class="app-step-nav__circle app-step-nav__circle--number">
@@ -116,7 +116,7 @@
 
         </li>
 
-        <li class="app-step-nav__step js-step" id="driving-lessons-and-practice" data-track-count="stepNavSection">
+        <li class="app-step-nav__step js-step" id="driving-lessons-and-practice" >
           <div class="app-step-nav__header js-toggle-panel" data-position="3">
             <h2 class="app-step-nav__title">
               <span class="app-step-nav__circle app-step-nav__circle--number">
@@ -159,7 +159,7 @@
 
         </li>
 
-        <li class="app-step-nav__step js-step" id="prepare-for-your-theory-test" data-track-count="stepNavSection">
+        <li class="app-step-nav__step js-step" id="prepare-for-your-theory-test" >
           <div class="app-step-nav__header js-toggle-panel" data-position="4">
             <h2 class="app-step-nav__title">
               <span class="app-step-nav__circle app-step-nav__circle--logic">
@@ -197,7 +197,7 @@
 
         </li>
 
-        <li class="app-step-nav__step js-step" id="book-and-manage-your-theory-test" data-track-count="stepNavSection">
+        <li class="app-step-nav__step js-step" id="book-and-manage-your-theory-test" >
           <div class="app-step-nav__header js-toggle-panel" data-position="5">
             <h2 class="app-step-nav__title">
               <span class="app-step-nav__circle app-step-nav__circle--number">
@@ -244,7 +244,7 @@
 
         </li>
 
-        <li class="app-step-nav__step js-step" id="book-and-manage-your-driving-test" data-track-count="stepNavSection">
+        <li class="app-step-nav__step js-step" id="book-and-manage-your-driving-test" >
           <div class="app-step-nav__header js-toggle-panel" data-position="6">
             <h2 class="app-step-nav__title">
               <span class="app-step-nav__circle app-step-nav__circle--number">
@@ -291,7 +291,7 @@
 
         </li>
 
-        <li class="app-step-nav__step js-step" id="when-you-pass" data-track-count="stepNavSection">
+        <li class="app-step-nav__step js-step" id="when-you-pass" >
           <div class="app-step-nav__header js-toggle-panel" data-position="7">
             <h2 class="app-step-nav__title">
               <span class="app-step-nav__circle app-step-nav__circle--number">

--- a/docs/views/templates/step-by-step-navigation.html
+++ b/docs/views/templates/step-by-step-navigation.html
@@ -1,0 +1,335 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Step by step navigation
+{% endblock %}
+
+{% block pageScripts %}
+  <script src="/public/javascripts/step-by-step-navigation.js"></script>
+  <script type="text/javascript">
+    var $element = $('#step-by-step-navigation')
+    var stepByStepNavigation = new GOVUK.Modules.StepByStepNavigation()
+    stepByStepNavigation.start($element)
+  </script>
+{% endblock %}
+
+{% block beforeContent %}
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="https://www.gov.uk">Home</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="#">Section</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link">Subsection</a>
+      </li>
+    </ol>
+  </div>
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">
+      Learn to drive a car: step by step
+    </h1>
+
+    <p>
+      Check what you need to do to learn to drive.
+    </p>
+
+    <div id="step-by-step-navigation" class="app-step-nav app-step-nav--large app-step-nav--active" data-show-text="Show" data-hide-text="Hide" data-show-all-text="Show all" data-hide-all-text="Hide all">
+      <ol class="app-step-nav__steps">
+        <li class="app-step-nav__step js-step" id="check-youre-allowed-to-drive" data-track-count="stepNavSection">
+          <div class="app-step-nav__header js-toggle-panel" data-position="1">
+            <h2 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--number">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    <span class="govuk-visually-hidden">Step</span> 1
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title">
+                <button class="app-step-nav__button app-step-nav__button--title js-step-title-button" aria-expanded="false" aria-controls="step-panel-check-youre-allowed-to-drive-1">
+                  <span class="js-step-title-text">
+                    Check you're allowed to drive
+                  </span>
+                  <span class="app-step-nav__toggle-link js-toggle-link" aria-hidden="true">Show</span>
+                </button>
+              </span>
+            </h2>
+          </div>
+
+          <div class="app-step-nav__panel js-panel js-hidden" id="step-panel-check-youre-allowed-to-drive-1">
+            <p class="app-step-nav__paragraph">Most people can start learning to drive when they’re 17.</p>
+
+            <ol class="app-step-nav__list " data-length="3">
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="1.1" class="app-step-nav__link js-link" href="#">Check what age you can drive </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="1.2" class="app-step-nav__link js-link" href="#">Requirements for driving legally </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="1.3" class="app-step-nav__link js-link" href="#">Driving eyesight rules </a>
+              </li>
+            </ol>
+          </div>
+
+        </li>
+
+        <li class="app-step-nav__step js-step" id="get-a-provisional-licence" data-track-count="stepNavSection">
+          <div class="app-step-nav__header js-toggle-panel" data-position="2">
+            <h2 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--number">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    <span class="govuk-visually-hidden">Step</span> 2
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title">
+                <button class="app-step-nav__button app-step-nav__button--title js-step-title-button" aria-expanded="false" aria-controls="step-panel-get-a-provisional-licence-2">
+                  <span class="js-step-title-text">
+                    Get a provisional licence
+                  </span>
+                  <span class="app-step-nav__toggle-link js-toggle-link" aria-hidden="true">Show</span>
+                </button>
+              </span>
+            </h2>
+          </div>
+
+          <div class="app-step-nav__panel js-panel js-hidden" id="step-panel-get-a-provisional-licence-2">
+            <ol class="app-step-nav__list " data-length="1">
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="2.1" class="app-step-nav__link js-link" href="#">Apply for your first provisional driving licence <span class="app-step-nav__context">£34 to £43</span></a>
+              </li>
+            </ol>
+          </div>
+
+        </li>
+
+        <li class="app-step-nav__step js-step" id="driving-lessons-and-practice" data-track-count="stepNavSection">
+          <div class="app-step-nav__header js-toggle-panel" data-position="3">
+            <h2 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--number">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    <span class="govuk-visually-hidden">Step</span> 3
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title">
+                <button class="app-step-nav__button app-step-nav__button--title js-step-title-button" aria-expanded="false" aria-controls="step-panel-driving-lessons-and-practice-3">
+                  <span class="js-step-title-text">
+                    Driving lessons and practice
+                  </span>
+                  <span class="app-step-nav__toggle-link js-toggle-link" aria-hidden="true">Show</span>
+                </button>
+              </span>
+            </h2>
+          </div>
+
+          <div class="app-step-nav__panel js-panel js-hidden" id="step-panel-driving-lessons-and-practice-3">
+            <p class="app-step-nav__paragraph">You need a provisional driving licence to take lessons or practice.</p>
+
+            <ol class="app-step-nav__list " data-length="4">
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="3.1" class="app-step-nav__link js-link" href="#">The Highway Code </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="3.2" class="app-step-nav__link js-link" href="#">Taking driving lessons </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="3.3" class="app-step-nav__link js-link" href="#">Find driving schools, lessons and instructors </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="3.4" class="app-step-nav__link js-link" href="#">Practise vehicle safety questions </a>
+              </li>
+            </ol>
+          </div>
+
+        </li>
+
+        <li class="app-step-nav__step js-step" id="prepare-for-your-theory-test" data-track-count="stepNavSection">
+          <div class="app-step-nav__header js-toggle-panel" data-position="4">
+            <h2 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--logic">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    and
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title">
+                <button class="app-step-nav__button app-step-nav__button--title js-step-title-button" aria-expanded="false" aria-controls="step-panel-prepare-for-your-theory-test-4">
+                  <span class="js-step-title-text">
+                    Prepare for your theory test
+                  </span>
+                  <span class="app-step-nav__toggle-link js-toggle-link" aria-hidden="true">Show</span>
+                </button>
+              </span>
+            </h2>
+          </div>
+
+          <div class="app-step-nav__panel js-panel js-hidden" id="step-panel-prepare-for-your-theory-test-4">
+            <ol class="app-step-nav__list " data-length="3">
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="4.1" class="app-step-nav__link js-link" href="#">Theory test revision and practice </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="4.2" class="app-step-nav__link js-link" href="#">Take a practice theory test </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a rel="external" data-position="4.3" class="app-step-nav__link js-link" href="#">Theory and hazard perception test app </a>
+              </li>
+            </ol>
+          </div>
+
+        </li>
+
+        <li class="app-step-nav__step js-step" id="book-and-manage-your-theory-test" data-track-count="stepNavSection">
+          <div class="app-step-nav__header js-toggle-panel" data-position="5">
+            <h2 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--number">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    <span class="govuk-visually-hidden">Step</span> 4
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title">
+                <button class="app-step-nav__button app-step-nav__button--title js-step-title-button" aria-expanded="false" aria-controls="step-panel-book-and-manage-your-theory-test-5">
+                  <span class="js-step-title-text">
+                    Book and manage your theory test
+                  </span>
+                  <span class="app-step-nav__toggle-link js-toggle-link" aria-hidden="true">Show</span>
+                </button>
+              </span>
+            </h2>
+          </div>
+
+          <div class="app-step-nav__panel js-panel js-hidden" id="step-panel-book-and-manage-your-theory-test-5">
+            <p class="app-step-nav__paragraph">You need a provisional driving licence to book your theory test.</p>
+
+            <ol class="app-step-nav__list " data-length="5">
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="5.1" class="app-step-nav__link js-link" href="#">£23</span>
+                </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="5.2" class="app-step-nav__link js-link" href="#">What to take to your test </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="5.3" class="app-step-nav__link js-link" href="#">Change your theory test appointment </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="5.4" class="app-step-nav__link js-link" href="#">Check your theory test appointment details </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="5.5" class="app-step-nav__link js-link" href="#">Cancel your theory test </a>
+              </li>
+            </ol>
+          </div>
+
+        </li>
+
+        <li class="app-step-nav__step js-step" id="book-and-manage-your-driving-test" data-track-count="stepNavSection">
+          <div class="app-step-nav__header js-toggle-panel" data-position="6">
+            <h2 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--number">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    <span class="govuk-visually-hidden">Step</span> 5
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title">
+                <button class="app-step-nav__button app-step-nav__button--title js-step-title-button" aria-expanded="false" aria-controls="step-panel-book-and-manage-your-driving-test-6">
+                  <span class="js-step-title-text">
+                    Book and manage your driving test
+                  </span>
+                  <span class="app-step-nav__toggle-link js-toggle-link" aria-hidden="true">Show</span>
+                </button>
+              </span>
+            </h2>
+          </div>
+
+          <div class="app-step-nav__panel js-panel js-hidden" id="step-panel-book-and-manage-your-driving-test-6">
+            <p class="app-step-nav__paragraph">You must pass your theory test before you can book your driving test.</p>
+
+            <ol class="app-step-nav__list " data-length="5">
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="6.1" class="app-step-nav__link js-link" href="#">£62 to £75</span>
+                </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="6.2" class="app-step-nav__link js-link" href="#">What to take to your test </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="6.3" class="app-step-nav__link js-link" href="#">Change your driving test appointment </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="6.4" class="app-step-nav__link js-link" href="#">Check your driving test appointment details </a>
+              </li>
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="6.5" class="app-step-nav__link js-link" href="#">Cancel your driving test </a>
+              </li>
+            </ol>
+          </div>
+
+        </li>
+
+        <li class="app-step-nav__step js-step" id="when-you-pass" data-track-count="stepNavSection">
+          <div class="app-step-nav__header js-toggle-panel" data-position="7">
+            <h2 class="app-step-nav__title">
+              <span class="app-step-nav__circle app-step-nav__circle--number">
+                <span class="app-step-nav__circle-inner">
+                  <span class="app-step-nav__circle-background">
+                    <span class="govuk-visually-hidden">Step</span> 6
+                  </span>
+                </span>
+              </span>
+
+              <span class="js-step-title">
+                <button class="app-step-nav__button app-step-nav__button--title js-step-title-button" aria-expanded="false" aria-controls="step-panel-when-you-pass-7">
+                  <span class="js-step-title-text">
+                    When you pass
+                  </span>
+                  <span class="app-step-nav__toggle-link js-toggle-link" aria-hidden="true">Show</span>
+                </button>
+              </span>
+            </h2>
+          </div>
+
+          <div class="app-step-nav__panel js-panel js-hidden" id="step-panel-when-you-pass-7">
+            <p class="app-step-nav__paragraph">You can start driving as soon as you pass your driving test.</p>
+
+            <p class="app-step-nav__paragraph">You must have an insurance policy that allows you to drive without supervision.</p>
+
+            <ol class="app-step-nav__list " data-length="1">
+              <li class="app-step-nav__list-item js-list-item ">
+                <a data-position="7.1" class="app-step-nav__link js-link" href="#">Find out about Pass Plus training courses </a>
+              </li>
+            </ol>
+          </div>
+
+        </li>
+      </ol>
+    </div>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/docs/views/tutorials-and-examples.html
+++ b/docs/views/tutorials-and-examples.html
@@ -122,10 +122,10 @@
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">Page templates</h2>
       <p>
-        Use these as the basis for your prototypes. We recommend making copies of the files rather than directly editing them.
+        You can find them in your prototype folder, in /docs/views/templates
       </p>
       <p>
-        You can find them in your prototype folder, in /docs/views/templates
+        Copy and paste the pages you need to your /app/views folder to make your prototypes.
       </p>
 
       <ul class="govuk-list govuk-list--bullet">
@@ -135,11 +135,6 @@
           </a> /
           <a href="/docs/templates/blank-unbranded">
             Blank (non-GOV.UK)
-          </a>
-        </li>
-        <li>
-          <a href="/docs/templates/start">
-            Start page
           </a>
         </li>
         <li>
@@ -169,6 +164,42 @@
         </li>
       </ul>
 
+      <p>
+        Your prototype folder also contains the following page templates.
+      </p>
+      <p>
+        You cannot adjust the design of these pages, but you can use them to help
+        you prototype realistic journeys connecting your service with GOV.UK content.
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          <a href="/docs/templates/start">
+            Start page
+          </a>
+        </li>
+        <li>
+          <a href="/docs/templates/step-by-step-navigation">
+            Step by step navigation
+          </a>
+        </li>
+        <li>
+          <a href="/docs/templates/start-with-step-by-step">
+            Start page with Step by step navigation
+          </a>
+        </li>
+      </ul>
+
+      <p>
+        Read more about how to get a <a href="https://design-system.service.gov.uk/patterns/start-pages/">
+        Start page</a> or <a href="https://design-system.service.gov.uk/patterns/step-by-step-navigation/">
+        Step by step navigation</a> for your service in the GOV.UK Design System.
+      </p>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">GOV.UK Design System</h2>
 
       <p>


### PR DESCRIPTION
This work adds a Step by step navigation page to the template pages in the Prototype Kit.

This means that a service can consider and prototype Step by step navigation as part of their service. It's a pattern we've found to be very successful and we'd like more teams to try it.

This is not an in-service pattern. Similar to Start pages, it would live on gov.uk publishing platform. If teams found a user need for it, they would need to work with the GOV.UK publishing team to get a page built or changed.

Since services should not be implementing this pattern themselves, this code is for prototyping, not production.

This is based on GOV.UK Publishing Components code, re-written for Nunjucks and GOV.UK Frontend

Original files:
- [JavaScript](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/javascripts/govuk_publishing_components/components/step-by-step-nav.js)
- [Sass](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/stylesheets/govuk_publishing_components/components/_step-by-step-nav.scss)
- [HTML based on Learn to drive a car](https://www.gov.uk/learn-to-drive-a-car)

**Preview with the 'active deployment' link further down**