### PR TITLE
Update GOV.UK Frontend to v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Unreleased
 
+New Features:
+
+- [#609 Update GOV.UK Frontend to v2.2.0](https://github.com/alphagov/govuk-prototype-kit/pull/609)
+
+Also includes a new character-count component
+
 Bug fixes:
 
 - [#605 Set stylesheet media to "all" to allow print styles](https://github.com/alphagov/govuk-prototype-kit/pull/605)
+
 - [#608 Clearing session data now uses a POST request rather than a destructive GET request](https://github.com/alphagov/govuk-prototype-kit/pull/608)
 
 # 8.1.0

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -3,6 +3,7 @@
 {% from "back-link/macro.njk"     import govukBackLink %}
 {% from "breadcrumbs/macro.njk"   import govukBreadcrumbs %}
 {% from "button/macro.njk"        import govukButton %}
+{% from "character-count/macro.njk"  import govukCharacterCount %}
 {% from "checkboxes/macro.njk"    import govukCheckboxes %}
 {% from "date-input/macro.njk"    import govukDateInput %}
 {% from "details/macro.njk"       import govukDetails %}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^2.1.0",
+    "govuk-frontend": "^2.2.0",
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "gulp": "^3.9.1",


### PR DESCRIPTION
- update to v2.2.0
- import the character-count component into app layout view