### PR TITLE
Layouts now have automatic vertical spacing on the main wrapper of the page by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,14 +27,20 @@ Update every item in your task list, removing the `app-task-list__task-name` cla
 
 ### Layouts now have automatic vertical spacing on the main wrapper of the page by default
 
-By default layouts now use the `.govuk-main-wrapper--auto-spacing` modifier on the main wrapper.
+The `<main>` element in layouts now has a `.govuk-main-wrapper--auto-spacing` class by default.
 
-This will apply the correct spacing depending on whether there are any elements (such the back link, breadcrumbs or phase banner components) before the `.govuk-main-wrapper` in the `.govuk-width-container`.
+This will add the correct amount of padding above the content, depending on whether there are elements above the `<main>` element inside the `govuk-width-container` wrapper. Elements above the `<main>` element could include a back link or breadcrumb component.
 
-If you need to control the spacing manually, use can still use the `.govuk-main-wrapper--l` modifier.
+If `govuk-main-wrapper--auto-spacing` does not work for your service, you can set the correct amount of padding by adding the `.govuk-main-wrapper--l` class to your page or layout by using:
 
-```js
+ ```js
 {% set mainClasses = "govuk-main-wrapper--l" %}
+```
+
+You can also turn off the `.govuk-main-wrapper--auto-spacing` class by using:
+
+ ```js
+{% set mainClasses = "" %}
 ```
 
 # 8.12.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,21 @@ Update every item in your task list, removing the `app-task-list__task-name` cla
 
 [Pull request #770: Update the task list focus state](https://github.com/alphagov/govuk-prototype-kit/pull/770)
 
+
+## New features
+
+### Layouts now have automatic vertical spacing on the main wrapper of the page by default
+
+By default layouts now use the `.govuk-main-wrapper--auto-spacing` modifier on the main wrapper.
+
+This will apply the correct spacing depending on whether there are any elements (such the back link, breadcrumbs or phase banner components) before the `.govuk-main-wrapper` in the `.govuk-width-container`.
+
+If you need to control the spacing manually, use can still use the `.govuk-main-wrapper--l` modifier.
+
+```js
+{% set mainClasses = "govuk-main-wrapper--l" %}
+```
+
 # 8.12.1
 
 Fixes:

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -48,6 +48,8 @@
   }) }}
 {% endblock %}
 
+{% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
+
 {% if useAutoStoreData %}
   {% block footer %}
     {{ govukFooter({

--- a/docs/views/layout.html
+++ b/docs/views/layout.html
@@ -72,6 +72,8 @@
   }) }}
 {% endblock %}
 
+{% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
+
 {% block footer %}
   {{ govukFooter({
     meta: {

--- a/docs/views/templates/confirmation.html
+++ b/docs/views/templates/confirmation.html
@@ -1,8 +1,5 @@
 {% extends "layout.html" %}
 
-<!-- Adds a class to increase vertical spacing for pages without a back button -->
-{% set mainClasses = "govuk-main-wrapper--l" %}
-
 {% block pageTitle %}
   Confirmation page example
 {% endblock %}

--- a/docs/views/templates/task-list.html
+++ b/docs/views/templates/task-list.html
@@ -1,8 +1,5 @@
 {% extends "layout.html" %}
 
-<!-- Adds a class to increase vertical spacing for pages without a back button -->
-{% set mainClasses = "govuk-main-wrapper--l" %}
-
 {% block pageTitle %}
   Task list
 {% endblock %}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "express-writer": "0.0.4",
     "fancy-log": "^1.3.3",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "github:alphagov/govuk-frontend#f8599ba8",
+    "govuk-frontend": "github:alphagov/govuk-frontend#407b1787",
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "gulp": "^4.0.0",


### PR DESCRIPTION
This feature sets the vertical spacing for the main wrapper depending on what is put in the 'beforeContent' block.

This should simplify using the kit for users as for the majority of cases they will no longer need to think about when to use the large modifier.

Closes https://github.com/alphagov/govuk-prototype-kit/issues/771