### PR TITLE
Specify node dependency using caret notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Bug fixes:
 - [#536 Import missing component macros](https://github.com/alphagov/govuk_prototype_kit/pull/536)
 - [#532 Update repo links from govuk_prototype_kit to govuk-prototype-kit](https://github.com/alphagov/govuk_prototype_kit/pull/532)
 - [#540 Fix grid css classes on check-your-answers page](https://github.com/alphagov/govuk-prototype-kit/pull/540)
+- [#562 Change the syntax used to specify node engine versions to fix a bug that prevented prototypes from being deployed to a CloudFoundry instance, by ](https://github.com/alphagov/govuk-prototype-kit/pull/562)
 
 # 7.0.0-beta.10
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "7.0.0-beta.10",
   "private": true,
   "engines": {
-    "node": ">=8.9.1 <9.0"
+    "node": "^8.9.1"
   },
   "scripts": {
     "start": "node start.js",


### PR DESCRIPTION
This fixes an issue when deploying to CloudFoundry instances (such as GOV.UK PaaS) where the buildpack fails on the semver range:

```
   -----> Nodejs Buildpack version 1.6.28
   -----> Installing binaries
          engines.node (package.json): >=8.9.1 <9.0
          engines.npm (package.json): unspecified (use default)
          **WARNING** Dangerous semver range (>) in engines.node. See: http://docs.cloudfoundry.org/buildpacks/node/node-tips.html
          **ERROR** Unable to install node: improper constraint: >=8.9.1 <9.0
   Failed to compile droplet: Failed to run all supply scripts: exit status 14
```

Using `^8.9.1` instead which is semantically equivalent (any version greater than 8.9.1 but less than 9.0) allows the app to deploy successfully:

```
   -----> Nodejs Buildpack version 1.6.28
   -----> Installing binaries
          engines.node (package.json): ^8.9.1
          engines.npm (package.json): unspecified (use default)
   -----> Installing node 8.11.3
          Download [https://buildpacks.cloudfoundry.org/dependencies/node/node-8.11.3-linux-x64-34b80d71.tgz]
```

- Current semver resolution for `node >=8.9.1 <9.0`: [8.11.3](https://semver.io/node/resolve/%3E=8.9.1%20%3C9.0)
- Current semver resolution for `node ^8.9.1`: [8.11.3](https://semver.io/node/resolve/%5E8.9.1)
