### PR TITLE
Add static asset caching

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -29,6 +29,9 @@ module.exports = {
   cookieText: 'GOV.UK uses cookies to make the site simpler. <a href="#">Find out more about cookies</a>',
 
   // Enable or disable Browser Sync
-  useBrowserSync: 'true'
+  useBrowserSync: 'true',
+  
+  // Set a value for the max age of all static assets in cache
+  assetsMaxAge: 0
 
 }

--- a/app/config.js
+++ b/app/config.js
@@ -30,7 +30,7 @@ module.exports = {
 
   // Enable or disable Browser Sync
   useBrowserSync: 'true',
-  
+
   // Set a value (in milliseconds) for the max age of all static assets in cache
   assetsMaxAge: 0
 

--- a/app/config.js
+++ b/app/config.js
@@ -31,7 +31,7 @@ module.exports = {
   // Enable or disable Browser Sync
   useBrowserSync: 'true',
   
-  // Set a value for the max age of all static assets in cache
+  // Set a value (in milliseconds) for the max age of all static assets in cache
   assetsMaxAge: 0
 
 }

--- a/server.js
+++ b/server.js
@@ -60,6 +60,7 @@ var useCookieSessionStore = process.env.USE_COOKIE_SESSION_STORE || config.useCo
 var useHttps = process.env.USE_HTTPS || config.useHttps
 var useBrowserSync = config.useBrowserSync
 var gtmId = process.env.GOOGLE_TAG_MANAGER_TRACKING_ID
+var staticAssetsMaxAge = process.env.ASSETS_MAX_AGE || config.assetsMaxAge;
 
 env = env.toLowerCase()
 useAuth = useAuth.toLowerCase()
@@ -110,8 +111,8 @@ utils.addNunjucksFilters(nunjucksAppEnv)
 app.set('view engine', 'html')
 
 // Middleware to serve static assets
-app.use('/public', express.static(path.join(__dirname, '/public')))
-app.use('/assets', express.static(path.join(__dirname, 'node_modules', 'govuk-frontend', 'assets')))
+app.use('/public', express.static(path.join(__dirname, '/public'), { maxAge: staticAssetsMaxAge || 0 }))
+app.use('/assets', express.static(path.join(__dirname, 'node_modules', 'govuk-frontend', 'assets'), { maxAge: staticAssetsMaxAge || 0 }))
 
 // Serve govuk-frontend in /public
 app.use('/node_modules/govuk-frontend', express.static(path.join(__dirname, '/node_modules/govuk-frontend')))

--- a/server.js
+++ b/server.js
@@ -115,7 +115,7 @@ app.use('/public', express.static(path.join(__dirname, '/public'), { maxAge: sta
 app.use('/assets', express.static(path.join(__dirname, 'node_modules', 'govuk-frontend', 'assets'), { maxAge: staticAssetsMaxAge || 0 }))
 
 // Serve govuk-frontend in /public
-app.use('/node_modules/govuk-frontend', express.static(path.join(__dirname, '/node_modules/govuk-frontend')))
+app.use('/node_modules/govuk-frontend', express.static(path.join(__dirname, '/node_modules/govuk-frontend'), { maxAge: staticAssetsMaxAge || 0 }))
 
 // Set up documentation app
 if (useDocumentation) {
@@ -166,9 +166,9 @@ if (useV6) {
   v6App.set('view engine', 'html')
 
   // Backward compatibility with GOV.UK Elements
-  app.use('/public/v6/', express.static(path.join(__dirname, '/node_modules/govuk_template_jinja/assets')))
-  app.use('/public/v6/', express.static(path.join(__dirname, '/node_modules/govuk_frontend_toolkit')))
-  app.use('/public/v6/javascripts/govuk/', express.static(path.join(__dirname, '/node_modules/govuk_frontend_toolkit/javascripts/govuk/')))
+  app.use('/public/v6/', express.static(path.join(__dirname, '/node_modules/govuk_template_jinja/assets'), { maxAge: staticAssetsMaxAge || 0 }))
+  app.use('/public/v6/', express.static(path.join(__dirname, '/node_modules/govuk_frontend_toolkit'), { maxAge: staticAssetsMaxAge || 0 }))
+  app.use('/public/v6/javascripts/govuk/', express.static(path.join(__dirname, '/node_modules/govuk_frontend_toolkit/javascripts/govuk/'), { maxAge: staticAssetsMaxAge || 0 }))
 }
 
 // Add global variable to determine if DoNotTrack is enabled.

--- a/server.js
+++ b/server.js
@@ -60,7 +60,7 @@ var useCookieSessionStore = process.env.USE_COOKIE_SESSION_STORE || config.useCo
 var useHttps = process.env.USE_HTTPS || config.useHttps
 var useBrowserSync = config.useBrowserSync
 var gtmId = process.env.GOOGLE_TAG_MANAGER_TRACKING_ID
-var staticAssetsMaxAge = process.env.ASSETS_MAX_AGE || config.assetsMaxAge;
+var staticAssetsMaxAge = process.env.ASSETS_MAX_AGE || config.assetsMaxAge
 
 env = env.toLowerCase()
 useAuth = useAuth.toLowerCase()


### PR DESCRIPTION
Recently we have demoed our prototype on heroku and locally through presentations and video, the prototype doesn't cache any static assets so during these presentations theres often a flash of unstyled text and layout shifting due to the lack of CSS and webfonts.

This PR will allow a cache maxAge option to be set through config or environment variables, which will default to 0 if neither is set (should make it less of a breaking change as it won't be required in config)