### PR TITLE
Add install guide Slack link

### DIFF
--- a/docs/documentation/install/introduction.md
+++ b/docs/documentation/install/introduction.md
@@ -1,6 +1,6 @@
 # Installation guide for new users
 
-This guide will walk you through installing and getting started with the kit. You don’t need any technical knowledge to follow along. If you get stuck, post a message on Slack, or if you have a developer on your team, they should be able to help.
+This guide will walk you through installing and getting started with the kit. You don’t need any technical knowledge to follow along. If you get stuck, contact us using the [#prototype-kit Slack channel](https://ukgovernmentdigital.slack.com/messages/C0647LW4R/convo/C41GC5UAY-1506957241.000096/), or if you have a developer on your team, they should be able to help.
 
 Installation takes up to 30 minutes depending on how much you need to install.
 

--- a/docs/documentation/install/introduction.md
+++ b/docs/documentation/install/introduction.md
@@ -1,6 +1,6 @@
 # Installation guide for new users
 
-This guide will walk you through installing and getting started with the kit. You don’t need any technical knowledge to follow along. If you get stuck, contact us using the [#prototype-kit Slack channel](https://ukgovernmentdigital.slack.com/messages/C0647LW4R/convo/C41GC5UAY-1506957241.000096/), or if you have a developer on your team, they should be able to help.
+This guide will walk you through installing and getting started with the kit. You don’t need any technical knowledge to follow along. If you get stuck, contact us using the [#prototype-kit Slack channel](https://ukgovernmentdigital.slack.com/messages/C0647LW4R/), or if you have a developer on your team, they should be able to help.
 
 Installation takes up to 30 minutes depending on how much you need to install.
 


### PR DESCRIPTION
In the Prototype Kit documentation there's a reference to Slack if people get stuck during installation. But we don't include a link to the [#prototype-kit Slack channel](https://ukgovernmentdigital.slack.com/messages/C0647LW4R/convo/C41GC5UAY-1506957241.000096/). It'd be good to include this.

[This relates to Prototype Kit issue 685](https://github.com/alphagov/govuk-prototype-kit/issues/685)