### PR TITLE
Remove unneeded settings import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+Fixes:
+
+- [#751 Remove unnecessary settings import from the 'unbranded' stylesheet](https://github.com/alphagov/govuk-prototype-kit/pull/752)
+
 # 8.11.0
 
 Features:

--- a/app/assets/sass/unbranded.scss
+++ b/app/assets/sass/unbranded.scss
@@ -1,4 +1,3 @@
-@import "node_modules/govuk-frontend/settings/all";
 $govuk-global-styles: true;
 
 // Override the govuk-frontend font stack


### PR DESCRIPTION
As all the settings are `!default`, the expected way to override settings is to define them before doing the import.

Importing the settings _generally_ works, because we just end up redefining them before they get used. However, it does break some things – specifically, where settings rely on each other (such as the legacy mode settings, or $govuk-assets-path which is relied on by $govuk-images-path and $govuk-fonts-path).

This doesn't work correctly because e.g. $govuk-images-path gets defined before $govuk-assets-path gets overridden, which means it uses the _old_ assets path.

This caught out a user who was using this as a template, and was overriding $govuk-assets-path but not seeing the expected changes represented in $govuk-images-path.