### PR TITLE
Update examples

### DIFF
--- a/app/assets/sass/patterns/_check-your-answers.scss
+++ b/app/assets/sass/patterns/_check-your-answers.scss
@@ -1,8 +1,8 @@
 // Recommended - Use these styles for the check your answers pattern
 .app-check-your-answers {
-
   @include govuk-font(19);
-
+  margin-top: 0;
+  @include govuk-responsive-margin(9, "bottom");
   @include govuk-media-query($from: desktop) {
     display: table;
   }

--- a/app/assets/sass/patterns/_task-list.scss
+++ b/app/assets/sass/patterns/_task-list.scss
@@ -1,61 +1,45 @@
 // Task list pattern
 
-// Override column width for tablet and up
-.app-column-minimum {
-  @include govuk-media-query($from: tablet) {
-    min-width: 600px;
-  }
-}
-
-// Spacing to the left of the task list
-$task-list-indent: 35px;
-
 .app-task-list {
-  list-style: none;
-  padding: 0;
-  margin-top: $govuk-gutter;
+  list-style-type: none;
+  padding-left: 0;
+  margin-top: 0;
+  margin-bottom: 0;
   @include govuk-media-query($from: tablet) {
-    margin-top: ($govuk-gutter * 2);
+    min-width: 550px;
   }
 }
 
 .app-task-list__section {
   display: table;
-
-  @include govuk-font(24, $weight: bold);
-  margin: 0;
-  padding-bottom: ($govuk-gutter / 6);
+  @include govuk-font($size:24, $weight: bold);
 }
 
 .app-task-list__section-number {
   display: table-cell;
-  padding-right: ($govuk-gutter / 6);
 
   @include govuk-media-query($from: tablet) {
-    min-width: $task-list-indent;
+    min-width: govuk-spacing(6);
     padding-right: 0;
   }
 }
 
-
 .app-task-list__items {
+  @include govuk-font($size: 19);
+  @include govuk-responsive-margin(9, "bottom");
   list-style: none;
-  padding: 0;
-  margin-bottom: $govuk-gutter;
+  padding-left: 0;
   @include govuk-media-query($from: tablet) {
-    margin-bottom: ($govuk-gutter * 2);
-  }
-
-  @include govuk-media-query($from: tablet) {
-    padding-left: $task-list-indent;
+    padding-left: govuk-spacing(6);
   }
 }
 
 .app-task-list__item {
   border-bottom: 1px solid $govuk-border-colour;
+  margin-bottom: 0 !important;
   padding-top: govuk-spacing(2);
   padding-bottom: govuk-spacing(2);
-  @include govuk-clearfix
+  @include govuk-clearfix;
 }
 
 .app-task-list__item:first-child {
@@ -63,10 +47,20 @@ $task-list-indent: 35px;
 }
 
 .app-task-list__task-name {
-  width: 33.3%;
-  float: left;
+  display: block;
+  @include govuk-media-query($from: 450px) {
+    float: left;
+    width: 75%;
+  }
 }
 
 .app-task-list__task-completed {
-  float: right;
+  margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(1);
+
+  @include govuk-media-query($from: 450px) {
+    float: right;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
 }

--- a/docs/views/examples/check-your-answers-page.html
+++ b/docs/views/examples/check-your-answers-page.html
@@ -12,7 +12,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-l">
+      <h1 class="govuk-heading-xl">
         Check your answers before sending your application
       </h1>
 

--- a/docs/views/examples/confirmation-page.html
+++ b/docs/views/examples/confirmation-page.html
@@ -1,5 +1,8 @@
 {% extends "layout.html" %}
 
+<!-- Adds a class to increase vertical spacing for pages without a back button -->
+{% set mainClasses = "govuk-main-wrapper--l" %}
+
 {% block pageTitle %}
   Confirmation page example
 {% endblock %}
@@ -10,7 +13,7 @@
     <div class="govuk-grid-column-two-thirds">
 
       <div class="govuk-panel govuk-panel--confirmation">
-        <h2 class="govuk-panel__title">Application complete</h2>
+        <h1 class="govuk-panel__title">Application complete</h1>
         <div class="govuk-panel__body">
           Your reference number<br><strong>HDJ2123F</strong>
         </div>

--- a/docs/views/examples/start-page.html
+++ b/docs/views/examples/start-page.html
@@ -28,7 +28,6 @@
 {% endblock %}
 
 {% block content %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
@@ -41,32 +40,41 @@
       <ul class="govuk-list govuk-list--bullet">
         <li>do something</li>
         <li>update your name, address or other details</li>
-        <li>you need to do this in order to do something else</li>
+        <li>do something else</li>
       </ul>
 
       <p>Registering takes around 5 minutes.</p>
 
-      <p>
-        <a href="#" class="govuk-button govuk-button--start" role="button">Start now</a>
-      </p>
+      <a href="#" role="button" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8">Start now</a>
 
       <h2 class="govuk-heading-m">Before you start</h2>
 
-      <p>You can also <a href="#">register by post.</a></p>
+      <p>You can also <a href="#">register by post</a>.</p>
 
-      <p>The online service is also available in <a href="#">Welsh (Cymraeg).</a></p>
+      <p>The online service is also available in <a href="#">Welsh (Cymraeg)</a>.</p>
 
       <p>You can’t register for this service if you’re in the UK illegally.</p>
 
     </div>
+
     <div class="govuk-grid-column-one-third">
 
       <aside class="app-related-items" role="complementary">
-        <h2 class="govuk-heading-m" id="subsection-title">Subsection</h2>
+        <h2 class="govuk-heading-m" id="subsection-title">
+          Subsection
+        </h2>
         <nav role="navigation" aria-labelledby="subsection-title">
-          <ul class="govuk-list govuk-body-s">
-            <li><a href="#">Related link</a></li>
-            <li><a href="#">Related link</a></li>
+          <ul class="govuk-list govuk-!-font-size-16">
+            <li>
+              <a href="#">
+                Related link
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                Related link
+              </a>
+            </li>
             <li>
               <a href="#" class="govuk-!-font-weight-bold">
                 More <span class="govuk-visually-hidden">in Subsection</span>
@@ -78,5 +86,4 @@
 
     </div>
   </div>
-
 {% endblock %}

--- a/docs/views/examples/task-list-page.html
+++ b/docs/views/examples/task-list-page.html
@@ -1,5 +1,7 @@
 {% extends "layout.html" %}
 
+{% set mainClasses = "govuk-main-wrapper--l" %}
+
 {% block pageTitle %}
   Task list
 {% endblock %}
@@ -7,9 +9,8 @@
 {% block content %}
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds app-column-minimum">
-
-      <h1 class="govuk-heading-l">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">
         Service name goes here
       </h1>
 
@@ -23,17 +24,13 @@
               <a class="app-task-list__task-name" href="#" aria-describedby="eligibility-completed">
                 Check eligibility
               </a>
-              <strong class="govuk-tag app-task-list__task-completed" id="eligibility-completed">
-                Completed
-              </strong>
+              <strong class="govuk-tag app-task-list__task-completed" id="eligibility-completed">Completed</strong>
             </li>
             <li class="app-task-list__item">
               <a class="app-task-list__task-name" href="#" aria-describedby="read-declaration-completed">
                 Read declaration
               </a>
-              <strong class="govuk-tag app-task-list__task-completed" id="read-declaration-completed">
-                Completed
-              </strong>
+              <strong class="govuk-tag app-task-list__task-completed" id="read-declaration-completed">Completed</strong>
             </li>
           </ul>
         </li>
@@ -46,17 +43,13 @@
               <a class="app-task-list__task-name" href="#" aria-describedby="company-information-completed">
                 Company information
               </a>
-              <strong class="govuk-tag app-task-list__task-completed" id="company-information-completed">
-                Completed
-              </strong>
+              <strong class="govuk-tag app-task-list__task-completed" id="company-information-completed">Completed</strong>
             </li>
             <li class="app-task-list__item">
               <a class="app-task-list__task-name" href="#" aria-describedby="contact-details-completed">
                 Your contact details
               </a>
-              <strong class="govuk-tag app-task-list__task-completed" id="contact-details-completed">
-                Completed
-              </strong>
+              <strong class="govuk-tag app-task-list__task-completed" id="contact-details-completed">Completed</strong>
             </li>
             <li class="app-task-list__item">
               <a class="app-task-list__task-name" href="#">
@@ -72,9 +65,7 @@
               <a class="app-task-list__task-name" href="#" aria-describedby="medical-information-completed">
                 Give medical information
               </a>
-              <strong class="govuk-tag app-task-list__task-completed" id="medical-information-completed">
-                Completed
-              </strong>
+              <strong class="govuk-tag app-task-list__task-completed" id="medical-information-completed">Completed</strong>
             </li>
           </ul>
         </li>

--- a/docs/views/examples/task-list-page.html
+++ b/docs/views/examples/task-list-page.html
@@ -1,5 +1,6 @@
 {% extends "layout.html" %}
 
+<!-- Adds a class to increase vertical spacing for pages without a back button -->
 {% set mainClasses = "govuk-main-wrapper--l" %}
 
 {% block pageTitle %}

--- a/docs/views/examples/template-content-page.html
+++ b/docs/views/examples/template-content-page.html
@@ -13,7 +13,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-l">
+      <h1 class="govuk-heading-xl">
         Heading goes here
       </h1>
 

--- a/docs/views/examples/template-question-page-blank.html
+++ b/docs/views/examples/template-question-page-blank.html
@@ -13,7 +13,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-l">Heading or question goes here
+      <h1 class="govuk-heading-xl">Heading or question goes here
       </h1>
 
       <form class="form" action="/url/of/next/page" method="post">


### PR DESCRIPTION
This PR updates example pages in the kit to use GOV.UK Frontend spacing etc

## Start Page

- Updates the Start page to use the same code as the Design System (apart from `<p>` and `<a>` tags which remain without classes)
- ~On top of that (separate commit) it then styles the Start page to be updated to the current GOV.UK start page (I'll be doing a PR for this on the Design System too)~ Not updating as related links design on GOV.UK isn't locked down.

## Task list 

- Updates code to use spacing from GOV.UK Frontend and adds extra behaviour for mid and mobile breakpoints
- Updates page layout to add class to main 

<img width="1065" alt="screen shot 2018-07-11 at 11 06 00" src="https://user-images.githubusercontent.com/23356842/42565318-027e5ede-84fb-11e8-9462-643d073aabc9.png">

## Check answers

- Updates `<h1>` to use govuk-heading-xl class
- Removes native margin on the `<dl>` and sets spacing with GOV.UK Frontend

<img width="1105" alt="screen shot 2018-07-11 at 11 06 32" src="https://user-images.githubusercontent.com/23356842/42565509-896bf92e-84fb-11e8-891e-d913466fcfca.png">

## Confirmation page

- Updates page layout to add class to main 
- Changes `<h2>` to `<h1>` in Panel (Next release GOV.UK Frontend)

<img width="1090" alt="screen shot 2018-07-11 at 11 06 42" src="https://user-images.githubusercontent.com/23356842/42565651-f636f9f0-84fb-11e8-8558-bb12795f9ea3.png">

## Question and Content pages

- Updates `<h1>` to use govuk-heading-xl class

<img width="1076" alt="screen shot 2018-07-11 at 11 05 48" src="https://user-images.githubusercontent.com/23356842/42565686-119fc8f2-84fc-11e8-9675-bf54e78907b5.png">
