### PR TITLE
Ignore travis.yml and tests in downloadable zip file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,10 @@
 # dont include the following files in the zip
 .gitattributes export-ignore
-README.md export-ignore
+.travis export-ignore
+.travis.yml export-ignore
+__tests__ export-ignore
+app.json export-ignore
 CHANGELOG.md export-ignore
 CONTRIBUTING.md export-ignore
 create-release.sh export-ignore
-travis.yml export-ignore
-.travis export-ignore
-app.json export-ignore
+README.md export-ignore


### PR DESCRIPTION
fixes #725

We should ignore `.travis.yml` and `__tests__` from the downloaded version of the kit as its unlikely that users would use the tests and they do no need our travis config file.

Test link: https://github.com/alphagov/govuk-prototype-kit/archive/ignore-files-zip.zip