### PR TITLE
Improve authentication middleware

### DIFF
--- a/lib/middleware/authentication/authentication.js
+++ b/lib/middleware/authentication/authentication.js
@@ -22,8 +22,8 @@ module.exports = function (req, res, next) {
   // Local Variables
   const env = (process.env.NODE_ENV || 'development').toLowerCase()
   const useAuth = (process.env.USE_AUTH || config.useAuth).toLowerCase()
-  const username = process.env.USERNAME
-  const password = process.env.PASSWORD
+  const username = (typeof process.env.USERNAME !== 'undefined') ? process.env.USERNAME : false
+  const password = (typeof process.env.PASSWORD !== 'undefined') ? process.env.PASSWORD : false
 
   if (env === 'production' && useAuth === 'true') {
     if (!username || !password) {

--- a/lib/middleware/authentication/authentication.test.js
+++ b/lib/middleware/authentication/authentication.test.js
@@ -28,14 +28,11 @@ describe('authentication', () => {
     beforeAll(() => {
       process.env.NODE_ENV = 'production'
       process.env.USE_AUTH = 'true'
+      delete process.env.USERNAME
+      delete process.env.PASSWORD
     })
 
     describe('server with no username/password set', () => {
-      beforeAll(() => {
-        delete process.env.USERNAME
-        delete process.env.PASSWORD
-      })
-
       beforeEach(() => {
         // Jest mocks stores each call to the mocked function
         // so we want to clear them before running the authentication again.
@@ -117,6 +114,27 @@ describe('authentication', () => {
 
         it('should not progress to the next middleware', () => {
           expect(next).not.toBeCalled()
+        })
+      })
+    })
+    describe('server with username/password set intentionally to a falsy value', () => {
+      beforeAll(() => {
+        process.env.USERNAME = 0
+        process.env.PASSWORD = 0
+      })
+
+      describe('when a user supplies correct username/password', () => {
+        beforeEach(() => {
+          jest.clearAllMocks()
+          basicAuth.mockReturnValue({
+            name: '0',
+            pass: '0'
+          })
+          authentication({}, res, next)
+        })
+
+        it('should progress to the next middleware', () => {
+          expect(next).toBeCalled()
         })
       })
     })


### PR DESCRIPTION
If a user were to set their username/password to a falsy value such as `0` it would have failed before since we we're not testing for the value existing.

This changes the logic to check if the username/password is set rather than if it's truthy.

https://trello.com/c/ZPBwWKpL/1655-improve-authentication-middleware