### PR TITLE
Update tutorial content on clearing users' data

### DIFF
--- a/docs/documentation/make-first-prototype/show-users-answers.md
+++ b/docs/documentation/make-first-prototype/show-users-answers.md
@@ -2,7 +2,7 @@
 
 If you do research with real user data, you must [open a new incognito window](https://support.google.com/chrome/answer/95464) for each research session, and close all windows before the next session.
 
-After the session is over, select the **Clear data** link at the bottom of the prototype to clear the user’s data.
+Another way to clear a user's data once the session is over, is to select the **Clear data** link at the bottom of the prototype.
 
 Check you’ve cleared the data by returning to a previously-loaded page and making sure the data is gone.
 

--- a/docs/documentation/make-first-prototype/show-users-answers.md
+++ b/docs/documentation/make-first-prototype/show-users-answers.md
@@ -1,8 +1,9 @@
 # Show the user's answers on your 'Check your answers' page
 
-If you do research with real user data, you must [open a new incognito window](https://support.google.com/chrome/answer/95464) for each research session, and close all windows before the next session.
+If you do research with real user data, you must clear a user's data before each session by either:
 
-Another way to clear a user's data once the session is over, is to select the **Clear data** link at the bottom of the prototype.
+- closing all browser windows and [opening a new incognito window](https://support.google.com/chrome/answer/95464)
+- selecting the **Clear data** link at the bottom of the prototype
 
 Check you’ve cleared the data by returning to a previously-loaded page and making sure the data is gone.
 


### PR DESCRIPTION
This pr updates the content in the tutorial on removing users' data to be clear that using an incognito window or selecting the Clear data link
will do the same thing but not both are needed.

Fixes #810