### PR TITLE
Update GOV.UK Frontend 3.0.0 pre-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "express-writer": "0.0.4",
     "fancy-log": "^1.3.3",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "github:alphagov/govuk-frontend#f8599ba8",
+    "govuk-frontend": "github:alphagov/govuk-frontend#407b1787",
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "gulp": "^4.0.0",


### PR DESCRIPTION
This updates the release to as close to what we will ship to users.