### PR TITLE
Remove 'Redirect users...' link from the final tutorial page

### DIFF
--- a/docs/documentation/make-first-prototype/link-index-page-start-page.md
+++ b/docs/documentation/make-first-prototype/link-index-page-start-page.md
@@ -5,7 +5,4 @@ You can route users from your service's index page to your start page. The index
 1. Open the `index.html` file in your `app/views` folder.
 2. Add an `<a>` tag that links to `/start`.
 
-You can now find out how to:
-
-- [redirect users based on their answers](https://govuk-prototype-kit.herokuapp.com/docs/creating-routes)
-- [publish your prototype online](https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku) to share it with your team or do user research
+You can now find out how to [publish your prototype online](https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku), so you can share it with your team or do user research.


### PR DESCRIPTION
This removes the link to 'Creating routes' from [the end of the tutorial](https://govuk-prototype-kit.herokuapp.com/docs/make-first-prototype/link-index-page-start-page), because the current linked page doesn't tell you how to redirect users based on their answers.