### PR TITLE
Update GOV.UK Frontend to version 2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "express-writer": "0.0.4",
     "fancy-log": "^1.3.3",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^2.5.1",
+    "govuk-frontend": "^2.6.0",
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "gulp": "^4.0.0",


### PR DESCRIPTION
See https://github.com/alphagov/govuk-frontend/releases/tag/v2.6.0