### PR TITLE
Remove sudo key from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,3 @@ jobs:
 
 notifications:
   email: false
-
-sudo: false


### PR DESCRIPTION
As flagged in Travis' build config validation:

> root: deprecated key sudo (The key `sudo` has no effect anymore.)