### PR TITLE
Fix path for page templates in tutorials-and-examples

### DIFF
--- a/docs/views/tutorials-and-examples.html
+++ b/docs/views/tutorials-and-examples.html
@@ -122,7 +122,7 @@
         Use these as the basis for your prototypes. We recommend making copies of the files rather than directly editing them.
       </p>
       <p>
-        You can find them in your prototype folder, in /docs/views/examples
+        You can find them in your prototype folder, in /docs/views/templates
       </p>
 
       <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
Site previously referred to /docs/views/examples, which was incorrect, and confused me for a bit.