### PR TITLE
Move legacy installation instructions

### DIFF
--- a/docs/documentation/updating-the-kit.md
+++ b/docs/documentation/updating-the-kit.md
@@ -4,14 +4,6 @@
 
 If you have made any changes outside the `app` folder, this process will destroy those changes. We will try and improve the update process to avoid this, but in the meantime you will need to make a note of your changes outside `app`, and add them back after updating.
 
-## Updating from version 6 to version 7
-
-Version 7 of the GOV.UK Prototype Kit is a large change from previous versions.
-
-If you have a large old prototype, follow this [guide to backward compatibility](/docs/backwards-compatibility) which lets you update the Prototype Kit without having to rewrite all your pages at once.
-
-There is a [guide to updating your code](https://design-system.service.gov.uk/get-started/updating-your-code/) on the GOV.UK Design System.
-
 ## Steps
 
 Download the latest Prototype Kit.
@@ -131,3 +123,11 @@ npm start
 ```
 
 If you still have an error, you can [raise an issue within github](https://github.com/alphagov/govuk-prototype-kit/issues) or ask in the [Slack channel for users of the Prototype Kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit/) by providing as much information as you can about the error and the computer you are attempting to run the prototyping kit on.
+
+## Updating from version 6 to version 7 or later
+
+Version 7 of the GOV.UK Prototype Kit is a large change from previous versions.
+
+If you have a large old prototype, follow this [guide to backward compatibility](/docs/backwards-compatibility) which lets you update the Prototype Kit without having to rewrite all your pages at once.
+
+There is a [guide to updating your code](https://design-system.service.gov.uk/get-started/updating-your-code/) on the GOV.UK Design System.


### PR DESCRIPTION
This won't be relevant for the large majority of users and might confuse some, so moving it down the page.

Long term we should consider removing the v6 backwards compatibility.

Fixes https://github.com/alphagov/govuk-prototype-kit/issues/779