### PR TITLE
Fix cookie banner not showing on docs website

### DIFF
--- a/server.js
+++ b/server.js
@@ -48,9 +48,8 @@ if (useV6) {
 // Set cookies for use in cookie banner.
 app.use(cookieParser())
 documentationApp.use(cookieParser())
-const handleCookies = utils.handleCookies(app)
-app.use(handleCookies)
-documentationApp.use(handleCookies)
+app.use(utils.handleCookies(app))
+documentationApp.use(utils.handleCookies(documentationApp))
 
 // Set up configuration variables
 var releaseVersion = packageJson.version


### PR DESCRIPTION
The variable to show the cookie banner was only set for the app server
not the documentationApp server.