### PR TITLE
Upgrade notify client to version 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Breaking changes
+
+- [Pull request #925: Upgrade Notify client library from 4.7.2 to 5.1.0](https://github.com/alphagov/govuk-prototype-kit/pull/925). This may break existing prototypes which are using the Notify client. If you have any issues, please [contact the GOV.UK Prototype Kit team](https://design-system.service.gov.uk/get-in-touch/).
+
 ## Fixes
 
 - [Pull request #1133: Remove express-writer from package file](https://github.com/alphagov/govuk-prototype-kit/pull/1133)

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "inquirer": "^7.1.0",
     "keypather": "^3.0.0",
     "marked": "^2.0.0",
-    "notifications-node-client": "^5.0.0",
+    "notifications-node-client": "^5.1.0",
     "nunjucks": "^3.2.1",
     "portscanner": "^2.1.1",
     "require-dir": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "inquirer": "^7.1.0",
     "keypather": "^3.0.0",
     "marked": "^2.0.0",
-    "notifications-node-client": "^4.7.2",
+    "notifications-node-client": "^5.0.0",
     "nunjucks": "^3.2.1",
     "portscanner": "^2.1.1",
     "require-dir": "^1.0.0",


### PR DESCRIPTION
Notify have just released version 5.0.0 of the notifications-node-client which is a breaking change (https://github.com/alphagov/notifications-node-client/blob/master/CHANGELOG.md). 

The main documentation (https://docs.notifications.service.gov.uk/node.html#node-js-client-documentation) for how to use the node client is based on version 5.0.0 and could cause some confusion for someone using an older version of the node client as the documentation would not be accurate for someone using say version 4.7.3. We do not publish older versions of the client documentation on our main site (although it is available in git).

Therefore this commit bumps the prototype kit to use version 5.0.0 so that if a user of the prototype kit needs to look at the documentation for how to use the Notify client, it will match the version of the client they have installed.

The prototype kit at a glance appears to be one of our biggest users of the node client (in terms of repos with it installed, although I realise many of those will not actually use the Notify functionality) and some users may not be 'node experts' so hopefully removing any possible confusion here will be valuable.

## Done when

- [ ] TBC
- [x] "Details of breaking change" section below completed to help with writing release notes

## Details of breaking change

- which users are affected: Users with existing prototypes that use GOV.UK Notify and use JavaScript to examine the response or error object returned by the Notify API calls
- the change that’s been made: The interface for the response and error objects has been changed
- changes users will have to make: Change their JavaScript that examines the response or error objects
- impact of users not making those changes: They will not be able to upgrade their prototype to the latest version of the prototype kit
