### PR TITLE
Add config to allow permanent session in cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 New features:
 
+- [Add config to allow permanent session in cookie](https://github.com/alphagov/govuk-prototype-kit/pull/593)
 - [Allow nested field values in session](https://github.com/alphagov/govuk-prototype-kit/pull/573)
 - [Restart the app if environment variables change](https://github.com/alphagov/govuk-prototype-kit/pull/389)
 - [Make it more difficult to accidentally clear the session data](https://github.com/alphagov/govuk-prototype-kit/pull/588)

--- a/app/config.js
+++ b/app/config.js
@@ -15,6 +15,10 @@ module.exports = {
   // Automatically stores form data, and send to all views
   useAutoStoreData: 'true',
 
+  // Enable cookie-based session store (persists on restart)
+  // Please note 4KB cookie limit per domain, cookies too large will silently be ignored
+  useCookieSessionStore: 'false',
+
   // Enable or disable built-in docs and examples.
   useDocumentation: 'true',
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -159,6 +159,9 @@ exports.forceHttps = function (req, res, next) {
     // 302 temporary - this is a feature that can be disabled
     return res.redirect(302, 'https://' + req.get('Host') + req.url)
   }
+
+  // Mark proxy as secure (allows secure cookies)
+  req.connection.proxySecure = true
   next()
 }
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "basic-auth-connect": "^1.0.0",
     "body-parser": "^1.14.1",
     "browser-sync": "^2.11.1",
+    "client-sessions": "^0.8.0",
     "cookie-parser": "^1.4.3",
     "cross-spawn": "^6.0.5",
     "dotenv": "^6.0.0",

--- a/server.js
+++ b/server.js
@@ -214,7 +214,7 @@ if (useAutoStoreData === 'true') {
 
 // Clear all data in session if you open /prototype-admin/clear-data
 app.get('/prototype-admin/clear-data', function (req, res) {
-  req.session.destroy()
+  req.session.data = {}
   res.render('prototype-admin/clear-data')
 })
 

--- a/server.js
+++ b/server.js
@@ -1,5 +1,4 @@
 // Core dependencies
-const crypto = require('crypto')
 const path = require('path')
 
 // NPM dependencies
@@ -8,7 +7,8 @@ const browserSync = require('browser-sync')
 const dotenv = require('dotenv')
 const express = require('express')
 const nunjucks = require('nunjucks')
-const session = require('express-session')
+const sessionInCookie = require('client-sessions')
+const sessionInMemory = require('express-session')
 const cookieParser = require('cookie-parser')
 
 // Run before other code to make sure variables from .env are available
@@ -56,6 +56,7 @@ var password = process.env.PASSWORD
 var env = process.env.NODE_ENV || 'development'
 var useAuth = process.env.USE_AUTH || config.useAuth
 var useAutoStoreData = process.env.USE_AUTO_STORE_DATA || config.useAutoStoreData
+var useCookieSessionStore = process.env.USE_COOKIE_SESSION_STORE || config.useCookieSessionStore
 var useHttps = process.env.USE_HTTPS || config.useHttps
 var useBrowserSync = config.useBrowserSync
 var gtmId = process.env.GOOGLE_TAG_MANAGER_TRACKING_ID
@@ -182,23 +183,36 @@ app.use(function (req, res, next) {
 app.locals.gtmId = gtmId
 app.locals.asset_path = '/public/'
 app.locals.useAutoStoreData = (useAutoStoreData === 'true')
+app.locals.useCookieSessionStore = (useCookieSessionStore === 'true')
 app.locals.cookieText = config.cookieText
 app.locals.promoMode = promoMode
 app.locals.releaseVersion = 'v' + releaseVersion
 app.locals.serviceName = config.serviceName
 
-// Support session data
-app.use(session({
+// Session uses service name to avoid clashes with other prototypes
+const sessionName = 'govuk-prototype-kit-' + (Buffer.from(config.serviceName, 'utf8')).toString('hex')
+let sessionOptions = {
+  secret: sessionName,
   cookie: {
     maxAge: 1000 * 60 * 60 * 4, // 4 hours
     secure: isSecure
-  },
-  // use random name to avoid clashes with other prototypes
-  name: 'govuk-prototype-kit-' + crypto.randomBytes(64).toString('hex'),
-  resave: false,
-  saveUninitialized: false,
-  secret: crypto.randomBytes(64).toString('hex')
-}))
+  }
+}
+
+// Support session data in cookie or memory
+if (useCookieSessionStore === 'true') {
+  app.use(sessionInCookie(Object.assign(sessionOptions, {
+    cookieName: sessionName,
+    proxy: true,
+    requestKey: 'session'
+  })))
+} else {
+  app.use(sessionInMemory(Object.assign(sessionOptions, {
+    name: sessionName,
+    resave: false,
+    saveUninitialized: false
+  })))
+}
 
 // Automatically store all data users enter
 if (useAutoStoreData === 'true') {


### PR DESCRIPTION
I'm currently working across two teams with long form journeys.

### A quick prototyping scenario

1. Enter lots and lots of form data
1. Reach the _Nth_ page in a journey
1. Edit a view or route

### What happens?

1. The prototype is restarted by nodemon
1. All typed in session data is now lost 😭 

### What's in this pull request

I've added the following config:

```js
{
  // Enable cookie-based session store (4KB limit, persists on restart)
  useCookieSessionStore: 'false'
}
```

When set to `true` it swaps _express-session_ with  Mozilla _[client-sessions](https://www.npmjs.com/package/client-sessions)_ so retains compatibility with `req.session` and persists all session data in a cookie.