### PR TITLE
Add acorn to dependency to fix npm Warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Fixes:
 
-- [#666 Add acorn dependency to fix npm warning](https://github.com/alphagov/govuk-prototype-kit/pull/666)
+- [#667 Add acorn dependency to fix npm warning](https://github.com/alphagov/govuk-prototype-kit/pull/667)
 - [#647 Fix link context in step-by-step templates](https://github.com/alphagov/govuk-prototype-kit/pull/647)
 
 Internal:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "npm run lint && gulp generate-assets && jest"
   },
   "dependencies": {
+    "acorn": "^6.0.5",
     "ansi-colors": "^3.2.3",
     "basic-auth": "^2.0.0",
     "basic-auth-connect": "^1.0.0",
@@ -51,7 +52,6 @@
     ]
   },
   "devDependencies": {
-    "acorn": "^6.0.5",
     "jest": "^23.6.0",
     "standard": "^12.0.1",
     "supertest": "^3.0.0"


### PR DESCRIPTION
We dont really need it but its needed for Standard and gulp-sourcemaps.

#666 deploy failed because Heroku removes dev dependency by default. 