### PR TITLE
Add acorn dependency to fix npm warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Fixes:
 
+- [#666 Add acorn dependency to fix npm warning](https://github.com/alphagov/govuk-prototype-kit/pull/666)
 - [#647 Fix link context in step-by-step templates](https://github.com/alphagov/govuk-prototype-kit/pull/647)
 
 Internal:

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     ]
   },
   "devDependencies": {
+    "acorn": "^6.0.5",
     "jest": "^23.6.0",
     "standard": "^12.0.1",
     "supertest": "^3.0.0"


### PR DESCRIPTION
It seems there is a problem with npm installing 'peer dependencies'
npm's warning says that we need to install this dependency ourselves.

We are getting this issue via `eslint`, via `standard`

The bug is tracked here:
https://github.com/eslint/eslint/issues/11018