### PR TITLE
Rename package.json name to be clearer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "express-prototype",
-  "description": "GOVUK prototyping app in Express",
+  "name": "govuk-prototype-kit",
+  "description": "Rapidly create HTML prototypes of GOV.UK services",
   "version": "9.0.0",
   "private": true,
   "engines": {


### PR DESCRIPTION
Not a big deal since this is not published but makes support easier since this name comes up in the error logs.