### PR TITLE
Update wording on when Protoype Kit started using GOV.UK Frontend  instead of GOV.UK Elements

### DIFF
--- a/docs/views/index.html
+++ b/docs/views/index.html
@@ -27,7 +27,7 @@ GOV.UK Prototype Kit
 
       <h2 class="govuk-heading-m">What’s new</h2>
       <p>
-        Version 7 of the GOV.UK Prototype Kit uses the new GOV.UK Design System which replaces GOV.UK Elements.
+        From version 7 the GOV.UK Prototype Kit uses the new GOV.UK Design System which replaces GOV.UK Elements.
       </p>
 
       <p>


### PR DESCRIPTION
Needs updating now that we have release version 8.