### PR TITLE
Fix security issue when running on Glitch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Fixes
+
+- [Pull request #913: Fix security issue when running on Glitch](https://github.com/alphagov/govuk-prototype-kit/pull/913)
+
 # 9.8.0 (Feature release)
 
 ## New features

--- a/lib/middleware/authentication/authentication.js
+++ b/lib/middleware/authentication/authentication.js
@@ -20,7 +20,8 @@ module.exports = function (req, res, next) {
   const config = require('../../../app/config.js')
 
   // Local Variables
-  const env = (process.env.NODE_ENV || 'development').toLowerCase()
+  const glitchEnv = (process.env.PROJECT_REMIX_CHAIN) ? 'production' : false // glitch.com
+  const env = (process.env.NODE_ENV || glitchEnv || 'development').toLowerCase()
   const useAuth = (process.env.USE_AUTH || config.useAuth).toLowerCase()
   const username = process.env.USERNAME
   const password = process.env.PASSWORD

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -113,7 +113,10 @@ exports.findAvailablePort = function (app, callback) {
 
 // Redirect HTTP requests to HTTPS
 exports.forceHttps = function (req, res, next) {
-  if (req.headers['x-forwarded-proto'] !== 'https') {
+  // Glitch returns a comma separated list for x-forwarded-proto
+  // We need the first to determine if running on https
+  var protocol = req.headers['x-forwarded-proto'].split(',').shift()
+  if (protocol !== 'https') {
     console.log('Redirecting request to https')
     // 302 temporary - this is a feature that can be disabled
     return res.redirect(302, 'https://' + req.get('Host') + req.url)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -113,9 +113,14 @@ exports.findAvailablePort = function (app, callback) {
 
 // Redirect HTTP requests to HTTPS
 exports.forceHttps = function (req, res, next) {
+
+  var protocol = req.headers['x-forwarded-proto']
   // Glitch returns a comma separated list for x-forwarded-proto
   // We need the first to determine if running on https
-  var protocol = req.headers['x-forwarded-proto'].split(',').shift()
+  if (protocol) {
+    protocol = protocol.split(',').shift()
+  }
+
   if (protocol !== 'https') {
     console.log('Redirecting request to https')
     // 302 temporary - this is a feature that can be disabled

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -113,7 +113,6 @@ exports.findAvailablePort = function (app, callback) {
 
 // Redirect HTTP requests to HTTPS
 exports.forceHttps = function (req, res, next) {
-
   var protocol = req.headers['x-forwarded-proto']
   // Glitch returns a comma separated list for x-forwarded-proto
   // We need the first to determine if running on https

--- a/server.js
+++ b/server.js
@@ -53,7 +53,8 @@ documentationApp.use(utils.handleCookies(documentationApp))
 
 // Set up configuration variables
 var releaseVersion = packageJson.version
-var env = (process.env.NODE_ENV || 'development').toLowerCase()
+var glitchEnv = (process.env.PROJECT_REMIX_CHAIN) ? 'production' : false // glitch.com
+var env = (process.env.NODE_ENV || glitchEnv || 'development').toLowerCase()
 var useAutoStoreData = process.env.USE_AUTO_STORE_DATA || config.useAutoStoreData
 var useCookieSessionStore = process.env.USE_COOKIE_SESSION_STORE || config.useCookieSessionStore
 var useHttps = process.env.USE_HTTPS || config.useHttps


### PR DESCRIPTION
The Prototype kit _mostly_ works fine when running on glitch, but has an issue.

**When you run the prototype, no username and password is required.**

The kit is meant to require a username and password when run online, so that people don't accidentally come across the prototypes.

Glitch doesn't set NODE_ENV, so the kit incorrectly thinks it's running in a local environment. This pr checks an env var [glitch uses](https://support.glitch.com/t/detect-if-app-is-running-on-glitch/3120/2), and if so, sets env to `production`.

This exposes a second bug - that the kit tries to apply https, but gets caught in a redirection loop because glitch sends a [comma separated list](https://support.glitch.com/t/x-forwarded-proto-contains-multiple-protocols/17219) for `X-Forwarded-Proto`. The accepted fix seems to be to split on `,` and use the first part (which would have no effect for most values of `X-Forwarded-Proto`).

---

I've tested this locally and on heroku and on glitch. It should cause no change locally or on heroku, but now correctly require username and password on glitch (and not crash if you set env to `production`).

If GDS doesn't want to 'officially' support glitch, I'd still suggest applying this pr - as it fixes the current security issue that Glitch prototypes incorrectly don't require a username and password.

I've avoided updating the docs about setting username and password on the assumption ['full' glitch support isn't yet wanted](https://github.com/alphagov/govuk-prototype-kit/issues/738). But if wanted, I could add a single line - which would basically say to set username and password in `.env`.
