### PR TITLE
Fix About link in nav

### DIFF
--- a/docs/views/layout.html
+++ b/docs/views/layout.html
@@ -59,7 +59,7 @@
         }
       },
       {
-        href: "docs/about",
+        href: "/docs/about",
         text: "About",
         attributes: {
           "data-about": "About"


### PR DESCRIPTION
[The relative link breaks on some pages](https://govuk-prototype-kit.herokuapp.com/docs/tutorials-and-examples). This PR makes it absolute.