### PR TITLE
Upgrade Heroku stack from cellar-14 to heroku-18

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,6 +16,7 @@
       {
         "url": "heroku/nodejs"
       }
-    ]
+    ],
+    "stack": "heroku-18"
   }
   


### PR DESCRIPTION
The reason for the update is that cellar-14 is now end of life
(https://devcenter.heroku.com/changelog-items/1603) and its recommended
that we upgrade it to [heroku-18](https://devcenter.heroku.com/articles/heroku-18-stack) to ensure it will still run on heroku.

To test/Check
- Login to heroku using the team account, visit https://dashboard.heroku.com/apps/govuk-prototype-kit-pr-775/settings (should mention heroku-18)
- open the app and all the pages work as expected