### PR TITLE
Exit on sass compilation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+New features:
+
+- [#606 Exit on sass compilation error](https://github.com/alphagov/govuk-prototype-kit/pull/606)
+
 Bug fixes:
 
 - [#605 Set stylesheet media to "all" to allow print styles](https://github.com/alphagov/govuk-prototype-kit/pull/605)

--- a/gulp/sass.js
+++ b/gulp/sass.js
@@ -8,11 +8,21 @@
 const gulp = require('gulp')
 const sass = require('gulp-sass')
 const sourcemaps = require('gulp-sourcemaps')
+const plumber = require('gulp-plumber')
 
 const config = require('./config.json')
+const errorHandler = function (error) {
+  // Log the error to the console
+  console.error(error.message)
+
+  // Ensure the task we're running exits with an error code
+  this.once('finish', () => process.exit(1))
+  this.emit('end')
+}
 
 gulp.task('sass', function () {
   return gulp.src(config.paths.assets + '/sass/*.scss')
+    .pipe(plumber(errorHandler))
     .pipe(sourcemaps.init())
     .pipe(sass({outputStyle: 'expanded'}).on('error', sass.logError))
     .pipe(sourcemaps.write())
@@ -21,6 +31,7 @@ gulp.task('sass', function () {
 
 gulp.task('sass-documentation', function () {
   return gulp.src(config.paths.docsAssets + '/sass/*.scss')
+    .pipe(plumber(errorHandler))
     .pipe(sourcemaps.init())
     .pipe(sass({outputStyle: 'expanded'}).on('error', sass.logError))
     .pipe(sourcemaps.write())
@@ -31,6 +42,7 @@ gulp.task('sass-documentation', function () {
 
 gulp.task('sass-v6', function () {
   return gulp.src(config.paths.v6Assets + '/sass/*.scss')
+    .pipe(plumber(errorHandler))
     .pipe(sourcemaps.init())
     .pipe(sass({
       outputStyle: 'expanded',

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gulp-clean": "^0.4.0",
     "gulp-mocha": "^6.0.0",
     "gulp-nodemon": "^2.1.0",
+    "gulp-plumber": "^1.2.0",
     "gulp-sass": "^4.0.1",
     "gulp-sourcemaps": "^2.6.0",
     "gulp-util": "^3.0.7",

--- a/start.js
+++ b/start.js
@@ -78,5 +78,6 @@ function runGulp () {
 
   gulp.on('exit', function (code) {
     console.log('gulp exited with code ' + code.toString())
+    process.exit(1)
   })
 }


### PR DESCRIPTION
Use gulp-plumber to terminate task should there be an error in the sass compilation tasks.

Addresses: #295 

Before:
<img width="301" alt="screen shot 2018-10-03 at 09 42 59" src="https://user-images.githubusercontent.com/3758555/46401000-bd4b9580-c6f3-11e8-9dd8-b140f43bb969.png">

After: 
<img width="299" alt="screen shot 2018-10-03 at 09 52 33" src="https://user-images.githubusercontent.com/3758555/46401006-c3da0d00-c6f3-11e8-97f3-85f16c81ef18.png">
