### PR TITLE
Update govuk-frontend to 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 New features: 
 
+- [#628 Update GOV.UK Frontend to v2.3.0](https://github.com/alphagov/govuk-prototype-kit/pull/628)
+
 - [#574 Add Notify integration guidance](https://github.com/alphagov/govuk-prototype-kit/pull/574)
 
 - [Add npm install reminder when prototype crashes](https://github.com/alphagov/govuk-prototype-kit/pull/598)

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^2.2.0",
+    "govuk-frontend": "^2.3.0",
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "gulp": "^3.9.1",


### PR DESCRIPTION
Latest released version.
Release notes here: https://github.com/alphagov/govuk-frontend/releases/tag/v2.3.0