### PR TITLE
Update GOV.UK Frontend to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+Breaking changes:
+
+- [#595 Update GOV.UK Frontend to v2.0.0](https://github.com/alphagov/govuk-prototype-kit/pull/595)
+
 New features:
 
 - [Add config to allow permanent session in cookie](https://github.com/alphagov/govuk-prototype-kit/pull/593)

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^1.3.0",
+    "govuk-frontend": "^2.0.0",
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "gulp": "^3.9.1",


### PR DESCRIPTION
Update GOV.UK Frontend dependency to the latest released version.

GOV.UK Frontend 2.0.0 is a breaking release. See [release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v2.0.0)