### PR TITLE
Add a config value for prompting if the default port is unavailable

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -9,6 +9,10 @@ module.exports = {
   // Default port that prototype runs on
   port: '3000',
 
+  // Ask to try another port if the default is unavailable
+  // or automatically use the next available port without prompting
+  promptWhenDefaultPortIsUnavailable: 'true',
+
   // Enable or disable password protection on production
   useAuth: 'true',
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -99,10 +99,13 @@ exports.findAvailablePort = function (app, callback) {
         required: true,
         type: 'string',
         pattern: /y(es)?|no?/i,
-        message: 'Please enter y or n'
+        message: 'Please enter y or n',
+        ask: function() {
+          return config.promptWhenDefaultPortIsUnavailable === 'true'
+        }
       }], function (err, result) {
         if (err) { throw err }
-        if (result.answer.match(/y(es)?/i)) {
+        if (result.answer.match(/y(es)?/i) || config.promptWhenDefaultPortIsUnavailable === 'false') {
           // User answers yes
           port = availablePort
           fs.writeFileSync(path.join(__dirname, '/../.port.tmp'), port)


### PR DESCRIPTION
As someone regularly running multiple prototypes locally this avoids needing to interact with the prompt each time I spin up a new prototype.

---

Set a config value for asking whether to try another port if the default is unavailable.

If set to true the behaviour remains the same (defaults to true).
If set to false the prototype will automatically try the next available port.

## Example prompt outputs

### When prompting
`promptWhenDefaultPortIsUnavailable: 'true',`

```
ERROR: Port 3000 in use - you may have another prototype running.

Change to an available port? (y/n) y
Changed to port 3001
Listening on port 3001   url: http://localhost:3001
```

```
ERROR: Port 3000 in use - you may have another prototype running.

Change to an available port? (y/n) n

You can set a new default port in server.js, or by running the server with PORT=XXXX

Exit by pressing 'ctrl + c'
```

### When not prompting

`promptWhenDefaultPortIsUnavailable: 'false',`

```
ERROR: Port 3000 in use - you may have another prototype running.

Changed to port 3001
Listening on port 3001   url: http://localhost:3001
```

Based on #697 