### PR TITLE
Bump govuk-frontend from v2.9.0 to v2.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "express-writer": "0.0.4",
     "fancy-log": "^1.3.3",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^2.9.0",
+    "govuk-frontend": "^2.10.0",
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "gulp": "^4.0.0",


### PR DESCRIPTION
## Changelog

### 🆕 New features:

- Add smaller versions of radio buttons and checkboxes([PR #1125](https://github.com/alphagov/govuk-frontend/pull/1125))

### 🔧 Fixes:

- Prevent duplicate checkbox aria-describedby([PR #1265](https://github.com/alphagov/govuk-frontend/pull/1265))

https://github.com/alphagov/govuk-frontend/releases/tag/v2.10.0