### PR TITLE
Load environment variables before requiring routes

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,6 +11,9 @@ const nunjucks = require('nunjucks')
 const session = require('express-session')
 const cookieParser = require('cookie-parser')
 
+// Environment variables
+dotenv.config()
+
 // Local dependencies
 const config = require('./app/config.js')
 const documentationRoutes = require('./docs/documentation_routes.js')
@@ -38,8 +41,6 @@ if (useV6) {
   console.log('/app/v6/routes.js detected - using v6 compatibility mode')
   v6App = express()
 }
-
-dotenv.config()
 
 // Set cookies for use in cookie banner.
 app.use(cookieParser())


### PR DESCRIPTION
Code in `route.js` may be looking for environment variables. If the environment variables aren’t loaded beforehand this will cause an exception.

I suspect this worked fine before https://github.com/alphagov/govuk-prototype-kit/commit/bbe15e8fa6d7ba75a7c09c0c5c2c0db7a2e55047#diff-78c12f5adc1848d13b1c6f07055d996e, which reordered the first lines in `server.js`.

This commit moves the loading of environment variables to before the requiring of any `routes.js` files.