### PR TITLE
Simplify install links and include release notes

### DIFF
--- a/docs/documentation/install/developer-install-instructions.md
+++ b/docs/documentation/install/developer-install-instructions.md
@@ -2,6 +2,8 @@
 
 It's built on the [Express](http://expressjs.com/) framework, and uses [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend).
 
+If you already installed a previous version of the Prototype Kit, you can [update the kit](/docs/updating-the-kit) instead.
+
 ## Requirements
 
 node.js - version 10.x.x

--- a/docs/documentation/install/introduction.md
+++ b/docs/documentation/install/introduction.md
@@ -4,6 +4,8 @@ This guide will walk you through installing and getting started with the kit. Yo
 
 Installation takes up to 30 minutes depending on how much you need to install.
 
+If you already installed a previous version of the Prototype Kit, you can [update the kit](/docs/updating-the-kit) instead.
+
 If you’re comfortable using git and the terminal, you may prefer the [developer friendly instructions](developer-install-instructions).
 
 > This guide is a work in progress. Please help [contribute](https://github.com/alphagov/govuk-prototype-kit/blob/master/CONTRIBUTING.md) to make it even better.

--- a/docs/documentation/updating-the-kit.md
+++ b/docs/documentation/updating-the-kit.md
@@ -6,7 +6,7 @@ If you have made any changes outside the `app` folder, this process will destroy
 
 ## Steps
 
-Download the latest Prototype Kit.
+[Download the latest Prototype Kit](/docs/download) and unzip it.
 
 In your project, delete everything apart from the `app` and `.git` folder.
 
@@ -17,6 +17,8 @@ Copy the config.js file from the `app` folder in the latest kit to the `app` fol
 Check `\app\assets\sass\patterns` in the latest kit for any new patterns. Copy the files over to your prototype.
 
 Check `\app\assets\sass\application.scss` in the latest kit to see if any changes have been made in the top section, above where it says `// Add extra styles here`. Copy anything new from that file to the version in your prototype, making sure you don't overwrite any extra styles you have added yourself.
+
+Check the [release notes for the latest release](https://github.com/alphagov/govuk-prototype-kit/releases/latest), for any additional changes you need to make to your prototype.
 
 ---
 
@@ -121,5 +123,7 @@ In terminal:
 ```
 npm start
 ```
+
+Check the [release notes for the latest release](https://github.com/alphagov/govuk-prototype-kit/releases/latest), for any additional changes you need to make to your prototype.
 
 If you still have an error, you can [raise an issue within github](https://github.com/alphagov/govuk-prototype-kit/issues) or ask in the [Slack channel for users of the Prototype Kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit/) by providing as much information as you can about the error and the computer you are attempting to run the prototyping kit on.

--- a/docs/views/install.html
+++ b/docs/views/install.html
@@ -36,6 +36,7 @@ Getting started - GOV.UK Prototype Kit
       <ul class="govuk-list govuk-list--bullet">
         <li><a href="/docs/install/introduction">simple install guide</a><br>for users new to Node.js, Git or the terminal</li>
         <li><a href="/docs/install/developer-install-instructions">advanced install guide</a><br>for users familiar with Node.js, Git and the terminal</li>
+        <li><a href="/docs/updating-the-kit">update the Prototype Kit</a> if you've already installed an earlier version</li>
       </ul>
 
   </div>


### PR DESCRIPTION
This pull request:

- adds an option to update your kit on the install page
- adds option to update from individual install guides
- adds release notes as part of the update guide


Fixes https://github.com/alphagov/govuk-prototype-kit/issues/784