### PR TITLE
Update install-the-kit.md

### DIFF
--- a/docs/documentation/install/install-the-kit.md
+++ b/docs/documentation/install/install-the-kit.md
@@ -16,23 +16,19 @@ Create a folder called `projects` in your home folder. You can open your home fo
 
 #### Windows users
 
-Create a folder called `projects` in your `Documents` or `My Documents` folder.
+Create a folder called `projects` in your `Documents` folder.
 
-### Unzip the kit
+### Unzip the kit and move it
 
-Unzip the kit you downloaded - you should end up with a folder called `govuk-prototype-kit-3.0.0`
-
-### Rename the kit
+Unzip the kit you downloaded - you should end up with a folder called `govuk-prototype-kit` followed by the version number.
 
 Rename the folder to something descriptive for your prototype. For this guide, we’ll use `juggling-licence-prototype`.
 
-### Move the kit in to projects folder
-
-Move the kit in to your newly created `projects` folder.
+Move the folder into your `projects` folder.
 
 ## Terminal basics
 
-The terminal (terminal on mac and linux, git bash on windows) lets you type in commands and run programs on your computer. You can also use it to browse your file system - to open folders, etc.
+The terminal (on mac and linux, git bash on windows) lets you type in commands and run programs on your computer. You can also use it to browse your file system - to open folders, etc.
 
 Learning a few basic terminal commands can make using the kit much easier.
 
@@ -41,7 +37,7 @@ Learning a few basic terminal commands can make using the kit much easier.
 
 ### Navigating to your prototype
 
-You need to be able to navigate to your prototype from the terminal. Most commands for the kit need to be run from the prototype folder.
+You need to navigate to your prototype in the terminal. Most commands for the kit need to be run in the prototype folder.
 
 #### Mac users:
 ```
@@ -49,35 +45,11 @@ cd ~/projects/juggling-licence-prototype
 ```
 
 #### Windows users:
-
-Navigating will depend on whether you have a `Documents` or a `My Documents` folder.
-
-Documents:
 ```
 cd ~/Documents/projects/juggling-licence-prototype
 ```
-My Documents:
-```
-cd ~/My\ Documents/projects/juggling-licence-prototype
-```
-
-#### Returning to this folder
-
-It’s important that you be able to navigate to your prototype in the terminal - most commands will need to be run from the prototype folder.
-
-To check you’re in the right folder, you can run `ls` (list items):
-```
-ls
-```
-You should see a list of files inside the prototype, starting with `CHANGELOG.md, CONTRIBUTING.md, gulpfile.js etc`
-
-> If you don’t see these files, check that you installed the kit into the right location and named it correctly.
 
 ## Install the kit
-
-### Open a terminal window
-
-If you don’t already have one open, open a terminal window and navigate to your prototype folder.
 
 ### Install modules
 


### PR DESCRIPTION
- correct reference to '3.0.0' folder
- simplify instructions for just installation, not returning
- drop instructions for 'My Documents' - this was for Windows older than Vista apparently