### PR TITLE
Pin version of Node to 10.15.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "lts/*"
+  - "10.15.1"
   - "8"
 
 os:


### PR DESCRIPTION
We're seeing PRs failing for the LTS of Node (12.13.0) so going to pin Node
to 10.15.1 which is what we pin nvm to in GOV.UK Frontend.

I tried to pin to Node 12 first but this kept failing:
https://travis-ci.com/alphagov/govuk-prototype-kit/builds/133218773