### PR TITLE
Fix code styling in bullets in Prototype Kit docs

### DIFF
--- a/docs/assets/sass/docs.scss
+++ b/docs/assets/sass/docs.scss
@@ -95,10 +95,11 @@ img{
     @extend .app-code;
   }
 
-  p code {
-    border: 1px solid $govuk-border-colour;
+  p code,
+  li code {
+    color: #d13118;
     background-color: govuk-colour("light-grey", $legacy: "grey-4");
-    padding: 0 govuk-spacing(2);
+    padding: 0 govuk-spacing(1);
   }
 
   // TODO: Blockquotes are likely the most semantic element to be using, update to use the inset component directly.


### PR DESCRIPTION
Prototype Kit docs pages aren't using the correct styling for code markdown in bullets.

This is how it looks at the moment on https://govuk-prototype-kit.herokuapp.com/docs/creating-routes. The code block and inline code are ok, but the bullets are missing the styling.

<img width="667" alt="Screen Shot 2019-09-25 at 09 21 03" src="https://user-images.githubusercontent.com/20596506/65582900-2d42d380-df76-11e9-84fe-e982a0249846.png">

Nick and I worked on this pull request to update the CSS to (just about) match code formatting on the Design System pages. 

