### PR TITLE
Turn off npm default auditing

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+audit=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Fixes:
 
 - [#697 Only ask for usage permission if TTY](https://github.com/alphagov/govuk-prototype-kit/pull/697). Thanks [zuzak](https://github.com/zuzak) for this contribution.
+- [#712 Turn off npm default auditing](https://github.com/alphagov/govuk-prototype-kit/pull/712).
 
 # 8.8.0
 


### PR DESCRIPTION
We have decide to avoid showing users of the prototype kit audit messages.

This is because a lot of the low level issues are not easy to fix, and will cause unnecessary worry.

We will prioritise the security alerts we recieve from GitHub's monitoring.

See https://github.com/alphagov/govuk-prototype-kit/issues/699 for the full discussion.

Resolves https://github.com/alphagov/govuk-prototype-kit/issues/699