### PR TITLE
Run Travis tests in 6.x/8.x and latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-- "lts/*"
+- "lts/boron"
+- "lts/carbon"
+- "stable"
 before_deploy:
 - test $TRAVIS_TEST_RESULT = 0
 before_install:


### PR DESCRIPTION
By running older and newer versions of Node.js we can be more confident that the Kit will work for more users.

We know lots of Kit users download the latest stable build, while we develop on 8.x currently.

This may slow builds down since it needs to run many more tests, but they should be in parallel, so long as there isn't congestion it shouldn't be too slow.

See https://github.com/nodejs/Release for release information

Closes https://github.com/alphagov/govuk-prototype-kit/issues/542