### PR TITLE
Update data attribute code block to use the right quote mark

### DIFF
--- a/docs/documentation/make-first-prototype/show-users-answers.md
+++ b/docs/documentation/make-first-prototype/show-users-answers.md
@@ -25,7 +25,7 @@ Change `INPUT-ATTRIBUTE-NAME` to the value you used in the [`name` attribute on 
 1. Open the `check-your-answers.html` file in your `app/views` folder.
 2. Find the `<dt>` tag that contains the text `Name`.
 3. Change `Name` to `Number of balls you can juggle`.
-4. In the `<dd>` tag on the next line, change `Sarah Philips` to `{{ data['how-many-balls’] }}`.
+4. In the `<dd>` tag on the next line, change `Sarah Philips` to `{{ data['how-many-balls'] }}`.
 
 You must also change `<span class="govuk-visually-hidden"> name</span>` to `<span class="govuk-visually-hidden"> number of balls you can juggle</span>`.
 


### PR DESCRIPTION
Submitted as an issue through the prototype-kit channel

> I just wanted to let you know it looks like there is a mistake in the prototyping tutorial. On the 'Show the user's answers on your 'Check your answers' page' page, the instruction on 'show your answer to question 1' reads 'In the <dd> tag on the next line, change Sarah Philips to {{ data['how-many-balls’] }}.' The apostrophe after balls is not the right one. Just for those whose who are copy and pasting!