### PR TITLE
Fix sass error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+Fixes:
+
+- [#763 Fix a Sass compilation error in the unbranded stylesheet](https://github.com/alphagov/govuk-prototype-kit/pull/763), which was introduced in 8.12.0.
+
 # 8.12.0
 
 Features:

--- a/__tests__/spec/sanity-checks.js
+++ b/__tests__/spec/sanity-checks.js
@@ -1,9 +1,17 @@
 /* eslint-env jest */
-var request = require('supertest')
-var app = require('../../server.js')
-var path = require('path')
-var fs = require('fs')
-var assert = require('assert')
+const assert = require('assert')
+const fs = require('fs')
+const path = require('path')
+const util = require('util')
+
+const glob = require('glob')
+const request = require('supertest')
+const sass = require('node-sass')
+
+const app = require('../../server.js')
+const gulpConfig = require('../../gulp/config.json')
+
+const sassRender = util.promisify(sass.render)
 
 function readFile (pathFromRoot) {
   return fs.readFileSync(path.join(__dirname, '../../' + pathFromRoot), 'utf8')
@@ -103,6 +111,14 @@ describe('The Prototype Kit', () => {
             }
           })
       })
+    })
+  })
+
+  const sassFiles = glob.sync(gulpConfig.paths.assets + '/sass/*.scss')
+
+  describe(`${gulpConfig.paths.assets}sass/`, () => {
+    it.each(sassFiles)('%s renders to CSS without errors', (file) => {
+      return sassRender({ file: file })
     })
   })
 })

--- a/app/assets/sass/unbranded.scss
+++ b/app/assets/sass/unbranded.scss
@@ -1,12 +1,24 @@
+// The unbranded stylesheet is used if you need to create pages in your
+// prototype without the GOV.UK branding.
+//
+// See localhost:3000/docs/examples/blank-unbranded
+
+// Import colour palette and applied colours so that we can use
+// $govuk-body-background-colour in our overrides below.
+// 
+// If you need to enable compatibility mode or the legacy palette, do that
+// *before* these imports.
+@import "node_modules/govuk-frontend/settings/colours-palette";
+@import "node_modules/govuk-frontend/settings/colours-applied";
+
+// Style links and paragraphs by default
 $govuk-global-styles: true;
 
 // Override the govuk-frontend font stack
 $govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
 
-// Remove canvas background colour, as is used with the GOV.UK Footer.
+// Override the canvas background colour, which is normally grey to blend with
+// the GOV.UK footer.
 $govuk-canvas-background-colour: $govuk-body-background-colour;
 
 @import "node_modules/govuk-frontend/all";
-
-// If you need to create a page as part of your journey, but without GOV.UK branding
-// See localhost:3000/docs/examples/blank-unbranded

--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
     ]
   },
   "devDependencies": {
+    "glob": "^7.1.4",
     "jest": "^24.0.1",
+    "node-sass": "^4.12.0",
     "standard": "^12.0.1",
     "supertest": "^3.0.0"
   }


### PR DESCRIPTION
The Prototype Kit is currently throwing a Sass error when trying to compile the unbranded stylesheet.

```
[10:36:10] Starting 'sass'...
Error in plugin "sass"
Message:
    app/assets/sass/unbranded.scss
Error: Undefined variable: "$govuk-body-background-colour".
        on line 7 of app/assets/sass/unbranded.scss
>> $govuk-canvas-background-colour: $govuk-body-background-colour;

   ---------------------------------^

[10:36:11] Finished 'sass' after 624 ms
```

In d901c7f we removed an import of govuk-frontend/settings/all because it caused issues for users overriding settings that relied on each other.

However, this broke the unbranded stylesheet as it refers to `$govuk-body-background-colour` which was then undefined.

Importing only the colour palette and applied colour settings solves this problem. We also document the fact that if a user (for whatever reason) wants to enable compatibility mode or use the legacy palette then they should do that before the import statements.

This also adds a test which compiles all Sass files in `assets/sass`, surfacing any compilation errors, which would have caught this.