### PR TITLE
Improve error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ New features:
 - [#557 Fix a broken link in an error message](https://github.com/alphagov/govuk-prototype-kit/pull/557)
 
 Bug fixes:
+- [#566 Improve error handling](https://github.com/alphagov/govuk-prototype-kit/pull/566)
 - [#556 Update branching example](https://github.com/alphagov/govuk-prototype-kit/pull/556)
 - [#536 Import missing component macros](https://github.com/alphagov/govuk_prototype_kit/pull/536)
 - [#532 Update repo links from govuk_prototype_kit to govuk-prototype-kit](https://github.com/alphagov/govuk_prototype_kit/pull/532)

--- a/app/routes.js
+++ b/app/routes.js
@@ -1,11 +1,6 @@
 const express = require('express')
 const router = express.Router()
 
-// Route index page
-router.get('/', function (req, res) {
-  res.render('index')
-})
-
 // Add your routes here - above the module.exports line
 
 module.exports = router

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -190,22 +190,44 @@ exports.getLatestRelease = function () {
 
 // Try to match a request to a template, for example a request for /test
 // would look for /app/views/test.html
-// or /app/views/text/index.html
-exports.matchRoutes = function (req, res) {
-  var path = (req.params[0])
-  res.render(path, function (err, html) {
-    if (err) {
-      res.render(path + '/index', function (err2, html) {
-        if (err2) {
-          res.status(404).send(err + '<br>' + err2)
-        } else {
-          res.end(html)
-        }
-      })
-    } else {
+// and /app/views/test/index.html
+
+function renderPath (path, res, next) {
+  // Try to render the path
+  res.render(path, function (error, html) {
+    if (!error) {
+      // Success - send the response
+      res.set({ 'Content-type': 'text/html; charset=utf-8' })
       res.end(html)
+      return
     }
+    if (!error.message.startsWith('template not found')) {
+      // We got an error other than template not found - call next with the error
+      next(error)
+      return
+    }
+    if (!path.endsWith('/index')) {
+      // Maybe it's a folder - try to render [path]/index.html
+      renderPath(path + '/index', res, next)
+      return
+    }
+    // We got template not found both times - call next to trigger the 404 page
+    next()
   })
+}
+
+exports.matchRoutes = function (req, res, next) {
+  var path = req.path
+
+  // Remove the first slash, render won't work with it
+  path = path.substr(1)
+
+  // If it's blank, render the root index
+  if (path === '') {
+    path = 'index'
+  }
+
+  renderPath(path, res, next)
 }
 
 // Try to match a request to a Markdown file and render it

--- a/server.js
+++ b/server.js
@@ -231,15 +231,15 @@ app.get(/\.html?$/i, function (req, res) {
 // Auto render any view that exists
 
 // App folder routes get priority
-app.get(/^\/([^.]+)$/, function (req, res) {
-  utils.matchRoutes(req, res)
+app.get(/^([^.]+)$/, function (req, res, next) {
+  utils.matchRoutes(req, res, next)
 })
 
 if (useDocumentation) {
   // Documentation  routes
-  documentationApp.get(/^\/([^.]+)$/, function (req, res) {
+  documentationApp.get(/^([^.]+)$/, function (req, res, next) {
     if (!utils.matchMdRoutes(req, res)) {
-      utils.matchRoutes(req, res)
+      utils.matchRoutes(req, res, next)
     }
   })
 }
@@ -247,6 +247,20 @@ if (useDocumentation) {
 // Redirect all POSTs to GETs - this allows users to use POST for autoStoreData
 app.post(/^\/([^.]+)$/, function (req, res) {
   res.redirect('/' + req.params[0])
+})
+
+// Catch 404 and forward to error handler
+app.use(function (req, res, next) {
+  var err = new Error(`Page not found: ${req.path}`)
+  err.status = 404
+  next(err)
+})
+
+// Display error
+app.use(function (err, req, res, next) {
+  console.error(err.message)
+  res.status(err.status || 500)
+  res.send(err.message)
 })
 
 console.log('\nGOV.UK Prototype Kit v' + releaseVersion)


### PR DESCRIPTION
This work has been pulled out of #553 as useful in its own right, and helps to prepare for that

- Use 'next' and middleware to handle errors, this is the [documented way to handle errors in Express](https://expressjs.com/en/guide/error-handling.html)
- Use console.error to output errors when rendering templates - these were previously hidden
- Serve the root index view with matchRoutes to be more consistent, no longer needs its own route
- Add missing content-type header to matchRoutes