### PR TITLE
Add a comma to Nunjucks nested fields code example

### DIFF
--- a/docs/views/examples/pass-data/index.html
+++ b/docs/views/examples/pass-data/index.html
@@ -140,7 +140,7 @@
   name: "vehicle1[vehicle-features]"
   fieldset: {
     legend: {
-      text: "Which of these applies to your vehicle?"
+      text: "Which of these applies to your vehicle?",
     }
   },
   hint: {


### PR DESCRIPTION
This comma fixes an error that displays when using the example as is