### PR TITLE
Update link from question page template to design system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+Bug fixes:
+
+- [Update link from question page template to design system](https://github.com/alphagov/govuk-prototype-kit/pull/575)
+
 # 7.0.0
 
 This release adds backwards compatibility, so you can use old prototypes

--- a/docs/views/examples/template-question-page-blank.html
+++ b/docs/views/examples/template-question-page-blank.html
@@ -20,7 +20,7 @@
 
         <p>[Insert question content here]</p>
 
-        <p>[See <a href="https://design-system.service.gov.uk/patterns/question-pages/">the GOV.UK Design System</a> for examples]</p>
+        <p>[See <a href="https://design-system.service.gov.uk">the GOV.UK Design System</a> for examples]</p>
 
         <button class="govuk-button">Continue</button>
 


### PR DESCRIPTION
Link to the home page instead of the Question page pattern - people could need any of the components or patterns, not necessarily guidance on the Question page itself