### PR TITLE
Optionally set session data with a url parameter, and reference data with dot notation

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -290,8 +290,8 @@ exports.autoStoreData = function (req, res, next) {
   storeData(req.body, req.session.data)
 
   // merge query parameters into the session data unless specifically requested otherwise.
-  if (req.query.persist != "No") {
-      storeData(req.query, req.session.data)
+  if (req.query.persist !== 'No') {
+    storeData(req.query, req.session.data)
   }
 
   // Send session data to all views

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,8 @@ const fs = require('fs')
 
 // NPM dependencies
 const getKeypath = require('keypather/get')
+const setKeypath = require('keypather/set')
+const delKeypath = require('keypather/del')
 const marked = require('marked')
 const path = require('path')
 const portScanner = require('portscanner')
@@ -231,7 +233,7 @@ var storeData = function (input, data) {
 
     // Delete values when users unselect checkboxes
     if (val === '_unchecked' || val === ['_unchecked']) {
-      delete data[i]
+      delKeypath(data, i) // should preserve the object structure but empty the contents of the value
       continue
     }
 
@@ -252,7 +254,17 @@ var storeData = function (input, data) {
       continue
     }
 
-    data[i] = val
+    // check it's a string - we're specifically looking for strings sent in the query parameters which are surrounded in squeare brackets denoting an array.
+    // console.log(val);
+    if (typeof val === 'string') {
+      if (val.match(/\[.+\]/g)) { // is the string surrounded in square brackets?
+        val = val.replace(/^\[/, '') // remove leading square bracket
+        val = val.replace(/\]+$/, '') // remove trailing square bracket
+        var arr = val.split(',') // Turn it into an array proper using a comma as the delimiter
+        val = arr // replace val with new array.
+      }
+    }
+    setKeypath(data, i, val)
   }
 }
 
@@ -276,7 +288,11 @@ exports.autoStoreData = function (req, res, next) {
   req.session.data = Object.assign({}, sessionDataDefaults, req.session.data)
 
   storeData(req.body, req.session.data)
-  storeData(req.query, req.session.data)
+
+  // merge query parameters into the session data unless specifically requested otherwise.
+  if (req.query.persist != "No") {
+      storeData(req.query, req.session.data)
+  }
 
   // Send session data to all views
 
@@ -284,6 +300,12 @@ exports.autoStoreData = function (req, res, next) {
 
   for (var j in req.session.data) {
     res.locals.data[j] = req.session.data[j]
+  }
+
+  // Query parameters will usually be merged with the session data, but you may additionally want to use them independently.
+  res.locals.query = res.locals.query || {}
+  for (var item in req.query) {
+    res.locals.query[item] = req.query[item]
   }
 
   next()


### PR DESCRIPTION
Update autoStoreData function to use Keypather library to allow
referencing of session data in templates using dot notation instead 
of array notation. Array notation ['value']['value'] still works.

This means you can reference session data in the template and 
in the app code (routes files) in the same way (using dot notation).

eg. {{ data.participant.profile.name }}

Data in the session can now be set with a parameter passed in the
url, also using dot notation.

eg. /question?participant.profile.name=stef

This data will be added to the session data, or overwrite existing
values. You may not want to merge this data into the session data
but still access the values in the template. To do this, you can
use the data.query value in the template to access the url parameters.
Include the additional parameter '&persist=No'  in the url. This will
prevent the values being merged into session.data, and subsequent
pages in the journey will not retain this value.

eg. /question?participant.profile.name=stef&persist=No

This would let you access the value in the template with:

{{ query.participant.profile.name }}

Add code to check for parameters passed in the query which have string
values wrapped in square brackets. It treats the comma as a delimiter
and turns the value into an array, attaching it to the session at the
path indicated by the parameter key. This is good for passing a
query in the url which contains a list of checkboxes which should
be set when the page loads.

eg. /question?participant.profile.faveColors=[yellow,burgundy,pink]