### PR TITLE
Prevent exceptions thrown from 'compatibility mode' routes from being silently caught, disabling compatibility mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Fixes
+
+- [Pull request #815: Prevent exceptions thrown from 'compatibility mode' routes from being silently caught, disabling compatibility mode](https://github.com/alphagov/govuk-prototype-kit/pull/815)
+
 # 9.3.0 (Feature release)
 
 ## New features

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 // Core dependencies
+const fs = require('fs')
 const path = require('path')
 
 // NPM dependencies
@@ -31,11 +32,9 @@ var useV6 = false
 var v6App
 var v6Routes
 
-try {
+if (fs.existsSync('./app/v6/routes.js')) {
   v6Routes = require('./app/v6/routes.js')
   useV6 = true
-} catch (e) {
-  // No routes.js in app/v6 so we can continue with useV6 false
 }
 
 const app = express()


### PR DESCRIPTION
We automatically ‘enable’ compatibility mode if the file `app/v6/routes.js` exists.

We currently do this by including it within a try/catch block, relying on the empty catch block handling the case where the file does not exist.

However this means that if any exception is encountered whilst requiring that file, we silently fail and do not enable compatibility mode.

This means that if e.g. a user’s v6 routes file includes a dependency which is not installed (which is likely if the user is trying to update their prototype, as doing so nukes any additional dependencies in their `package.json` file) then this error will not be reported and compatibility mode just won’t work.

Instead, we test for the presence of `app/v6/routes.js` – if it exists, then we require it. If any exception is encountered in doing so, it’ll be thrown as expected.

Fixes #799