### PR TITLE
Spike namespace changes

### DIFF
--- a/__tests__/spec/sanity-checks.js
+++ b/__tests__/spec/sanity-checks.js
@@ -54,7 +54,7 @@ describe('The Prototype Kit', () => {
           if (err) {
             done(err)
           } else {
-            assert.strictEqual('' + res.text, readFile('node_modules/govuk-frontend/all.js'))
+            assert.strictEqual('' + res.text, readFile('node_modules/govuk-frontend/govuk/all.js'))
             done()
           }
         })
@@ -69,7 +69,7 @@ describe('The Prototype Kit', () => {
           if (err) {
             done(err)
           } else {
-            assert.strictEqual('' + res.body, readFile('node_modules/govuk-frontend/assets/images/favicon.ico'))
+            assert.strictEqual('' + res.body, readFile('node_modules/govuk-frontend/govuk/assets/images/favicon.ico'))
             done()
           }
         })
@@ -91,14 +91,14 @@ describe('The Prototype Kit', () => {
     describe('misconfigured prototype kit - while upgrading kit developer did not copy over changes in /app folder', () => {
       it('should still allow known assets to be loaded from node_modules', (done) => {
         request(app)
-          .get('/node_modules/govuk-frontend/all.js')
+          .get('/node_modules/govuk-frontend/govuk/all.js')
           .expect('Content-Type', /application\/javascript; charset=UTF-8/)
           .expect(200)
           .end(function (err, res) {
             if (err) {
               done(err)
             } else {
-              assert.strictEqual('' + res.text, readFile('node_modules/govuk-frontend/all.js'))
+              assert.strictEqual('' + res.text, readFile('node_modules/govuk-frontend/govuk/all.js'))
               done()
             }
           })

--- a/app/assets/sass/unbranded.scss
+++ b/app/assets/sass/unbranded.scss
@@ -6,7 +6,7 @@ $govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", san
 // Remove canvas background colour, as is used with the GOV.UK Footer.
 $govuk-canvas-background-colour: $govuk-body-background-colour;
 
-@import "node_modules/govuk-frontend/all";
+@import "node_modules/govuk-frontend/govuk/all";
 
 // If you need to create a page as part of your journey, but without GOV.UK branding
 // See localhost:3000/docs/examples/blank-unbranded

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -38,30 +38,29 @@
           </a>
         </li>
       </ul>
+      {% from "hmcts/components/progress-bar/macro.njk" import hmctsProgressBar %}
 
-      {% from "hmcts-progress-bar/macro.njk" import hmctsProgressBar %}
-
-{{ hmctsProgressBar({
-items: [{
-label: {
-  text: 'You apply'
-},
-complete: true
-}, {
-label: {
-  text: 'Your husband/wife responds'
-},
-active: true
-}, {
-label: {
-  text: 'The court decides'
-}
-}, {
-label: {
-  text: 'Divorce finalised'
-}
-}]
-}) }}
+      {{ hmctsProgressBar({
+      items: [{
+      label: {
+        text: 'You apply'
+      },
+      complete: true
+      }, {
+      label: {
+        text: 'Your husband/wife responds'
+      },
+      active: true
+      }, {
+      label: {
+        text: 'The court decides'
+      }
+      }, {
+      label: {
+        text: 'Divorce finalised'
+      }
+      }]
+      }) }}
     </div>
 </div>
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -38,6 +38,30 @@
           </a>
         </li>
       </ul>
+
+      {% from "hmcts-progress-bar/macro.njk" import hmctsProgressBar %}
+
+{{ hmctsProgressBar({
+items: [{
+label: {
+  text: 'You apply'
+},
+complete: true
+}, {
+label: {
+  text: 'Your husband/wife responds'
+},
+active: true
+}, {
+label: {
+  text: 'The court decides'
+}
+}, {
+label: {
+  text: 'Divorce finalised'
+}
+}]
+}) }}
     </div>
 </div>
 

--- a/docs/assets/sass/docs.scss
+++ b/docs/assets/sass/docs.scss
@@ -1,4 +1,4 @@
-@import "node_modules/govuk-frontend/all";
+@import "node_modules/govuk-frontend/govuk/all";
 
 img{
   max-width: 100%;

--- a/lib/extensions/extensions.test.js
+++ b/lib/extensions/extensions.test.js
@@ -105,7 +105,7 @@ describe('extensions', () => {
     })
     it('should lookup scripts paths as file system paths', () => {
       expect(extensions.getFileSystemPaths('scripts')).toEqual(joinPaths([
-        'node_modules/govuk-frontend/all.js'
+        'node_modules/govuk-frontend/govuk/all.js'
       ]))
     })
     it('should not break when asking for an extension key which isn\'t used', function () {
@@ -282,8 +282,8 @@ describe('extensions', () => {
 
     it('should output govuk-frontend nunjucks paths as an array', () => {
       expect(extensions.getAppViews()).toEqual(joinPaths([
-        'node_modules/govuk-frontend/components',
-        'node_modules/govuk-frontend'
+        'node_modules/govuk-frontend/govuk/components',
+        'node_modules/govuk-frontend/govuk'
       ]))
     })
 
@@ -298,7 +298,7 @@ describe('extensions', () => {
       expect(extensions.getAppViews()).toEqual(joinPaths([
         'node_modules/hmcts-frontend/my-layouts',
         'node_modules/hmcts-frontend/my-components',
-        'node_modules/govuk-frontend/components',
+        'node_modules/govuk-frontend/govuk/components',
         'node_modules/govuk-frontend'
       ]))
     })
@@ -314,7 +314,7 @@ describe('extensions', () => {
         '/app/views',
         '/lib'
       ]))).toEqual(joinPaths([
-        'node_modules/govuk-frontend/components',
+        'node_modules/govuk-frontend/govuk/components',
         'node_modules/govuk-frontend',
         '/app/views',
         '/lib'
@@ -325,8 +325,8 @@ describe('extensions', () => {
       expect(extensions.getAppViews([
         '/my-new-views-directory'
       ])).toEqual([
-        path.join(rootPath, 'node_modules/govuk-frontend/components'),
-        path.join(rootPath, 'node_modules/govuk-frontend'),
+        path.join(rootPath, 'node_modules/govuk-frontend/govuk/components'),
+        path.join(rootPath, 'node_modules/govuk-frontend/govuk'),
         '/my-new-views-directory'
       ])
     })

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "npm run lint && gulp generate-assets && jest"
   },
   "dependencies": {
+    "@hmcts/frontend": "0.0.34-alpha",
     "acorn": "^6.0.5",
     "ansi-colors": "^3.2.3",
     "basic-auth": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "express-writer": "0.0.4",
     "fancy-log": "^1.3.3",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^2.12.0",
+    "govuk-frontend": "github:alphagov/govuk-frontend#fb047642",
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "gulp": "^4.0.0",

--- a/server.js
+++ b/server.js
@@ -117,8 +117,8 @@ app.use('/node_modules/govuk-frontend', express.static(path.join(__dirname, '/no
 // Set up documentation app
 if (useDocumentation) {
   var documentationViews = [
-    path.join(__dirname, '/node_modules/govuk-frontend/'),
-    path.join(__dirname, '/node_modules/govuk-frontend/components'),
+    path.join(__dirname, '/node_modules/govuk-frontend/govuk/'),
+    path.join(__dirname, '/node_modules/govuk-frontend/govuk/components'),
     path.join(__dirname, '/docs/views/'),
     path.join(__dirname, '/lib/')
   ]


### PR DESCRIPTION
To get this spike to work you need to change the @hmcts/frontend config file (node_modules/@hmcts/frontend/govuk-prototype-kit.config.json) to be:

```
{
  "assets": [
    "/hmcts/hmcts-assets/images"
  ],
  "nunjucksPaths": [
    "/"
  ],
  "sass": [
    "/hmcts/all.scss"
  ],
  "scripts": [
    "/hmcts/vendor/jquery.js",
    "/hmcts/all.js"
  ]
}
```

You also need to change the GOV.UK Frontend config file (node_modules/govuk-frontend/govuk-prototype-kit.config.json) to be:

```
{
  "nunjucksPaths": [
    "/"
  ],
  "scripts": [
    "/govuk/all.js"
  ],
  "assets": [
    "/govuk/assets"
  ],
  "sass": [
    "/govuk/all.scss"
  ]
}

```