### PR TITLE
Add docs about checking package.json when updating

### DIFF
--- a/docs/documentation/updating-the-kit.md
+++ b/docs/documentation/updating-the-kit.md
@@ -14,7 +14,7 @@
 
 6. Replace the `app/config.js` file in your prototype with the `app/config.js` file from the unzipped folder.
 
-7. Compare your new `config.js` file to the `config.js` file in the backup you made in step 1, and copy over anything you need to from the backup - for example your service name.
+7. Compare your new `config.js` file to the `config.js` file in the backup you made in step 3, and copy over anything you need to from the backup - for example your service name.
 
 8. Copy `app/assets/sass/patterns` from the unzipped folder to your prototype.
 
@@ -38,7 +38,7 @@
 
 16. [Run the kit and check it works](/docs/install/run-the-kit).
 
-If your prototype does not work, compare the new `package.json` file to the `package.json` file in the backup you made in step 1. Run `npm install PACKAGE-NAME` for each package that's missing in the new file.
+If your prototype does not work, compare the new `package.json` file to the `package.json` file in the backup you made in step 3. Run `npm install PACKAGE-NAME` for each package that's missing in the new file.
 
 ## Get help
 

--- a/docs/documentation/updating-the-kit.md
+++ b/docs/documentation/updating-the-kit.md
@@ -38,6 +38,8 @@
 
 16. [Run the kit and check it works](/docs/install/run-the-kit).
 
+If your prototype does not work, compare the new `package.json` file to the `package.json` file in the backup you made in step 1. Run `npm install PACKAGE-NAME` for each package that's missing in the new file.
+
 ## Get help
 
 You can:


### PR DESCRIPTION
This updates the docs on [updating the Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs/updating-the-kit) with guidance on checking your package.json file if your prototype does not work after updating, and installing any missing packages.

Needs 2i before publishing.