### PR TITLE
Fix list of excluded styles

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 .gitattributes export-ignore
 README.md export-ignore
 CHANGELOG.md export-ignore
-CONTRIBUTING.MD export-ignore
+CONTRIBUTING.md export-ignore
 create-release.sh export-ignore
 travis.yml export-ignore
 .travis export-ignore


### PR DESCRIPTION
Fix a typo, as the CONTRIBUTING.md file wan't excluded from the generated zip. 
File suffix isn't case-sensitive it seems