### PR TITLE
Update focus states on step-by-step navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Fixes
+
+- [Pull request #796: Update focus states on step-by-step navigation](https://github.com/alphagov/govuk-prototype-kit/pull/796).
+
 # 9.0.0 (Breaking release)
 
 This release updates GOV.UK Prototype Kit to v3.0.0 of GOV.UK Frontend.

--- a/app/assets/sass/patterns/_step-by-step-navigation.scss
+++ b/app/assets/sass/patterns/_step-by-step-navigation.scss
@@ -128,7 +128,7 @@
   padding: 0.5em 0;
   text-decoration: underline;
 
-  &:hover {
+  &:hover:not(:focus) {
     color: $govuk-link-hover-colour;
   }
 

--- a/app/assets/sass/patterns/_step-by-step-navigation.scss
+++ b/app/assets/sass/patterns/_step-by-step-navigation.scss
@@ -93,6 +93,14 @@
   background: none;
   border: 0;
   margin: 0;
+
+  &:focus {
+    @include govuk-focused-text;
+  }
+}
+
+.app-step-nav__header:hover .app-step-nav__button:not(:focus) {
+  color: $govuk-link-colour;
 }
 
 // removes extra dotted outline from buttons in Firefox
@@ -111,7 +119,6 @@
   .app-step-nav--large & {
     @include govuk-font(24, $weight: bold)
   }
-
 }
 
 .app-step-nav__button--controls {
@@ -232,6 +239,10 @@
   }
 }
 
+.app-step-nav__header:hover .app-step-nav__circle {
+  color: $govuk-link-colour;
+}
+
 .app-step-nav__circle--number {
   @include govuk-font(16, $weight: bold)
   line-height: 23px;
@@ -304,15 +315,6 @@
   cursor: pointer;
 }
 
-.app-step-nav__header:hover .app-step-nav__button,
-.app-step-nav__header:hover .app-step-nav__circle {
-  color: $govuk-link-colour;
-}
-
-.app-step-nav__header:hover .app-step-nav__toggle-link {
-  text-decoration: underline;
-}
-
 @include govuk-media-query($from: tablet) {
   .app-step-nav--large .app-step-nav__header {
     padding: 30px 0;
@@ -351,6 +353,10 @@
   color: $govuk-link-colour;
 }
 
+.app-step-nav__header:hover .app-step-nav__button:not(:focus) .app-step-nav__toggle-link {
+  text-decoration: underline;
+}
+
 .app-step-nav--large .app-step-nav__toggle-link {
   @include govuk-font(16)
   line-height: 1.2;
@@ -361,6 +367,10 @@
     font-size: 16px;
     line-height: 1.2;
   }
+}
+
+.app-step-nav__button:focus .app-step-nav__toggle-link {
+  color: inherit;
 }
 
 .app-step-nav__panel {


### PR DESCRIPTION
This pull requests updates the focus state styles for the step-by-step navigation component to use frontend v3.0

![Screen Shot 2019-08-28 at 13 49 45](https://user-images.githubusercontent.com/7225720/63856937-b0363580-c99a-11e9-8215-f6d9609000ba.png)

![Screen Shot 2019-08-28 at 13 48 58](https://user-images.githubusercontent.com/7225720/63856925-a8769100-c99a-11e9-839a-e45bf0aa956c.png)

Fixes issue #755