### PR TITLE
Correctly close <code> tags

### DIFF
--- a/docs/views/examples/pass-data/index.html
+++ b/docs/views/examples/pass-data/index.html
@@ -127,7 +127,7 @@
     }
   ]
 }) }}
-{% endraw %}<code></pre>
+{% endraw %}</code></pre>
 
       <h3 class="govuk-heading-s">
         Using the data in Nunjucks macros (nested fields)
@@ -167,7 +167,7 @@
     }
   ]
 }) }}
-{% endraw %}<code></pre>
+{% endraw %}</code></pre>
 
       <h3 class="govuk-heading-s">
         Using the data on the server


### PR DESCRIPTION
This fixes a rendering issue on the pass data example page.

## Before

(Note the text getting larger after each of the two long examples)

![govuk-prototype-kit herokuapp com_docs_examples_pass-data](https://user-images.githubusercontent.com/121939/56793592-4519fe00-6804-11e9-907f-bec88cc3eaa0.png)

## After

![localhost_3000_docs_examples_pass-data](https://user-images.githubusercontent.com/121939/56793600-4814ee80-6804-11e9-8147-2fe79c57c338.png)
