### PR TITLE
Move closing H1 tag onto the same line as the opening tag

### DIFF
--- a/docs/views/templates/question.html
+++ b/docs/views/templates/question.html
@@ -13,8 +13,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">Heading or question goes here
-      </h1>
+      <h1 class="govuk-heading-xl">Heading or question goes here</h1>
 
       <form class="form" action="/url/of/next/page" method="post">
 


### PR DESCRIPTION
In prototype kit training some users were confused by the fact that the closing tag was not on the same line as the opening tag – inconsistent with the paragraph tags in the same file.