### PR TITLE
Setup exclusion list for the generated ZIP download

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# dont include the following files in the zip
+.gitattributes export-ignore
+README.md export-ignore
+CHANGELOG.md export-ignore
+CONTRIBUTING.MD export-ignore
+create-release.sh export-ignore
+travis.yml export-ignore
+.travis export-ignore
+app.json export-ignore


### PR DESCRIPTION
Make use of `.gitattributes` file to list all files that we don't want to include in the ZIP users download

As per https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#_exporting_your_repository

Addresses: #519 