### PR TITLE
Consistently indent docs links on homepage

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -31,11 +31,11 @@
       <h2 class="govuk-heading-m">Examples and documentation</h2>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li><a href="/docs/tutorials-and-examples">Example pages and documentation</a></li>
         <li>
-          <a href="https://design-system.service.gov.uk">
-            GOV.UK Design System
-          </a>
+          <a href="/docs/tutorials-and-examples">Example pages and documentation</a>
+        </li>
+        <li>
+          <a href="https://design-system.service.gov.uk">GOV.UK Design System</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Some participants in the training were confused by the way the two different list items are indented. Indent them consistently so that it's clear what the markup is.