### PR TITLE
Remove Google Analytics

### DIFF
--- a/docs/views/includes/tracking_body.html
+++ b/docs/views/includes/tracking_body.html
@@ -1,4 +1,0 @@
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{gtmId}}"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->

--- a/docs/views/includes/tracking_head.html
+++ b/docs/views/includes/tracking_head.html
@@ -1,7 +1,0 @@
-<!--  Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','{{gtmId}}');</script>
-<!-- End Google Tag Manager -->

--- a/docs/views/layout.html
+++ b/docs/views/layout.html
@@ -28,16 +28,6 @@
 
 {% block head %}
   {% include "includes/head.html" %}
-  {% if doNotTrackEnabled == false and promoMode == 'true' and gtmId %}
-    {% include "includes/tracking_head.html" %}
-  {% endif %}
-{% endblock %}
-
-
-{% block bodyStart %}
-  {% if doNotTrackEnabled == false and promoMode == 'true' and gtmId %}
-    {% include "includes/tracking_body.html" %}
-  {% endif %}
 {% endblock %}
 
 {% block header %}

--- a/server.js
+++ b/server.js
@@ -58,7 +58,6 @@ var env = (process.env.NODE_ENV || 'development').toLowerCase()
 var useAutoStoreData = process.env.USE_AUTO_STORE_DATA || config.useAutoStoreData
 var useCookieSessionStore = process.env.USE_COOKIE_SESSION_STORE || config.useCookieSessionStore
 var useHttps = process.env.USE_HTTPS || config.useHttps
-var gtmId = process.env.GOOGLE_TAG_MANAGER_TRACKING_ID
 
 useHttps = useHttps.toLowerCase()
 
@@ -159,17 +158,7 @@ if (useV6) {
   app.use('/public/v6/javascripts/govuk/', express.static(path.join(__dirname, '/node_modules/govuk_frontend_toolkit/javascripts/govuk/')))
 }
 
-// Add global variable to determine if DoNotTrack is enabled.
-// This indicates a user has explicitly opted-out of tracking.
-// Therefore we can avoid injecting third-party scripts that do not respect this decision.
-app.use(function (req, res, next) {
-  // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/DNT
-  res.locals.doNotTrackEnabled = (req.header('DNT') === '1')
-  next()
-})
-
 // Add variables that are available in all views
-app.locals.gtmId = gtmId
 app.locals.asset_path = '/public/'
 app.locals.useAutoStoreData = (useAutoStoreData === 'true')
 app.locals.useCookieSessionStore = (useCookieSessionStore === 'true')


### PR DESCRIPTION
Complying with ICO guidance around cookie consent we can’t set non-essential cookies without consent being granted. In the short term then we have to disable Google Analytics as it stores cookies.

We're going to update the relevant aspects of the cookie banner / privacy policy in an additional change.

We intend on reviewing our approach in the new year.