### PR TITLE
Change 'Confirmation' to 'Check your answers' page

### DIFF
--- a/docs/documentation/make-first-prototype/let-user-change-answers.md
+++ b/docs/documentation/make-first-prototype/let-user-change-answers.md
@@ -2,7 +2,7 @@
 
 ## Make the ‘Change’ links work
 
-Make the **Change** links on the ‘Confirmation’ page work by adding the right links.
+Make the **Change** links on the ‘Check your answers’ page work by adding the right links.
 
 1. In the the `<a>` tag under `{{ data['how-many-balls'] }}`, change the href attribute from `#` to `/juggling-balls`
 2. In the the `<a>` tag under `{{ data['most-impressive-trick'] }}`, change the href attribute from `#` to `/juggling-trick`


### PR DESCRIPTION
Guidance was referencing the 'Confirmation' page when it should have been referencing 'Check your answers'.