### PR TITLE
Move backwards compatibility into advanced usage

### DIFF
--- a/docs/documentation/updating-the-kit.md
+++ b/docs/documentation/updating-the-kit.md
@@ -4,14 +4,6 @@
 
 If you have made any changes outside the `app` folder, this process will destroy those changes. We will try and improve the update process to avoid this, but in the meantime you will need to make a note of your changes outside `app`, and add them back after updating.
 
-## Updating from version 6 to version 7
-
-Version 7 of the GOV.UK Prototype Kit is a large change from previous versions.
-
-If you have a large old prototype, follow this [guide to backward compatibility](/docs/backwards-compatibility) which lets you update the Prototype Kit without having to rewrite all your pages at once.
-
-There is a [guide to updating your code](https://design-system.service.gov.uk/get-started/updating-your-code/) on the GOV.UK Design System.
-
 ## Steps
 
 Download the latest Prototype Kit.

--- a/docs/views/tutorials-and-examples.html
+++ b/docs/views/tutorials-and-examples.html
@@ -108,11 +108,13 @@
         <li>
           <a href="/docs/using-notify">Using GOV.UK Notify</a>
         </li>
-
         <li>
           <a href="https://design-system.service.gov.uk/styles/page-template/#changing-template-content">
             Template partial areas
           </a>
+        </li>
+        <li>
+          <a href="/docs/backwards-compatibility">Backwards compatibility</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Since most users do not need to use this functionality,
we want to ensure people are not confused when updating.

Closes https://github.com/alphagov/govuk-prototype-kit/issues/779