### PR TITLE
Fix handling arrays in session data

### DIFF
--- a/__tests__/spec/data-storage.js
+++ b/__tests__/spec/data-storage.js
@@ -1,0 +1,76 @@
+/* eslint-env jest */
+const request = require('supertest')
+const app = require('../../server.js')
+const path = require('path')
+const fs = require('fs')
+const utils = require('../../lib/utils.js')
+
+jest.setTimeout(30000)
+
+function readFile (pathFromRoot) {
+  return fs.readFileSync(path.join(__dirname, '../../' + pathFromRoot), 'utf8')
+}
+/**
+ *
+ */
+describe('The data storage', () => {
+  // check session-data defaults file exists
+
+  it.skip('file should exist', (done) => {
+    const sessionDataDefaultsFile = readFile('app/data/session-data-defaults.js')
+
+    request(app)
+      .get(sessionDataDefaultsFile)
+      .expect('Content-Type', /application\/javascript; charset=UTF-8/)
+      // .expect(200)
+      .end(function (err, res) {
+        if (err) {
+          done(err)
+        } else {
+          done()
+        }
+      })
+  })
+
+  describe('storeData function', () => {
+    it('should add input data into session data', async () => {
+      let initialSessionData = {
+        'driver-name': 'Dr Emmett Brown'
+      }
+
+      const inputData = {
+        'vehicle-registration': 'OUTATIME'
+      }
+
+      utils.storeData(inputData, initialSessionData)
+
+      expect(initialSessionData).toEqual({
+        'driver-name': 'Dr Emmett Brown',
+        'vehicle-registration': 'OUTATIME'
+      })
+    })
+
+    it('should merge object into object', async () => {
+      let initialSessionData = {
+        vehicle: {
+          'driver-name': 'Dr Emmett Brown'
+        }
+      }
+
+      const inputData = {
+        vehicle: {
+          registration: 'OUTATIME'
+        }
+      }
+
+      utils.storeData(inputData, initialSessionData)
+
+      expect(initialSessionData).toEqual({
+        vehicle: {
+          'driver-name': 'Dr Emmett Brown',
+          registration: 'OUTATIME'
+        }
+      })
+    })
+  })
+})

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -16,9 +16,47 @@ Example usage:
 ============================================================================
 
 */
-
 module.exports = {
-
-  // Insert values here
-
+  // Example as used in current docs
+  claimant: {
+    field1: 'Example 1',
+    field2: 'Example 2',
+    field3: 'Example 3'
+  },
+  partner: {
+    field1: 'Example 1',
+    field2: 'Example 2',
+    field3: 'Example 3'
+  },
+  myObject: {
+    // Array of objects within object
+    myArrayOfObjects: [
+      {
+        name: 'test1',
+        address: 'test2'
+      },
+      {
+        name: 'test3'
+      }
+    ],
+    // Simple array within object
+    mySimpleArray: [
+      'test4',
+      'test5'
+    ],
+    // Multi-level array within object
+    myMultiLevelArray: [
+      [
+        ['test6', 'test7'],
+        'test8'
+      ]
+    ]
+  },
+  // Arrays within array
+  myArray: [
+    [
+      'test9',
+      ['test10', 'test11']
+    ]
+  ]
 }

--- a/docs/views/examples/pass-data/test1.html
+++ b/docs/views/examples/pass-data/test1.html
@@ -1,0 +1,47 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Example - Passing data
+{% endblock %}
+
+{% block beforeContent %}
+  {% include "includes/breadcrumb_examples.html" %}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form action="/docs/examples/pass-data/test2" method="post" class="form">
+
+        <div class="govuk-form-group">
+          <h3 class="govuk-label-wrapper">
+            Example as used in current docs
+          </h3>
+          <input class="govuk-input" id="registration-number" name="[claimant][field1]" value="{{ data['claimant']['field1'] }}" type="text">
+          <h3 class="govuk-label-wrapper">
+            Array of objects within object
+          </h3>
+          <input class="govuk-input" id="registration-number" name="[myObject][myArrayOfObjects][0][name]" value="{{ data['myObject']['myArrayOfObjects'][0]['name'] }}" type="text">
+          <h3 class="govuk-label-wrapper">
+            Simple array within object
+          </h3>
+          <input class="govuk-input" id="registration-number" name="[myObject][mySimpleArray][0]" value="{{ data['myObject']['mySimpleArray'][0] }}" type="text">
+          <h3 class="govuk-label-wrapper">
+            Multi-level array within object
+          </h3>
+          <input class="govuk-input" id="registration-number" name="[myObject][myMultiLevelArray][0][0][0]" value="{{ data['myObject']['myMultiLevelArray'][0][0][0] }}" type="text">
+          <h3 class="govuk-label-wrapper">
+            Arrays within array
+          </h3>
+          <input class="govuk-input" id="registration-number" name="[myArray][0][0]" value="{{ data['myArray'][0][0] }}" type="text">
+        </div>
+
+        <button class="govuk-button">Continue</button>
+
+      </form>
+
+    </div>
+  </div>
+{% endblock %}

