### PR TITLE
Add new route to clear session data without any confirmation, then redirect to index page

### DIFF
--- a/lib/prototype-admin/clear-data.html
+++ b/lib/prototype-admin/clear-data.html
@@ -21,8 +21,9 @@
       <h1 class="govuk-heading-xl">
         Clear data?
       </h1>
+      <p>This will clear all of the data entered in this session, and reload any default values.</p>
       {{ govukWarningText({
-        text: "This will clear all of the data entered in this session",
+        text: "All data entered during this session will be erased",
         iconFallbackText: "Warning"
       }) }}
 

--- a/server.js
+++ b/server.js
@@ -218,6 +218,13 @@ if (useAutoStoreData === 'true') {
   }
 }
 
+// Clear session object without confirmation and redirect to prototype index page.
+// Session defaults will reload automatically in subsequent GET request
+app.get('/prototype-admin/clear-data-without-confirmation', function (req, res, next) {
+  req.session.data = {}
+  res.redirect('/')
+})
+
 // Clear all data in session if you open /prototype-admin/clear-data
 app.post('/prototype-admin/clear-data', function (req, res) {
   req.session.data = {}


### PR DESCRIPTION
In usability testing it's useful to be able to restart the prototype with a brand new session, and reinstate any data included in the default data file. This route will redirect the user to the home (/) page of the prototype after resetting req.session.data.