### PR TITLE
Only ask for usage permission if TTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+Fixes:
+
+- [#697 Only ask for usage permission if TTY](https://github.com/alphagov/govuk-prototype-kit/pull/697). Thanks [zuzak](https://github.com/zuzak) for this contribution.
+
 # 8.8.0
 
 Features:

--- a/lib/usage_data.js
+++ b/lib/usage_data.js
@@ -51,7 +51,10 @@ exports.askForUsageDataPermission = function () {
       required: true,
       type: 'string',
       pattern: /y(es)?|no?/i,
-      message: 'Please enter y or n'
+      message: 'Please enter y or n',
+      ask: function () {
+        return process.stdout.isTTY
+      }
     }], function (err, result) {
       if (err) {
         reject(err)


### PR DESCRIPTION
You can run the prototype toolkit in a way that does not accept input.
A basic example would be:

   $ npm start | cat

If this is the first time you have run the prototype kit, the
application will hang as there is no way to respond to the question
about recording usage data. This means it is difficult to run the
prototype kit solely without user input.

This commit changes the behaviour of that prompt to only appear if the
user is running the command in a TTY context.

If the user is not running the prototype kit in a TTY, the prompt will
be skipped and the default action will occur as if the user had simply
hit return. In this case, it'll default to "no" and opt the user out of
usage data collection automatically.

A downside of this approach is that the user will not get asked again
if they subsequently run the kit interactively. However, it is unlikely
that users will wish to run the prototype kit initially within a
pipeline whilst also wishing to run it interactively at a later date.

----

Closes #695.

Another prompt occurs when the chosen port is in use, but
this PR doesn't attempt to edit that (the other prompt is only going to show when things go wrong, whereas this prompt occurs on the initial run of the app, every time).

I haven't included tests as there's no existing tests for the usage data feature.