### PR TITLE
Add guidance on cd-ing to folder names with spaces

### DIFF
--- a/docs/documentation/install/install-the-kit.md
+++ b/docs/documentation/install/install-the-kit.md
@@ -39,14 +39,22 @@ Learning a few basic terminal commands can make using the kit much easier.
 
 You need to navigate to your prototype in the terminal. Most commands for the kit need to be run in the prototype folder.
 
-#### Mac users:
+If you're using a Mac, enter:
+
 ```
 cd ~/projects/juggling-licence-prototype
 ```
 
-#### Windows users:
+If you're using Windows, enter:
+
 ```
 cd ~/Documents/projects/juggling-licence-prototype
+```
+
+You must add quotation marks around everything after `~/` if any of your folder names contain spaces. For example:
+
+```
+cd ~/"a folder name with spaces/Documents/projects/juggling-licence-prototype"
 ```
 
 ## Install the kit

--- a/docs/documentation/install/install-the-kit.md
+++ b/docs/documentation/install/install-the-kit.md
@@ -51,7 +51,7 @@ If you're using Windows, enter:
 cd ~/Documents/projects/juggling-licence-prototype
 ```
 
-You must add quotation marks around everything after `~/` if any of your folder names contain spaces. For example:
+If any of your folder names contain spaces, you must add quotation marks around everything after `~/`. For example:
 
 ```
 cd ~/"a folder name with spaces/Documents/projects/juggling-licence-prototype"


### PR DESCRIPTION
This adds a short section to [Install the kit](https://govuk-prototype-kit.herokuapp.com/docs/install/install-the-kit.md) to clarify that you need to add quotes if you're `cd`-ing to your prototype folder and one of the parent folders has spaces.

I've also taken the Mac/Windows code examples out of their own sections, to avoid having to repeat the new content twice (once for each section).