--- a/docs/views/examples/pass-data/test2.html
+++ b/docs/views/examples/pass-data/test2.html
@@ -1,0 +1,42 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+Check your answers
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h3>Example as used in current docs</h3>
+      {{ data['claimant']['field1'] }}
+      {{ data['claimant']['field2'] }}
+      <br>
+      <br>
+      <h3>Array of objects within object</h3>
+      {{ data['myObject']['myArrayOfObjects'][0]['name'] }}
+      {{ data['myObject']['myArrayOfObjects'][0]['address'] }}
+      {{ data['myObject']['myArrayOfObjects'][1]['name'] }}
+      <br>
+      <br>
+      <h3>Simple array within object</h3>
+      {{ data['myObject']['mySimpleArray'][0] }}
+      {{ data['myObject']['mySimpleArray'][1] }}
+      <br>
+      <br>
+      <h3>Multi-level array within object</h3>
+      {{ data['myObject']['myMultiLevelArray'][0][0][0] }}
+      {{ data['myObject']['myMultiLevelArray'][0][0][1] }}
+      {{ data['myObject']['myMultiLevelArray'][0][1] }}
+      <br>
+      <br>
+      <h3>Arrays within array</h3>
+      {{ data['myArray'][0][0] }}
+      {{ data['myArray'][0][1][0] }}
+      {{ data['myArray'][0][1][1] }}
+    </div>
+
+  </div>
+
+{% endblock %}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -221,6 +221,9 @@ exports.matchMdRoutes = function (req, res) {
 
 // Store data from POST body or GET query in session
 var storeData = function (input, data) {
+  // Value we store to indicate unchecked checkboxes. See `auto-store-data.js`
+  var uncheckedValue = '_unchecked'
+
   for (var i in input) {
     // any input where the name starts with _ is ignored
     if (i.indexOf('_') === 0) {
@@ -230,25 +233,26 @@ var storeData = function (input, data) {
     var val = input[i]
 
     // Delete values when users unselect checkboxes
-    if (val === '_unchecked' || val === ['_unchecked']) {
+    if (val === uncheckedValue || val === [uncheckedValue]) {
       delete data[i]
       continue
     }
 
-    // Remove _unchecked from arrays of checkboxes
-    if (Array.isArray(val) && val.indexOf('_unchecked') !== -1) {
-      val.splice(val.indexOf('_unchecked'), 1)
-    } else if (typeof val === 'object') {
-      // Store nested objects that aren't arrays
-      if (typeof data[i] !== 'object') {
-        data[i] = {}
+    if (typeof val === 'object') {
+      // If array contains `uncheckedValue`, it's array of checkboxes
+      if (Array.isArray(val) && val.indexOf(uncheckedValue) !== -1) {
+        // Remove `uncheckedValue` from arrays of checkboxes
+        val.splice(val.indexOf(uncheckedValue), 1)
+      } else { // Store arrays that don't contain "_unchecked", and nested objects
+        if (typeof data[i] !== 'object') {
+          data[i] = {}
+        }
+
+        // Add nested values
+        storeData(val, data[i])
+        continue
       }
-
-      // Add nested values
-      storeData(val, data[i])
-      continue
     }
-
     data[i] = val
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -236,11 +236,8 @@ var storeData = function (input, data) {
     }
 
     // Remove _unchecked from arrays of checkboxes
-    if (Array.isArray(val)) {
-      var index = val.indexOf('_unchecked')
-      if (index !== -1) {
-        val.splice(index, 1)
-      }
+    if (Array.isArray(val) && val.indexOf('_unchecked') !== -1) {
+      val.splice(val.indexOf('_unchecked'), 1)
     } else if (typeof val === 'object') {
       // Store nested objects that aren't arrays
       if (typeof data[i] !== 'object') {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -220,7 +220,7 @@ exports.matchMdRoutes = function (req, res) {
 }
 
 // Store data from POST body or GET query in session
-var storeData = function (input, data) {
+function storeData (input, data) {
   // Value we store to indicate unchecked checkboxes. See `auto-store-data.js`
   var uncheckedValue = '_unchecked'
 
@@ -256,6 +256,8 @@ var storeData = function (input, data) {
     data[i] = val
   }
 }
+
+exports.storeData = storeData
 
 // Get session default data from file
 let sessionDataDefaults = {}


### PR DESCRIPTION
Draft fix for #693.

If user stores data in array format the rest of the data in the surrounding item gets overwritten. This fork happens when we [check for checkboxes data](https://github.com/alphagov/govuk-prototype-kit/blob/master/lib/utils.js#L239). Storing data as objects as we show in our [docs](https://govuk-prototype-kit.herokuapp.com/docs/session#accessing-nested-fields-from-the-session) works fine.

This PR:
- Moves the check up in the code so that we catch the checkboxes data separately from other arrays
- Does some tidying up of the logic to make it easier to follow

We should really have automated tests in place to check if the session data is being stored correctly but as the kit currently has only very simple tests we need to think about how we're going to do the test coverage.

For now, I've added in a really simple manual way of testing whether the storage is working by setting lots of different shapes of data in `session-data-defaults.js`, amending them in a form and echoing them on the following page to check that they are retained when the values are changed. See [test page](https://govuk-prototype-kit-pr-709.herokuapp.com/docs/examples/pass-data/test1).

To do:
- [ ] Remove [manual test commit](https://github.com/alphagov/govuk-prototype-kit/commit/399dd8efdfc2de33dd8b3d97abdd6dd62ab9a35a)
- [ ] Add automated tests to check that user data of various shapes is stored correctly or create a card for adding the tests later - the test commit above shows what these tests could be. 