### PR TITLE
Allow Kit specific patterns to be used with the unbranded template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Fixes
 
+### Allow Kit specific patterns to be used with the unbranded template
+
+Patterns like [step by step](https://govuk-prototype-kit.herokuapp.com/docs/templates/step-by-step-navigation) and [task list](https://govuk-prototype-kit.herokuapp.com/docs/templates/task-list) now work with the [unbranded template](https://govuk-prototype-kit.herokuapp.com/docs/templates/blank-unbranded).
+
+If do not need to do anything if you're installing this version for the first time.
+
+If you're upgrading from an older version of the Kit you will need to:
+
+1. update the `app/assets/sass/unbranded.scss` Sass `@import` value from `node_modules/govuk-frontend/govuk/all` to `application`
+2. update the `app/views/layout_unbranded.html` template `extends` path from `govuk/template.njk` to `layout.html`
+
+- [#842: Allow Kit specific patterns to be used with the unbranded template](https://github.com/alphagov/govuk-prototype-kit/pull/842).
+
 - [Pull request #840: Update Kit to use latest active LTS Node.js version 12.x](https://github.com/alphagov/govuk-prototype-kit/pull/840).
 
 # 9.4.0 (Feature release)

--- a/app/assets/sass/unbranded-ie8.scss
+++ b/app/assets/sass/unbranded-ie8.scss
@@ -1,0 +1,3 @@
+$govuk-is-ie8: true;
+
+@import "unbranded";

--- a/app/assets/sass/unbranded.scss
+++ b/app/assets/sass/unbranded.scss
@@ -1,24 +1,16 @@
 // The unbranded stylesheet is used if you need to create pages in your
 // prototype without the GOV.UK branding.
 //
-// See localhost:3000/docs/examples/blank-unbranded
+// See localhost:3000/docs/templates/blank-unbranded
 
-// Import colour palette and applied colours so that we can use
-// $govuk-body-background-colour in our overrides below.
-// 
-// If you need to enable compatibility mode or the legacy palette, do that
-// *before* these imports.
-@import "node_modules/govuk-frontend/govuk/settings/colours-palette";
-@import "node_modules/govuk-frontend/govuk/settings/colours-applied";
+// Import settings first so we can override them before importing all of GOV.UK Frontend
+// If you need to enable compatibility mode or the legacy palette, do that *before* this import.
+@import "node_modules/govuk-frontend/govuk/settings/all";
 
-// Style links and paragraphs by default
-$govuk-global-styles: true;
-
-// Override the govuk-frontend font stack
+// Override the default GOV.UK Frontend font stack
 $govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
 
-// Override the canvas background colour, which is normally grey to blend with
-// the GOV.UK footer.
+// Override the canvas background colour, which is normally grey to blend with the GOV.UK footer.
 $govuk-canvas-background-colour: $govuk-body-background-colour;
 
-@import "node_modules/govuk-frontend/govuk/all";
+@import "application";

--- a/app/views/layout_unbranded.html
+++ b/app/views/layout_unbranded.html
@@ -1,24 +1,17 @@
-{#- We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework. -#}
-{%- set assetPath = '/govuk/assets' -%}
-
-{% extends "govuk/template.njk" %}
+{% extends "layout.html" %}
 
 {% block headIcons %}
   <link rel="shortcut icon" href="{{ asset_path }}images/unbranded.ico?0.18.3" type="image/x-icon" />
-  <link rel="mask-icon" href="{{ asset_path }}images/gov.uk_logotype_crown.svg?0.18.3" color="#0b0c0c">
-  <link rel="apple-touch-icon-precomposed" sizes="152x152" href="{{ asset_path }}images/apple-touch-icon-152x152.png?0.18.3">
-  <link rel="apple-touch-icon-precomposed" sizes="120x120" href="{{ asset_path }}images/apple-touch-icon-120x120.png?0.18.3">
-  <link rel="apple-touch-icon-precomposed" sizes="76x76" href="{{ asset_path }}images/apple-touch-icon-76x76.png?0.18.3">
-  <link rel="apple-touch-icon-precomposed" href="{{ asset_path }}images/apple-touch-icon-60x60.png?0.18.3">
 {% endblock %}
 
 {% block head %}
-  <link href="/public/stylesheets/unbranded.css" media="all" rel="stylesheet" type="text/css">
+  <!--[if lte IE 8]><link href="/public/stylesheets/unbranded-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if gt IE 8]><!--><link href="/public/stylesheets/unbranded.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
+
+  {% for stylesheetUrl in extensionConfig.stylesheets %}
+    <link href="{{ stylesheetUrl }}" rel="stylesheet" type="text/css" />
+  {% endfor %}
 {% endblock %}
 
 {% block header %}{% endblock %}
 {% block footer %}{% endblock %}
-
-{% block bodyEnd %}
-  {% include "includes/scripts.html" %}
-{% endblock %}

--- a/docs/views/layout_unbranded.html
+++ b/docs/views/layout_unbranded.html
@@ -1,24 +1,13 @@
-{#- We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework. -#}
-{%- set assetPath = '/govuk/assets' -%}
-
-{% extends "govuk/template.njk" %}
+{% extends "layout.html" %}
 
 {% block headIcons %}
   <link rel="shortcut icon" href="{{ asset_path }}images/unbranded.ico?0.18.3" type="image/x-icon" />
-  <link rel="mask-icon" href="{{ asset_path }}images/gov.uk_logotype_crown.svg?0.18.3" color="#0b0c0c">
-  <link rel="apple-touch-icon-precomposed" sizes="152x152" href="{{ asset_path }}images/apple-touch-icon-152x152.png?0.18.3">
-  <link rel="apple-touch-icon-precomposed" sizes="120x120" href="{{ asset_path }}images/apple-touch-icon-120x120.png?0.18.3">
-  <link rel="apple-touch-icon-precomposed" sizes="76x76" href="{{ asset_path }}images/apple-touch-icon-76x76.png?0.18.3">
-  <link rel="apple-touch-icon-precomposed" href="{{ asset_path }}images/apple-touch-icon-60x60.png?0.18.3">
 {% endblock %}
 
 {% block head %}
-  <link href="/public/stylesheets/unbranded.css" media="all" rel="stylesheet" type="text/css">
+  <!--[if lte IE 8]><link href="/public/stylesheets/unbranded-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
+  <!--[if gt IE 8]><!--><link href="/public/stylesheets/unbranded.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
 {% endblock %}
 
 {% block header %}{% endblock %}
 {% block footer %}{% endblock %}
-
-{% block bodyEnd %}
-  {% include "includes/scripts.html" %}
-{% endblock %}


### PR DESCRIPTION
Updates the unbranded template to extend the main layout, which allows users to use Prototype Kit specific patterns such as the task list and step-by-step patterns.

Closes https://github.com/alphagov/govuk-prototype-kit/issues/841