### PR TITLE
Opt out of fund messaging

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 package-lock=false
 audit=false
+fund=false


### PR DESCRIPTION
After running npm install, npm outputs the number of packages looking for funding:

> 35 packages are looking for funding
>  run `npm fund` for details

We've seen one user confused by this, who then ran npm fund.

Given it's not really relevant for our users, disable the fund output to reduce the noise when running npm install.