### PR TITLE
Set stylesheet media to "all" to allow print styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+Bug fixes:
+
+- [#605 Set stylesheet media to "all" to allow print styles](https://github.com/alphagov/govuk-prototype-kit/pull/605)
+
 # 8.1.0
 
 New features:

--- a/app/views/includes/head.html
+++ b/app/views/includes/head.html
@@ -1,2 +1,2 @@
 <!--[if lte IE 8]><link href="/public/stylesheets/application-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
-<!--[if gt IE 8]><!--><link href="/public/stylesheets/application.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
+<!--[if gt IE 8]><!--><link href="/public/stylesheets/application.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->

--- a/docs/views/includes/head.html
+++ b/docs/views/includes/head.html
@@ -1,6 +1,6 @@
 <meta name="description" content="Use the GOV.UK Prototype Kit to quickly make realistic HTML prototypes of GOV.UK services.">
 
 <!--[if lte IE 8]><link href="/public/stylesheets/application-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
-<!--[if gt IE 8]><!--><link href="/public/stylesheets/application.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
+<!--[if gt IE 8]><!--><link href="/public/stylesheets/application.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
 <!--[if lte IE 8]><link href="/public/stylesheets/docs-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
-<!--[if gt IE 8]><!--><link href="/public/stylesheets/docs.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
+<!--[if gt IE 8]><!--><link href="/public/stylesheets/docs.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->

--- a/docs/views/layout_unbranded.html
+++ b/docs/views/layout_unbranded.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block head %}
-  <link href="/public/stylesheets/unbranded.css" media="screen" rel="stylesheet" type="text/css">
+  <link href="/public/stylesheets/unbranded.css" media="all" rel="stylesheet" type="text/css">
 {% endblock %}
 
 {% block header %}{% endblock %}


### PR DESCRIPTION
In GOV.UK Frontend components no longer have separate print stylesheet;
print styles are built into the component partials.

By setting media to all we allow those styles to apply in print situations.

Fixes: #604

Before: 
[before.pdf](https://github.com/alphagov/govuk-prototype-kit/files/2437168/before.pdf)

After: 
[after.pdf](https://github.com/alphagov/govuk-prototype-kit/files/2437170/after.pdf)

