### PR TITLE
Add Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+usage-data-config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:8.12-alpine
+
+ADD . /app
+WORKDIR /app
+
+ARG COLLECT_USAGE_DATA=true
+
+RUN npm install
+RUN echo "{\"collectUsageData\": $COLLECT_USAGE_DATA}" > usage-data-config.json
+
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/docs/documentation/install/developer-install-instructions.md
+++ b/docs/documentation/install/developer-install-instructions.md
@@ -1,20 +1,57 @@
 # Instructions for developers
 
+There are multiple ways of running the application locally.
+
+## Native
+
 It's built on the [Express](http://expressjs.com/) framework, and uses [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend).
 
-## Requirements
+### Requirements
 
 node.js - version 8.x.x
 
-## Install dependencies
+### Install dependencies
 
 ```
 npm install
 ```
 
-## Run the kit
+### Run the kit
 ```
 npm start
 ```
 
 Go to [localhost:3000](http://localhost:3000) in your browser.
+
+## Docker
+
+You may choose to run the application in the docker environment. Doing so you'd
+probably be driven by some of the following:
+
+- avoid installing/managing node on your machine
+- avoid remembering to install/compile dependencies
+- running application in an artifact way
+  - ability to push to Kubernetes (RE Build & Run) or CloudFoundry (GOV.UK PaaS)
+- run in _production-like_ environment
+
+We've placed a `Dockerfile` in the root of the project.
+
+You can build an image by running the following:
+
+```
+docker build . -t govuk-prototype-kit:latest
+```
+
+This step will pull a small image containing a base operating system with node
+pre-installed. Additionally, will mount your current working directory along
+with installing some `node_modules`.
+
+You can run it afterwards with:
+
+```
+docker run -p 3000:3000 govuk-prototype-kit:latest
+```
+
+The application will listen on your exposed port (`3000` in this case). You
+should be able to visit http://localhost:3000/
+


### PR DESCRIPTION
## What

We'd like to add a docker image, in order to use the prototype kit as "well known" example application that can be hosted on (in our case) Kubernetes.

We had to work in a Docker argument in order for it to be used by the kit to either disable or enable the data usage sharing.

## How to review

- Review code
- Run:
  ```docker build . -t "govuk-prototype-kit:0.0.$(date +"%s")"```
  or
  ```docker build . -t "govuk-prototype-kit:0.0.$(date +"%s")" --build-arg COLLECT_USAGE_DATA=false```
  This will build a Docker image you can run
- Run:
  ```docker run -p 3000:3000 "govuk-prototype-kit:0.0.$(date +"%s")"```
  Make sure the timestamp matches the one from the build step
- You should be able to visit http://localhost:3000/