### PR TITLE
Update Heroku stack to Heroku 18

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,5 +16,6 @@
     {
       "url": "heroku/nodejs"
     }
-  ]
+  ],
+  "stack": "heroku-18"
 }

--- a/app.json
+++ b/app.json
@@ -1,21 +1,20 @@
 {
-    "name": "govuk-prototype-kit",
-    "scripts": {},
-    "env": {
-      "USE_AUTH": {
-        "required": true
-      }
-    },
-    "formation": {
-      "web": {
-        "quantity": 1
-      }
-    },
-    "addons": [],
-    "buildpacks": [
-      {
-        "url": "heroku/nodejs"
-      }
-    ]
-  }
-  
+  "name": "govuk-prototype-kit",
+  "scripts": {},
+  "env": {
+    "USE_AUTH": {
+      "required": true
+    }
+  },
+  "formation": {
+    "web": {
+      "quantity": 1
+    }
+  },
+  "addons": [],
+  "buildpacks": [
+    {
+      "url": "heroku/nodejs"
+    }
+  ]
+}


### PR DESCRIPTION
The current Cedar-14 stack is end-of-life (EOL). After November 2, apps on Cedar-14 will continue to run, but may not build or receive security updates.

Changing the stack definition in app.json only changes the stack for new review apps. Once this has been tested, we’ll also need to change the stack for the current running ‘production’ app using the Heroku CLI or the Heroku Dashboard.

https://devcenter.heroku.com/articles/upgrading-to-the-latest-stack

Part of #943