### PR TITLE
Avoid double-nested buttons in step-by-step navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+Bug fixes:
+
+- [#634 Avoid double-nested buttons in step-by-step navigation](https://github.com/alphagov/govuk-prototype-kit/pull/634)
+
 # 8.3.0
 
 New features:

--- a/docs/views/templates/step-by-step-navigation.html
+++ b/docs/views/templates/step-by-step-navigation.html
@@ -56,12 +56,7 @@
               </span>
 
               <span class="js-step-title">
-                <button class="app-step-nav__button app-step-nav__button--title js-step-title-button" aria-expanded="false" aria-controls="step-panel-check-youre-allowed-to-drive-1">
-                  <span class="js-step-title-text">
-                    Check you're allowed to drive
-                  </span>
-                  <span class="app-step-nav__toggle-link js-toggle-link" aria-hidden="true">Show</span>
-                </button>
+                Check you're allowed to drive
               </span>
             </h2>
           </div>
@@ -96,12 +91,7 @@
               </span>
 
               <span class="js-step-title">
-                <button class="app-step-nav__button app-step-nav__button--title js-step-title-button" aria-expanded="false" aria-controls="step-panel-get-a-provisional-licence-2">
-                  <span class="js-step-title-text">
-                    Get a provisional licence
-                  </span>
-                  <span class="app-step-nav__toggle-link js-toggle-link" aria-hidden="true">Show</span>
-                </button>
+                Get a provisional licence
               </span>
             </h2>
           </div>
@@ -128,12 +118,7 @@
               </span>
 
               <span class="js-step-title">
-                <button class="app-step-nav__button app-step-nav__button--title js-step-title-button" aria-expanded="false" aria-controls="step-panel-driving-lessons-and-practice-3">
-                  <span class="js-step-title-text">
-                    Driving lessons and practice
-                  </span>
-                  <span class="app-step-nav__toggle-link js-toggle-link" aria-hidden="true">Show</span>
-                </button>
+                Driving lessons and practice
               </span>
             </h2>
           </div>
@@ -171,12 +156,7 @@
               </span>
 
               <span class="js-step-title">
-                <button class="app-step-nav__button app-step-nav__button--title js-step-title-button" aria-expanded="false" aria-controls="step-panel-prepare-for-your-theory-test-4">
-                  <span class="js-step-title-text">
-                    Prepare for your theory test
-                  </span>
-                  <span class="app-step-nav__toggle-link js-toggle-link" aria-hidden="true">Show</span>
-                </button>
+                Prepare for your theory test
               </span>
             </h2>
           </div>
@@ -209,12 +189,7 @@
               </span>
 
               <span class="js-step-title">
-                <button class="app-step-nav__button app-step-nav__button--title js-step-title-button" aria-expanded="false" aria-controls="step-panel-book-and-manage-your-theory-test-5">
-                  <span class="js-step-title-text">
-                    Book and manage your theory test
-                  </span>
-                  <span class="app-step-nav__toggle-link js-toggle-link" aria-hidden="true">Show</span>
-                </button>
+                Book and manage your theory test
               </span>
             </h2>
           </div>
@@ -256,12 +231,7 @@
               </span>
 
               <span class="js-step-title">
-                <button class="app-step-nav__button app-step-nav__button--title js-step-title-button" aria-expanded="false" aria-controls="step-panel-book-and-manage-your-driving-test-6">
-                  <span class="js-step-title-text">
-                    Book and manage your driving test
-                  </span>
-                  <span class="app-step-nav__toggle-link js-toggle-link" aria-hidden="true">Show</span>
-                </button>
+                Book and manage your driving test
               </span>
             </h2>
           </div>
@@ -303,12 +273,7 @@
               </span>
 
               <span class="js-step-title">
-                <button class="app-step-nav__button app-step-nav__button--title js-step-title-button" aria-expanded="false" aria-controls="step-panel-when-you-pass-7">
-                  <span class="js-step-title-text">
-                    When you pass
-                  </span>
-                  <span class="app-step-nav__toggle-link js-toggle-link" aria-hidden="true">Show</span>
-                </button>
+                When you pass
               </span>
             </h2>
           </div>


### PR DESCRIPTION
We can remove these, they're added by JS automatically.

Fixes https://github.com/alphagov/govuk-prototype-kit/issues/633