### PR TITLE
Add npm install reminder on crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Unreleased
 
+New features: 
+
 - [#574 Add Notify integration guidance](https://github.com/alphagov/govuk-prototype-kit/pull/574)
+
+- [Add npm install reminder when prototype crashes](https://github.com/alphagov/govuk-prototype-kit/pull/598)
 
 # 8.2.0
 

--- a/gulp/nodemon.js
+++ b/gulp/nodemon.js
@@ -8,23 +8,35 @@ const fs = require('fs')
 const path = require('path')
 
 const gulp = require('gulp')
+const gutil = require('gulp-util')
 const nodemon = require('gulp-nodemon')
 
 const config = require('./config.json')
+
+// Warn about npm install on crash
+const onCrash = () => {
+  gutil.log(gutil.colors.cyan('[nodemon] For missing modules try running `npm install`'))
+}
+
+// Remove .port.tmp if it exists
+const onQuit = () => {
+  try {
+    fs.unlinkSync(path.join(__dirname, '/../.port.tmp'))
+  } catch (e) {}
+
+  process.exit(0)
+}
 
 gulp.task('server', function () {
   nodemon({
     watch: ['.env', '**/*.js', '**/*.json'],
     script: 'server.js',
-    ignore: [config.paths.public + '*',
+    ignore: [
+      config.paths.public + '*',
       config.paths.assets + '*',
-      config.paths.nodeModules + '*']
-  }).on('quit', function () {
-    // remove .port.tmp if it exists
-    try {
-      fs.unlinkSync(path.join(__dirname, '/../.port.tmp'))
-    } catch (e) {}
-
-    process.exit(0)
+      config.paths.nodeModules + '*'
+    ]
   })
+    .on('crash', onCrash)
+    .on('quit', onQuit)
 })


### PR DESCRIPTION
Not everyone remembers (or knows about) the `npm install` guidance when updating here:
https://govuk-prototype-kit.herokuapp.com/docs/updating-the-kit

I've added a `crash` listener to Nodemon to output a little reminder:

![crash-warning](https://user-images.githubusercontent.com/415517/45304546-3817fb00-b510-11e8-96b8-c8a2235f507b.png)

Thought it might help 🙂 