### PR TITLE
updates support details

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,14 @@
 
 We really like contributions and bug reports, in fact the project wouldn't have got to this stage without them.
 We do have a few guidelines to bear in mind.
+        
+## Contributing
 
-## Community
+If you’ve got an idea or suggestion you can:
 
-We have two Slack channels for the Prototype Kit. You'll need a government email address to join them.
-
-* [Slack channel for users of the Prototype Kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit/)
-* [Slack channel for developers of the Prototype Kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit-dev/)
+* email [govuk-design-system-support@digital.cabinet-office.gov.uk](mailto:govuk-design-system-support@digital.cabinet-office.gov.uk) 
+* [get in touch on developer Slack channel](https://ukgovernmentdigital.slack.com/messages/prototype-kit-dev)([open in app](slack://channel?team=T04V6EBTR&amp;id=C0E1063DW))
+* [create a GitHub issue](https://github.com/alphagov/govuk-prototype-kit/issues)       
 
 ## Raising bugs
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,17 @@ You must protect user privacy at all times, even when using prototypes. Prototyp
 - [Installation guide for new users (non technical)](https://govuk-prototype-kit.herokuapp.com/docs/install/introduction)
 - [Installation guide for developers (technical)](https://govuk-prototype-kit.herokuapp.com/docs/install/developer-install-instructions)
 
-## Community
+## Support
 
-We have two Slack channels for the Prototype Kit. You'll need a government email address to join them.
+The GOV.UK Prototype Kit is maintained by the Government Digital Service. If you’ve got a question or need support you can:
 
-* [Slack channel for users of the Prototype Kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit/)
-* [Slack channel for developers of the Prototype Kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit-dev/)
+* email [govuk-design-system-support@digital.cabinet-office.gov.uk](mailto:govuk-design-system-support@digital.cabinet-office.gov.uk) 
+* [get in touch on Slack](https://ukgovernmentdigital.slack.com/messages/prototype-kit)([open in app](slack://channel?team=T04V6EBTR&amp;id=C0647LW4R)) 
+* [view known issues on GitHub](https://github.com/alphagov/govuk-prototype-kit/issues)
+        
+## Contributing
+
+If you’ve got an idea or suggestion you can:
+
+* [get in touch on the developer Slack channel](https://ukgovernmentdigital.slack.com/messages/prototype-kit-dev)([open in app](slack://channel?team=T04V6EBTR&amp;id=C0E1063DW))
+* [create a GitHub issue](https://github.com/alphagov/govuk-prototype-kit/issues)

--- a/docs/views/about.html
+++ b/docs/views/about.html
@@ -24,15 +24,45 @@ About - GOV.UK Prototype Kit
       <p class="govuk-body-l">
         The GOV.UK Prototype Kit provides a simple way to make interactive prototypes that look like pages on GOV.UK. These prototypes can be used to show ideas to people you work with, and to do user research
       </p>
-
-      <h2 class="govuk-heading-m">Community</h2>
-
-      <p>We have two Slack channels for the GOV.UK Prototype Kit. You'll need a government email address to join.</p>
+      
+      <h2 class="govuk-heading-m">Support</h2>
+      
+      <p>The GOV.UK Prototype Kit is maintained by the Government Digital Service. If you’ve got a question or need support you can:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li><a href="https://ukgovernmentdigital.slack.com/messages/prototype-kit/">Slack channel for users of the GOV.UK Prototype Kit</a></li>
-        <li><a href="https://ukgovernmentdigital.slack.com/messages/prototype-kit-dev/">Slack channel for developers of the GOV.UK Prototype Kit</a></li>
+        <li>email 
+          <a href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" class="govuk-link">
+            govuk-design-system-support@digital.cabinet-office.gov.uk
+          </a>
+        </li>
+        <li>
+          <a href="https://ukgovernmentdigital.slack.com/messages/prototype-kit" class="govuk-link">
+            get in touch on Slack
+          </a> 
+          (<a class="govuk-link" href="slack://channel?team=T04V6EBTR&amp;id=C0647LW4R">open in app</a>)
+        </li>
+        <li>
+          <a href="https://github.com/alphagov/govuk-prototype-kit/issues" class="govuk-link">
+            view known issues on GitHub
+          </a>
+        </li>
       </ul>
 
+      <h2 class="govuk-heading-m">Contributing</h2>
+      
+      <p>If you’ve got an idea or suggestion you can:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          <a href="https://ukgovernmentdigital.slack.com/messages/prototype-kit-dev" class="govuk-link">
+            get in touch on the developer Slack channel
+          </a> 
+          (<a class="govuk-link" href="slack://channel?team=T04V6EBTR&amp;id=C0E1063DW">open in app</a>)
+        </li>
+        <li>
+          <a href="https://github.com/alphagov/govuk-prototype-kit/issues" class="govuk-link">
+            create a GitHub issue
+          </a>
+        </li>
+      </ul>
 
       <h2 class="govuk-heading-m">Principles</h2>
 


### PR DESCRIPTION
I tried to follow the pattern we use in Design System https://design-system.service.gov.uk/#support

Trello ticket: https://trello.com/c/KTqAyEp8

Example: https://govuk-prototype-kit-pr-639.herokuapp.com/docs/about
