### PR TITLE
Remove gulp-util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Internal:
 - [#663 update Standard to 12.0.1](https://github.com/alphagov/govuk-prototype-kit/pull/663)
 - [#640 Replace Mocha with Jest](https://github.com/alphagov/govuk-prototype-kit/pull/640)
 - [#659 Upgrade kit to use Gulp 4](https://github.com/alphagov/govuk-prototype-kit/pull/659)
+- [#664 Remove deprecated gulp-util](https://github.com/alphagov/govuk-prototype-kit/pull/664)
 
 # 8.4.0
 

--- a/gulp/nodemon.js
+++ b/gulp/nodemon.js
@@ -10,13 +10,14 @@ const path = require('path')
 const gulp = require('gulp')
 const gutil = require('gulp-util')
 const colour = require('ansi-colors')
+const log = require('fancy-log')
 const nodemon = require('gulp-nodemon')
 
 const config = require('./config.json')
 
 // Warn about npm install on crash
 const onCrash = () => {
-  gutil.log(colour.cyan('[nodemon] For missing modules try running `npm install`'))
+  log(colour.cyan('[nodemon] For missing modules try running `npm install`'))
 }
 
 // Remove .port.tmp if it exists

--- a/gulp/nodemon.js
+++ b/gulp/nodemon.js
@@ -8,7 +8,6 @@ const fs = require('fs')
 const path = require('path')
 
 const gulp = require('gulp')
-const gutil = require('gulp-util')
 const colour = require('ansi-colors')
 const log = require('fancy-log')
 const nodemon = require('gulp-nodemon')

--- a/gulp/nodemon.js
+++ b/gulp/nodemon.js
@@ -9,13 +9,14 @@ const path = require('path')
 
 const gulp = require('gulp')
 const gutil = require('gulp-util')
+const colour = require('ansi-colors')
 const nodemon = require('gulp-nodemon')
 
 const config = require('./config.json')
 
 // Warn about npm install on crash
 const onCrash = () => {
-  gutil.log(gutil.colors.cyan('[nodemon] For missing modules try running `npm install`'))
+  gutil.log(colour.cyan('[nodemon] For missing modules try running `npm install`'))
 }
 
 // Remove .port.tmp if it exists

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "npm run lint && gulp generate-assets && jest"
   },
   "dependencies": {
+    "ansi-colors": "^3.2.3",
     "basic-auth": "^2.0.0",
     "basic-auth-connect": "^1.0.0",
     "body-parser": "^1.14.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "gulp-nodemon": "^2.1.0",
     "gulp-sass": "^4.0.1",
     "gulp-sourcemaps": "^2.6.0",
-    "gulp-util": "^3.0.7",
     "keypather": "^3.0.0",
     "marked": "^0.4.0",
     "notifications-node-client": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "express": "4.16.3",
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",
+    "fancy-log": "^1.3.3",
     "govuk-elements-sass": "^3.1.3",
     "govuk-frontend": "^2.4.1",
     "govuk_frontend_toolkit": "^7.5.0",


### PR DESCRIPTION
Addresses the warning mentioned in issue #660 by replacing gulp-util with the two individual packages (ansi-color and fancy-logs) as recommended [here](https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5).

Another great thing about removing gulp-utils is that it was pulling in 18 other dependencies. Ansi-color required no other dependencies and fancy-logs needs only 4 small dependencies.