### PR TITLE
Heroku review app config

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,21 @@
+{
+    "name": "govuk-prototype-kit",
+    "scripts": {},
+    "env": {
+      "USE_AUTH": {
+        "required": true
+      }
+    },
+    "formation": {
+      "web": {
+        "quantity": 1
+      }
+    },
+    "addons": [],
+    "buildpacks": [
+      {
+        "url": "heroku/nodejs"
+      }
+    ]
+  }
+  


### PR DESCRIPTION
Required config to enable review apps on Heroku
Auto-generated by Heroku, but creating a pull request this way instead of auto-committing to master

As per https://devcenter.heroku.com/articles/github-integration-review-apps

Trello ticket: https://trello.com/c/XnrMzz0P/1512-setting-up-review-apps-on-the-prototype-kit