### PR TITLE
Update GOV.UK Frontend to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 New Features:
 
+- [Update GOV.UK Frontend to v1.3.0](https://github.com/alphagov/govuk-prototype-kit/pull/581)
 - [Rename and reorganise template pages to be easier to use](https://github.com/alphagov/govuk-prototype-kit/pull/578)
 - [Add kit version and link to footer](https://github.com/alphagov/govuk-prototype-kit/pull/476)
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^1.2.0",
+    "govuk-frontend": "^1.3.0",
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "gulp": "^3.9.1",


### PR DESCRIPTION
[GOV.UK Frontend v1.3.0 release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v1.3.0)