### PR TITLE
Fix link context in step-by-step templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+Fixes:
+
+- [#647 Fix link context in step-by-step templates](https://github.com/alphagov/govuk-prototype-kit/pull/647)
+
 Internal:
 
 - [#640 Replace Mocha with Jest](https://github.com/alphagov/govuk-prototype-kit/pull/640)

--- a/docs/views/templates/start-with-step-by-step.html
+++ b/docs/views/templates/start-with-step-by-step.html
@@ -105,7 +105,7 @@
           <div class="app-step-nav__panel js-panel" id="step-panel-get-a-provisional-licence-2">
             <ol class="app-step-nav__list " data-length="1">
               <li class="app-step-nav__list-item js-list-item ">
-                <a data-position="2.1" class="app-step-nav__link js-link" href="#">£34 to £43</span>
+                <a data-position="2.1" class="app-step-nav__link js-link" href="#">Apply for your first provisional driving licence <span class="app-step-nav__context">£34 to £43</span></span>
                 </a>
               </li>
             </ol>
@@ -208,8 +208,7 @@
 
             <ol class="app-step-nav__list " data-length="5">
               <li class="app-step-nav__list-item js-list-item ">
-                <a data-position="5.1" class="app-step-nav__link js-link" href="#">£23</span>
-                </a>
+                <a data-position="5.1" class="app-step-nav__link js-link" href="#">Book your theory test <span class="app-step-nav__context">£23</span></a>
               </li>
               <li class="app-step-nav__list-item js-list-item ">
                 <a data-position="5.2" class="app-step-nav__link js-link" href="#">What to take to your test </a>
@@ -251,8 +250,7 @@
 
             <ol class="app-step-nav__list " data-length="5">
               <li class="app-step-nav__list-item js-list-item ">
-                <a data-position="6.1" class="app-step-nav__link js-link" href="#">£62 to £75</span>
-                </a>
+                <a data-position="6.1" class="app-step-nav__link js-link" href="#">Book your driving test <span class="app-step-nav__context">£62 to £75</span></a>
               </li>
               <li class="app-step-nav__list-item js-list-item ">
                 <a data-position="6.2" class="app-step-nav__link js-link" href="#">What to take to your test </a>

--- a/docs/views/templates/step-by-step-navigation.html
+++ b/docs/views/templates/step-by-step-navigation.html
@@ -199,8 +199,7 @@
 
             <ol class="app-step-nav__list " data-length="5">
               <li class="app-step-nav__list-item js-list-item ">
-                <a data-position="5.1" class="app-step-nav__link js-link" href="#">£23</span>
-                </a>
+                <a data-position="5.1" class="app-step-nav__link js-link" href="#">Book your theory test <span class="app-step-nav__context">£23</span></a>
               </li>
               <li class="app-step-nav__list-item js-list-item ">
                 <a data-position="5.2" class="app-step-nav__link js-link" href="#">What to take to your test </a>
@@ -241,7 +240,7 @@
 
             <ol class="app-step-nav__list " data-length="5">
               <li class="app-step-nav__list-item js-list-item ">
-                <a data-position="6.1" class="app-step-nav__link js-link" href="#">£62 to £75</span>
+                <a data-position="6.1" class="app-step-nav__link js-link" href="#">Book your driving test <span class="app-step-nav__context">£62 to £75</span></a>
                 </a>
               </li>
               <li class="app-step-nav__list-item js-list-item ">


### PR DESCRIPTION
Link context (price) wasn't showing correctly previously