### PR TITLE
Data tracking attributes to header navigation and docs homepage

### DIFF
--- a/docs/views/index.html
+++ b/docs/views/index.html
@@ -42,7 +42,7 @@ GOV.UK Prototype Kit
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third govuk-!-margin-top-6">
 
-      <h2 class="govuk-heading-m"><a href="/docs/install">Install</a></h2>
+      <h2 class="govuk-heading-m"><a href="/docs/install" data-hinstall="Install">Install</a></h2>
       <p>
         Download and installation instructions.
       </p>
@@ -50,7 +50,7 @@ GOV.UK Prototype Kit
     </div>
     <div class="govuk-grid-column-one-third govuk-!-margin-top-6">
 
-      <h2 class="govuk-heading-m"><a href="/docs/tutorials-and-examples">Tutorials and examples</a></h2>
+      <h2 class="govuk-heading-m"><a href="/docs/tutorials-and-examples" data-htutorials="Tutorials and examples">Tutorials and examples</a></h2>
       <p>
         Tutorials, examples and templates.
       </p>
@@ -58,7 +58,7 @@ GOV.UK Prototype Kit
     </div>
     <div class="govuk-grid-column-one-third govuk-!-margin-top-6">
 
-      <h2 class="govuk-heading-m"><a href="/docs/about">About</a></h2>
+      <h2 class="govuk-heading-m"><a href="/docs/about" data-habout="About">About</a></h2>
       <p>
         Get support, Prototype Kit principles, privacy.
       </p>

--- a/docs/views/layout.html
+++ b/docs/views/layout.html
@@ -40,26 +40,49 @@
 {% block header %}
   {% include "includes/cookie-banner.html" %}
   {# Set serviceName in config.js. #}
-  {{ govukHeader({
-    "homepageUrl": "/",
-    "serviceName": serviceName,
-    "serviceUrl": "/",
-    "containerClasses": "govuk-width-container",
-    "navigation": [
-      {
-        "href": "/docs/install",
-        "text": "Install"
-      },
-      {
-        "href": "/docs/tutorials-and-examples",
-        "text": "Tutorials and examples"
-      },
-      {
-        "href": "/docs/about",
-        "text": "About"
-      }
-    ]
-  }) }}
+{# TODO: Use the macro when data attributes can be passed to individual items: #}
+{# https://github.com/alphagov/govuk-frontend/issues/904 #}
+<header class="govuk-header " role="banner" data-module="header">
+  <div class="govuk-header__container govuk-width-container">
+    <div class="govuk-header__logo">
+      <a href="/" class="govuk-header__link govuk-header__link--homepage">
+        <span class="govuk-header__logotype">
+          <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="32" width="36">
+            <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+            <image src="/assets/images/govuk-logotype-crown.png" class="govuk-header__logotype-crown-fallback-image"></image>
+          </svg>
+          <span class="govuk-header__logotype-text">
+            GOV.UK
+          </span>
+        </span>
+      </a>
+    </div><div class="govuk-header__content">
+    <a href="/" class="govuk-header__link govuk-header__link--service-name">
+      {{ serviceName }}
+    </a>
+    <button role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+    <nav>
+      <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
+        <li class="govuk-header__navigation-item">
+          <a class="govuk-header__link" href="/docs/install" data-install="Install">
+            Install
+          </a>
+        </li>
+        <li class="govuk-header__navigation-item">
+          <a class="govuk-header__link" href="/docs/tutorials-and-examples" data-tutorials="Tutorials and examples">
+            Tutorials and examples
+          </a>
+        </li>
+        <li class="govuk-header__navigation-item">
+          <a class="govuk-header__link" href="/docs/about" data-about="About">
+            About
+          </a>
+        </li>
+      </ul>
+    </nav>
+    </div>
+  </div>
+</header>
 {% endblock %}
 
 {% block footer %}


### PR DESCRIPTION
- Add data- tracking attributes to docs/index page
- Add data- tracking attributes to header navigation

Unfortunately at the moment we cannot pass data attributes to items, so we have to replace the Nunjucks macro with HTML.

Trello ticket: https://trello.com/c/PmXfI1BD/1156-add-data-attributes-for-tracking-to-prototype-kit-website