### PR TITLE
Update to GOV.UK Frontend 3.0.0

### DIFF
--- a/__tests__/spec/sanity-checks.js
+++ b/__tests__/spec/sanity-checks.js
@@ -70,14 +70,14 @@ describe('The Prototype Kit', () => {
 
     it('should allow known assets to be loaded from node_modules', (done) => {
       request(app)
-        .get('/assets/images/favicon.ico')
+        .get('/govuk/assets/images/favicon.ico')
         .expect('Content-Type', /image\/x-icon/)
         .expect(200)
         .end(function (err, res) {
           if (err) {
             done(err)
           } else {
-            assert.strictEqual('' + res.body, readFile('node_modules/govuk-frontend/assets/images/favicon.ico'))
+            assert.strictEqual('' + res.body, readFile('node_modules/govuk-frontend/govuk/assets/images/favicon.ico'))
             done()
           }
         })
@@ -85,7 +85,7 @@ describe('The Prototype Kit', () => {
 
     it('should not expose everything', function (done) {
       request(app)
-        .get('/assets/common.js')
+        .get('/common.js')
         .expect(404)
         .end(function (err, res) {
           if (err) {

--- a/__tests__/spec/sanity-checks.js
+++ b/__tests__/spec/sanity-checks.js
@@ -55,14 +55,14 @@ describe('The Prototype Kit', () => {
   describe('extensions', () => {
     it('should allow known assets to be loaded from node_modules', (done) => {
       request(app)
-        .get('/extension-assets/govuk-frontend/all.js')
+        .get('/extension-assets/govuk-frontend/govuk/all.js')
         .expect('Content-Type', /application\/javascript; charset=UTF-8/)
         .expect(200)
         .end(function (err, res) {
           if (err) {
             done(err)
           } else {
-            assert.strictEqual('' + res.text, readFile('node_modules/govuk-frontend/all.js'))
+            assert.strictEqual('' + res.text, readFile('node_modules/govuk-frontend/govuk/all.js'))
             done()
           }
         })
@@ -99,14 +99,14 @@ describe('The Prototype Kit', () => {
     describe('misconfigured prototype kit - while upgrading kit developer did not copy over changes in /app folder', () => {
       it('should still allow known assets to be loaded from node_modules', (done) => {
         request(app)
-          .get('/node_modules/govuk-frontend/all.js')
+          .get('/node_modules/govuk-frontend/govuk/all.js')
           .expect('Content-Type', /application\/javascript; charset=UTF-8/)
           .expect(200)
           .end(function (err, res) {
             if (err) {
               done(err)
             } else {
-              assert.strictEqual('' + res.text, readFile('node_modules/govuk-frontend/all.js'))
+              assert.strictEqual('' + res.text, readFile('node_modules/govuk-frontend/govuk/all.js'))
               done()
             }
           })

--- a/__tests__/spec/sanity-checks.js
+++ b/__tests__/spec/sanity-checks.js
@@ -85,7 +85,7 @@ describe('The Prototype Kit', () => {
 
     it('should not expose everything', function (done) {
       request(app)
-        .get('/common.js')
+        .get('/govuk/assets/common.js')
         .expect(404)
         .end(function (err, res) {
           if (err) {

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -1,6 +1,9 @@
 // global styles for <a> and <p> tags
 $govuk-global-styles: true;
 
+// We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework.
+$govuk-assets-path: '/govuk/assets/';
+
 // Import GOV.UK Frontend and any extension styles if extensions have been configured
 @import "lib/extensions/extensions";
 

--- a/app/assets/sass/patterns/_step-by-step-navigation.scss
+++ b/app/assets/sass/patterns/_step-by-step-navigation.scss
@@ -5,7 +5,7 @@
 .app-step-nav-header {
   position: relative;
   padding: 10px;
-  background: govuk-colour("grey-4");
+  background: govuk-colour("light-grey", $legacy: "grey-4");
   border-top: solid 1px $govuk-border-colour;
   border-bottom: solid 1px $govuk-border-colour;
   @include govuk-media-query($from: tablet) {
@@ -297,7 +297,7 @@
 
 .app-step-nav__header {
   padding: 15px 0;
-  border-top: solid 2px govuk-colour("grey-3");
+  border-top: solid 2px govuk-colour("light-grey", $legacy: "grey-3");
 }
 
 .app-step-nav--active .app-step-nav__header {
@@ -491,7 +491,7 @@
 .app-step-nav__help {
   position: relative;
   padding: 15px 0;
-  border-top: solid 2px govuk-colour("grey-3");
+  border-top: solid 2px govuk-colour("light-grey", $legacy: "grey-3");
 }
 
 .app-step-nav__help:after {
@@ -532,7 +532,7 @@
 .app-step-nav__substep {
   position: relative;
   padding-top: 15px;
-  border-top: solid 2px govuk-colour("grey-3");
+  border-top: solid 2px govuk-colour("light-grey", $legacy: "grey-3");
 }
 
 .app-step-nav__substep:after {

--- a/app/assets/sass/unbranded.scss
+++ b/app/assets/sass/unbranded.scss
@@ -8,8 +8,8 @@
 // 
 // If you need to enable compatibility mode or the legacy palette, do that
 // *before* these imports.
-@import "node_modules/govuk-frontend/settings/colours-palette";
-@import "node_modules/govuk-frontend/settings/colours-applied";
+@import "node_modules/govuk-frontend/govuk/settings/colours-palette";
+@import "node_modules/govuk-frontend/govuk/settings/colours-applied";
 
 // Style links and paragraphs by default
 $govuk-global-styles: true;
@@ -21,4 +21,4 @@ $govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", san
 // the GOV.UK footer.
 $govuk-canvas-background-colour: $govuk-body-background-colour;
 
-@import "node_modules/govuk-frontend/all";
+@import "node_modules/govuk-frontend/govuk/all";

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -1,30 +1,30 @@
-{% extends "template.njk" %}
+{% extends "govuk/template.njk" %}
 
-{% from "accordion/macro.njk"        import govukAccordion %}
-{% from "back-link/macro.njk"        import govukBackLink %}
-{% from "breadcrumbs/macro.njk"      import govukBreadcrumbs %}
-{% from "button/macro.njk"           import govukButton %}
-{% from "character-count/macro.njk"  import govukCharacterCount %}
-{% from "checkboxes/macro.njk"       import govukCheckboxes %}
-{% from "date-input/macro.njk"       import govukDateInput %}
-{% from "details/macro.njk"          import govukDetails %}
-{% from "error-message/macro.njk"    import govukErrorMessage %}
-{% from "error-summary/macro.njk"    import govukErrorSummary %}
-{% from "fieldset/macro.njk"         import govukFieldset %}
-{% from "file-upload/macro.njk"      import govukFileUpload %}
-{% from "input/macro.njk"            import govukInput %}
-{% from "inset-text/macro.njk"       import govukInsetText %}
-{% from "panel/macro.njk"            import govukPanel %}
-{% from "phase-banner/macro.njk"     import govukPhaseBanner %}
-{% from "radios/macro.njk"           import govukRadios %}
-{% from "select/macro.njk"           import govukSelect %}
-{% from "skip-link/macro.njk"        import govukSkipLink %}
-{% from "summary-list/macro.njk"     import govukSummaryList %}
-{% from "table/macro.njk"            import govukTable %}
-{% from "tabs/macro.njk"             import govukTabs %}
-{% from "tag/macro.njk"              import govukTag %}
-{% from "textarea/macro.njk"         import govukTextarea %}
-{% from "warning-text/macro.njk"     import govukWarningText %}
+{% from "govuk/components/accordion/macro.njk"        import govukAccordion %}
+{% from "govuk/components/back-link/macro.njk"        import govukBackLink %}
+{% from "govuk/components/breadcrumbs/macro.njk"      import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk"           import govukButton %}
+{% from "govuk/components/character-count/macro.njk"  import govukCharacterCount %}
+{% from "govuk/components/checkboxes/macro.njk"       import govukCheckboxes %}
+{% from "govuk/components/date-input/macro.njk"       import govukDateInput %}
+{% from "govuk/components/details/macro.njk"          import govukDetails %}
+{% from "govuk/components/error-message/macro.njk"    import govukErrorMessage %}
+{% from "govuk/components/error-summary/macro.njk"    import govukErrorSummary %}
+{% from "govuk/components/fieldset/macro.njk"         import govukFieldset %}
+{% from "govuk/components/file-upload/macro.njk"      import govukFileUpload %}
+{% from "govuk/components/input/macro.njk"            import govukInput %}
+{% from "govuk/components/inset-text/macro.njk"       import govukInsetText %}
+{% from "govuk/components/panel/macro.njk"            import govukPanel %}
+{% from "govuk/components/phase-banner/macro.njk"     import govukPhaseBanner %}
+{% from "govuk/components/radios/macro.njk"           import govukRadios %}
+{% from "govuk/components/select/macro.njk"           import govukSelect %}
+{% from "govuk/components/skip-link/macro.njk"        import govukSkipLink %}
+{% from "govuk/components/summary-list/macro.njk"     import govukSummaryList %}
+{% from "govuk/components/table/macro.njk"            import govukTable %}
+{% from "govuk/components/tabs/macro.njk"             import govukTabs %}
+{% from "govuk/components/tag/macro.njk"              import govukTag %}
+{% from "govuk/components/textarea/macro.njk"         import govukTextarea %}
+{% from "govuk/components/warning-text/macro.njk"     import govukWarningText %}
 
 {% block head %}
   {% include "includes/head.html" %}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -1,3 +1,6 @@
+{#- We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework. -#}
+{%- set assetPath = '/govuk/assets' -%}
+
 {% extends "govuk/template.njk" %}
 
 {% from "govuk/components/accordion/macro.njk"        import govukAccordion %}

--- a/app/views/layout_unbranded.html
+++ b/app/views/layout_unbranded.html
@@ -1,4 +1,4 @@
-{% extends "template.njk" %}
+{% extends "govuk/template.njk" %}
 
 {% block headIcons %}
   <link rel="shortcut icon" href="{{ asset_path }}images/unbranded.ico?0.18.3" type="image/x-icon" />

--- a/app/views/layout_unbranded.html
+++ b/app/views/layout_unbranded.html
@@ -1,3 +1,6 @@
+{#- We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework. -#}
+{%- set assetPath = '/govuk/assets' -%}
+
 {% extends "govuk/template.njk" %}
 
 {% block headIcons %}

--- a/docs/assets/sass/docs.scss
+++ b/docs/assets/sass/docs.scss
@@ -1,4 +1,4 @@
-@import "node_modules/govuk-frontend/all";
+@import "node_modules/govuk-frontend/govuk/all";
 
 img{
   max-width: 100%;

--- a/docs/assets/sass/docs.scss
+++ b/docs/assets/sass/docs.scss
@@ -1,3 +1,6 @@
+// We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework.
+$govuk-assets-path: '/govuk/assets/';
+
 @import "node_modules/govuk-frontend/govuk/all";
 
 img{

--- a/docs/assets/sass/docs.scss
+++ b/docs/assets/sass/docs.scss
@@ -36,7 +36,7 @@ img{
   padding: govuk-spacing(3);
   overflow: auto;
   border: 1px solid $govuk-border-colour;
-  background-color: govuk-colour("grey-4");
+  background-color: govuk-colour("light-grey", $legacy: "grey-4");
   max-width: 38em;
   @include govuk-responsive-margin(5, "bottom");
 }
@@ -97,7 +97,7 @@ img{
 
   p code {
     border: 1px solid $govuk-border-colour;
-    background-color: govuk-colour("grey-4");
+    background-color: govuk-colour("light-grey", $legacy: "grey-4");
     padding: 0 govuk-spacing(2);
   }
 

--- a/docs/documentation/tips-and-tricks.md
+++ b/docs/documentation/tips-and-tricks.md
@@ -17,7 +17,7 @@ You can change the service name by editing the file '/app/config.js'.
 
 Import the header component macro place it in the `{% block header %}`and provide `navigation` items as shown below.
 
-    {% from 'header/macro.njk' import govukHeader %}
+    {% from 'govuk/components/header/macro.njk' import govukHeader %}
 
     {% block header %}
       {{ govukHeader({
@@ -47,7 +47,7 @@ Import the phase-banner component and supply tag and feedback text. The phase ba
 
 ### How to include an Alpha banner
 
-    {% from 'phase-banner/macro.njk' import govukPhaseBanner %}
+    {% from 'govuk/components/phase-banner/macro.njk' import govukPhaseBanner %}
 
     {{ govukPhaseBanner({
       tag: {
@@ -58,7 +58,7 @@ Import the phase-banner component and supply tag and feedback text. The phase ba
 
 ### How to include a Beta banner
 
-    {% from 'phase-banner/macro.njk' import govukPhaseBanner %}
+    {% from 'govuk/components/phase-banner/macro.njk' import govukPhaseBanner %}
 
     {{ govukPhaseBanner({
       tag: {

--- a/docs/documentation/using-notify.md
+++ b/docs/documentation/using-notify.md
@@ -90,7 +90,7 @@ example:
           <input class="govuk-input" id="email-address" name="emailAddress" type="text">
         </div>
 
-        <button class="govuk-button">Continue</button>
+        <button class="govuk-button" data-module="govuk-button">Continue</button>
 
       </form>
     </div>

--- a/docs/views/examples/branching/index.html
+++ b/docs/views/examples/branching/index.html
@@ -54,7 +54,7 @@
           </fieldset>
         </div>
 
-        <button class="govuk-button">Continue</button>
+        <button class="govuk-button" data-module="govuk-button">Continue</button>
 
       </form>
 

--- a/docs/views/examples/pass-data/vehicle-features.html
+++ b/docs/views/examples/pass-data/vehicle-features.html
@@ -48,7 +48,7 @@
           </fieldset>
         </div>
 
-        <button class="govuk-button">Continue</button>
+        <button class="govuk-button" data-module="govuk-button">Continue</button>
 
       </form>
 

--- a/docs/views/examples/pass-data/vehicle-registration.html
+++ b/docs/views/examples/pass-data/vehicle-registration.html
@@ -24,7 +24,7 @@
           <input class="govuk-input" id="registration-number" name="vehicle-registration" value="{{ data['vehicle-registration'] }}" type="text">
         </div>
 
-        <button class="govuk-button">Continue</button>
+        <button class="govuk-button" data-module="govuk-button">Continue</button>
 
       </form>
 

--- a/docs/views/examples/pass-data/vehicle-type.html
+++ b/docs/views/examples/pass-data/vehicle-type.html
@@ -45,7 +45,7 @@
           </fieldset>
         </div>
 
-        <button class="govuk-button">Continue</button>
+        <button class="govuk-button" data-module="govuk-button">Continue</button>
 
       </form>
 

--- a/docs/views/includes/scripts.html
+++ b/docs/views/includes/scripts.html
@@ -1,6 +1,6 @@
 <!-- Javascript -->
 <script src="/public/javascripts/jquery-1.11.3.js"></script>
-<script src="/extension-assets/govuk-frontend/all.js"></script>
+<script src="/extension-assets/govuk-frontend/govuk/all.js"></script>
 <script src="/public/javascripts/docs.js"></script>
 
 {% if useAutoStoreData %}

--- a/docs/views/layout.html
+++ b/docs/views/layout.html
@@ -1,27 +1,27 @@
-{% extends "template.njk" %}
+{% extends "govuk/template.njk" %}
 
-{% from "back-link/macro.njk"     import govukBackLink %}
-{% from "breadcrumbs/macro.njk"   import govukBreadcrumbs %}
-{% from "button/macro.njk"        import govukButton %}
-{% from "checkboxes/macro.njk"    import govukCheckboxes %}
-{% from "date-input/macro.njk"    import govukDateInput %}
-{% from "details/macro.njk"       import govukDetails %}
-{% from "error-message/macro.njk" import govukErrorMessage %}
-{% from "error-summary/macro.njk" import govukErrorSummary %}
-{% from "fieldset/macro.njk"      import govukFieldset %}
-{% from "file-upload/macro.njk"   import govukFileUpload %}
-{% from "input/macro.njk"         import govukInput %}
-{% from "inset-text/macro.njk"    import govukInsetText %}
-{% from "panel/macro.njk"         import govukPanel %}
-{% from "phase-banner/macro.njk"  import govukPhaseBanner %}
-{% from "radios/macro.njk"        import govukRadios %}
-{% from "select/macro.njk"        import govukSelect %}
-{% from "skip-link/macro.njk"     import govukSkipLink %}
-{% from "table/macro.njk"         import govukTable %}
-{% from "tabs/macro.njk"          import govukTabs %}
-{% from "tag/macro.njk"           import govukTag %}
-{% from "textarea/macro.njk"      import govukTextarea %}
-{% from "warning-text/macro.njk"  import govukWarningText %}
+{% from "govuk/components/back-link/macro.njk"     import govukBackLink %}
+{% from "govuk/components/breadcrumbs/macro.njk"   import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk"        import govukButton %}
+{% from "govuk/components/checkboxes/macro.njk"    import govukCheckboxes %}
+{% from "govuk/components/date-input/macro.njk"    import govukDateInput %}
+{% from "govuk/components/details/macro.njk"       import govukDetails %}
+{% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/fieldset/macro.njk"      import govukFieldset %}
+{% from "govuk/components/file-upload/macro.njk"   import govukFileUpload %}
+{% from "govuk/components/input/macro.njk"         import govukInput %}
+{% from "govuk/components/inset-text/macro.njk"    import govukInsetText %}
+{% from "govuk/components/panel/macro.njk"         import govukPanel %}
+{% from "govuk/components/phase-banner/macro.njk"  import govukPhaseBanner %}
+{% from "govuk/components/radios/macro.njk"        import govukRadios %}
+{% from "govuk/components/select/macro.njk"        import govukSelect %}
+{% from "govuk/components/skip-link/macro.njk"     import govukSkipLink %}
+{% from "govuk/components/table/macro.njk"         import govukTable %}
+{% from "govuk/components/tabs/macro.njk"          import govukTabs %}
+{% from "govuk/components/tag/macro.njk"           import govukTag %}
+{% from "govuk/components/textarea/macro.njk"      import govukTextarea %}
+{% from "govuk/components/warning-text/macro.njk"  import govukWarningText %}
 
 {% block head %}
   {% include "includes/head.html" %}

--- a/docs/views/layout.html
+++ b/docs/views/layout.html
@@ -1,3 +1,6 @@
+{#- We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework. -#}
+{%- set assetPath = '/govuk/assets' -%}
+
 {% extends "govuk/template.njk" %}
 
 {% from "govuk/components/back-link/macro.njk"     import govukBackLink %}

--- a/docs/views/layout_unbranded.html
+++ b/docs/views/layout_unbranded.html
@@ -1,4 +1,4 @@
-{% extends "template.njk" %}
+{% extends "govuk/template.njk" %}
 
 {% block headIcons %}
   <link rel="shortcut icon" href="{{ asset_path }}images/unbranded.ico?0.18.3" type="image/x-icon" />

--- a/docs/views/layout_unbranded.html
+++ b/docs/views/layout_unbranded.html
@@ -1,3 +1,6 @@
+{#- We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework. -#}
+{%- set assetPath = '/govuk/assets' -%}
+
 {% extends "govuk/template.njk" %}
 
 {% block headIcons %}

--- a/docs/views/templates/check-your-answers.html
+++ b/docs/views/templates/check-your-answers.html
@@ -149,7 +149,7 @@
 
         <input type="hidden" name="answers-checked" value="true">
 
-        <button type="submit" class="govuk-button">
+        <button type="submit" class="govuk-button" data-module="govuk-button">
           Accept and send
         </button>
 

--- a/docs/views/templates/question.html
+++ b/docs/views/templates/question.html
@@ -21,7 +21,7 @@
 
         <p>[See <a href="https://design-system.service.gov.uk">the GOV.UK Design System</a> for examples]</p>
 
-        <button class="govuk-button">Continue</button>
+        <button class="govuk-button" data-module="govuk-button">Continue</button>
 
       </form>
 

--- a/docs/views/templates/start-with-step-by-step.html
+++ b/docs/views/templates/start-with-step-by-step.html
@@ -30,7 +30,7 @@
       <li>do something else</li>
     </ul>
 
-    <a href="#" role="button" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8">Start now</a>
+    <a href="#" role="button" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8" data-module="govuk-button">Start now</a>
 
   </div>
 

--- a/docs/views/templates/start-with-step-by-step.html
+++ b/docs/views/templates/start-with-step-by-step.html
@@ -30,7 +30,12 @@
       <li>do something else</li>
     </ul>
 
-    <a href="#" role="button" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8" data-module="govuk-button">Start now</a>
+    <a href="#" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8" data-module="govuk-button">
+      Start now
+      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
+        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
+      </svg>
+    </a>
 
   </div>
 

--- a/docs/views/templates/start.html
+++ b/docs/views/templates/start.html
@@ -43,7 +43,7 @@
 
       <p>Registering takes around 5 minutes.</p>
 
-      <a href="#" role="button" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8">Start now</a>
+      <a href="#" role="button" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">Start now</a>
 
       <h2 class="govuk-heading-m">Before you start</h2>
 

--- a/docs/views/templates/start.html
+++ b/docs/views/templates/start.html
@@ -43,7 +43,12 @@
 
       <p>Registering takes around 5 minutes.</p>
 
-      <a href="#" role="button" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">Start now</a>
+      <a href="#" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
+        Start now
+        <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
+          <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
+        </svg>
+      </a>
 
       <h2 class="govuk-heading-m">Before you start</h2>
 

--- a/lib/extensions/extensions.js
+++ b/lib/extensions/extensions.js
@@ -132,8 +132,8 @@ setExtensionsByType()
 // The hard-coded reference to govuk-frontend allows us to soft launch without a breaking change.  After a hard launch
 // govuk-frontend assets will be served on /extension-assets/govuk-frontend
 const getPublicUrl = config => {
-  if (config.item === '/assets' && config.packageName === 'govuk-frontend') {
-    return '/assets'
+  if (config.item.endsWith('assets') && config.packageName === 'govuk-frontend') {
+    return '/govuk/assets'
   } else {
     return ['', 'extension-assets', config.packageName]
       .concat(config.item.split('/').filter(filterOutParentAndEmpty))

--- a/lib/extensions/extensions.test.js
+++ b/lib/extensions/extensions.test.js
@@ -24,7 +24,7 @@ describe('extensions', () => {
       fileSystem: {}
     }
     addFileToMockFileSystem(['package.json'], fs.readFileSync('package.json', 'utf8'))
-    addFileToMockFileSystem(['node_modules', 'govuk-frontend', 'govuk-prototype-kit.config.json'], '{"nunjucksPaths": ["/","/components"],"scripts": ["/all.js"],"assets": ["/assets"],"sass": ["/all.scss"]}')
+    addFileToMockFileSystem(['node_modules', 'govuk-frontend', 'govuk-prototype-kit.config.json'], '{"nunjucksPaths": ["/"],"scripts": ["/govuk/all.js"],"assets": ["/govuk/assets"],"sass": ["/govuk/all.scss"]}')
     setupFakeFilesystem()
     extensions.setExtensionsByType()
   })
@@ -36,7 +36,7 @@ describe('extensions', () => {
   describe('Lookup file system paths', () => {
     it('should lookup asset paths as file system paths', () => {
       expect(extensions.getFileSystemPaths('assets')).toEqual(joinPaths([
-        ['node_modules', 'govuk-frontend', 'assets']
+        ['node_modules', 'govuk-frontend', 'govuk', 'assets']
       ]))
     })
     it('should not allow traversing the file system', () => {
@@ -54,7 +54,7 @@ describe('extensions', () => {
         assets: ['/ghi', '/jkl']
       })
       expect(extensions.getFileSystemPaths('assets')).toEqual(joinPaths([
-        ['node_modules', 'govuk-frontend', 'assets'],
+        ['node_modules', 'govuk-frontend', 'govuk', 'assets'],
         ['node_modules', 'another-frontend', 'abc'],
         ['node_modules', 'another-frontend', 'def'],
         ['node_modules', 'hmrc-frontend', 'ghi'],
@@ -72,7 +72,7 @@ describe('extensions', () => {
       expect(extensions.getFileSystemPaths('assets')).toEqual(joinPaths([
         ['node_modules', 'another-frontend', 'abc'],
         ['node_modules', 'another-frontend', 'def'],
-        ['node_modules', 'govuk-frontend', 'assets'],
+        ['node_modules', 'govuk-frontend', 'govuk', 'assets'],
         ['node_modules', 'hmrc-frontend', 'ghi'],
         ['node_modules', 'hmrc-frontend', 'jkl']
       ]))
@@ -88,7 +88,7 @@ describe('extensions', () => {
       expect(extensions.getFileSystemPaths('assets')).toEqual(joinPaths([
         ['node_modules', 'hmrc-frontend', 'ghi'],
         ['node_modules', 'hmrc-frontend', 'jkl'],
-        ['node_modules', 'govuk-frontend', 'assets'],
+        ['node_modules', 'govuk-frontend', 'govuk', 'assets'],
         ['node_modules', 'another-frontend', 'abc'],
         ['node_modules', 'another-frontend', 'def']
       ]))
@@ -98,7 +98,7 @@ describe('extensions', () => {
         assets: ['/abc', '/def']
       })
       expect(extensions.getFileSystemPaths('assets')).toEqual(joinPaths([
-        ['node_modules', 'govuk-frontend', 'assets'],
+        ['node_modules', 'govuk-frontend', 'govuk', 'assets'],
         ['node_modules', 'hmrc-frontend', 'abc'],
         ['node_modules', 'hmrc-frontend', 'def']
       ]))
@@ -123,7 +123,7 @@ describe('extensions', () => {
         assets: ['/ghi', '/jkl']
       })
       expect(extensions.getPublicUrls('assets')).toEqual([
-        '/assets',
+        '/govuk/assets',
         '/extension-assets/another-frontend/abc',
         '/extension-assets/another-frontend/def',
         '/extension-assets/hmrc-frontend/ghi',
@@ -141,7 +141,7 @@ describe('extensions', () => {
       expect(extensions.getPublicUrls('assets')).toEqual([
         '/extension-assets/another-frontend/abc',
         '/extension-assets/another-frontend/def',
-        '/assets',
+        '/govuk/assets',
         '/extension-assets/hmrc-frontend/ghi',
         '/extension-assets/hmrc-frontend/jkl'
       ])
@@ -157,7 +157,7 @@ describe('extensions', () => {
       expect(extensions.getPublicUrls('assets')).toEqual([
         '/extension-assets/hmrc-frontend/ghi',
         '/extension-assets/hmrc-frontend/jkl',
-        '/assets',
+        '/govuk/assets',
         '/extension-assets/another-frontend/abc',
         '/extension-assets/another-frontend/def'
       ])
@@ -181,8 +181,8 @@ describe('extensions', () => {
       })
       expect(extensions.getPublicUrlAndFileSystemPaths('assets')).toEqual([
         {
-          publicUrl: '/assets',
-          fileSystemPath: path.join(rootPath, 'node_modules', 'govuk-frontend', 'assets')
+          publicUrl: '/govuk/assets',
+          fileSystemPath: path.join(rootPath, 'node_modules', 'govuk-frontend', 'govuk', 'assets')
         },
         {
           publicUrl: '/extension-assets/another-frontend/abc',
@@ -220,8 +220,8 @@ describe('extensions', () => {
           fileSystemPath: path.join(rootPath, 'node_modules', 'another-frontend', 'def')
         },
         {
-          publicUrl: '/assets',
-          fileSystemPath: path.join(rootPath, 'node_modules', 'govuk-frontend', 'assets')
+          publicUrl: '/govuk/assets',
+          fileSystemPath: path.join(rootPath, 'node_modules', 'govuk-frontend', 'govuk', 'assets')
         },
         {
           publicUrl: '/extension-assets/hmrc-frontend/ghi',
@@ -251,8 +251,8 @@ describe('extensions', () => {
           fileSystemPath: path.join(rootPath, 'node_modules', 'hmrc-frontend', 'jkl')
         },
         {
-          publicUrl: '/assets',
-          fileSystemPath: path.join(rootPath, 'node_modules', 'govuk-frontend', 'assets')
+          publicUrl: '/govuk/assets',
+          fileSystemPath: path.join(rootPath, 'node_modules', 'govuk-frontend', 'govuk', 'assets')
         },
         {
           publicUrl: '/extension-assets/another-frontend/abc',
@@ -282,7 +282,6 @@ describe('extensions', () => {
 
     it('should output govuk-frontend nunjucks paths as an array', () => {
       expect(extensions.getAppViews()).toEqual(joinPaths([
-        'node_modules/govuk-frontend/components',
         'node_modules/govuk-frontend'
       ]))
     })
@@ -298,7 +297,6 @@ describe('extensions', () => {
       expect(extensions.getAppViews()).toEqual(joinPaths([
         'node_modules/hmcts-frontend/my-layouts',
         'node_modules/hmcts-frontend/my-components',
-        'node_modules/govuk-frontend/components',
         'node_modules/govuk-frontend'
       ]))
     })
@@ -314,7 +312,6 @@ describe('extensions', () => {
         '/app/views',
         '/lib'
       ]))).toEqual(joinPaths([
-        'node_modules/govuk-frontend/components',
         'node_modules/govuk-frontend',
         '/app/views',
         '/lib'
@@ -325,7 +322,6 @@ describe('extensions', () => {
       expect(extensions.getAppViews([
         '/my-new-views-directory'
       ])).toEqual([
-        path.join(rootPath, 'node_modules/govuk-frontend/components'),
         path.join(rootPath, 'node_modules/govuk-frontend'),
         '/my-new-views-directory'
       ])

--- a/lib/extensions/extensions.test.js
+++ b/lib/extensions/extensions.test.js
@@ -105,7 +105,7 @@ describe('extensions', () => {
     })
     it('should lookup scripts paths as file system paths', () => {
       expect(extensions.getFileSystemPaths('scripts')).toEqual(joinPaths([
-        'node_modules/govuk-frontend/all.js'
+        'node_modules/govuk-frontend/govuk/all.js'
       ]))
     })
     it('should not break when asking for an extension key which isn\'t used', function () {
@@ -343,7 +343,7 @@ describe('extensions', () => {
 
     it('should return a list of public urls for the scripts', () => {
       expect(extensions.getAppConfig().scripts).toEqual([
-        '/extension-assets/govuk-frontend/all.js'
+        '/extension-assets/govuk-frontend/govuk/all.js'
       ])
     })
 
@@ -354,7 +354,7 @@ describe('extensions', () => {
     it('should include installed extensions', () => {
       mockExtensionConfig('my-extension', { scripts: ['/abc/def/ghi.js'] })
       expect(extensions.getAppConfig().scripts).toEqual([
-        '/extension-assets/govuk-frontend/all.js',
+        '/extension-assets/govuk-frontend/govuk/all.js',
         '/extension-assets/my-extension/abc/def/ghi.js'
       ])
     })

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "express-writer": "0.0.4",
     "fancy-log": "^1.3.3",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^2.12.0",
+    "govuk-frontend": "github:alphagov/govuk-frontend#f8599ba8",
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "gulp": "^4.0.0",


### PR DESCRIPTION
This pull request establishes the base for the upcoming Prototype Kit 9.0 release which'll include GOV.UK Frontend 3.0.0.

I followed the release notes for 3.0.0 to do this pull request.

It has a pre-release installed which will be changed when we're ready to release this properly.