### PR TITLE
Replace `gulp-nodemon` with `nodemon`

### DIFF
--- a/gulp/nodemon.js
+++ b/gulp/nodemon.js
@@ -9,7 +9,7 @@ const path = require('path')
 
 const gulp = require('gulp')
 const gutil = require('gulp-util')
-const nodemon = require('gulp-nodemon')
+const nodemon = require('nodemon')
 
 const config = require('./config.json')
 
@@ -28,7 +28,7 @@ const onQuit = () => {
 }
 
 gulp.task('server', function () {
-  nodemon({
+  return nodemon({
     watch: ['.env', '**/*.js', '**/*.json'],
     script: 'listen-on-port.js',
     ignore: [

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "gulp-util": "^3.0.7",
     "keypather": "^3.0.0",
     "marked": "^0.4.0",
+    "nodemon": "^1.18.7",
     "notifications-node-client": "^4.1.0",
     "nunjucks": "^3.1.3",
     "portscanner": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "govuk_template_jinja": "^0.24.1",
     "gulp": "^3.9.1",
     "gulp-clean": "^0.4.0",
-    "gulp-nodemon": "^2.1.0",
     "gulp-sass": "^4.0.1",
     "gulp-sourcemaps": "^2.6.0",
     "gulp-util": "^3.0.7",


### PR DESCRIPTION
Nodemon has been updated to not depend on vulnerable dependencies, whereas 'gulp-nodemon` that uses nodemon hasn't.

This work makes changes needed to use nodemon directly, remove one level of abstraction, regardless of the (now no longer-existent) vulnerability.

Ways to test:
- start the app , make a change in a *.js file and the changes should force javascript to be recompiled
- stop the app, delete node_modules and start it up again. It should display "ERROR: Node module folder missing. Try running `npm install`"