### PR TITLE
Automatically rebuild node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "start": "node start.js",
     "lint": "standard",
-    "test": "npm run lint && gulp generate-assets && jest"
+    "test": "npm run lint && gulp generate-assets && jest",
+    "postinstall": "node-sass --version > /dev/null 2>&1 || (echo 'Rebuilding node-sass...' && npm rebuild node-sass)"
   },
   "dependencies": {
     "acorn": "^7.1.1",


### PR DESCRIPTION
After npm install, test that `node-sass --version` exits cleanly. If it doesn't, assume that this is because node-sass needs rebuilding, so run `npm rebuild node-sass`.