### PR TITLE
Fix sass files being copied to public directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixes
 
 - [#938: Update Marked module to fix security issue](https://github.com/alphagov/govuk-prototype-kit/pull/938)
+- [#948: Fix sass files being copied to public directory](https://github.com/alphagov/govuk-prototype-kit/pull/948)
 
 # 9.10.1 (Patch release)
 

--- a/gulp/copy-assets.js
+++ b/gulp/copy-assets.js
@@ -9,19 +9,25 @@ const gulp = require('gulp')
 const config = require('./config.json')
 
 gulp.task('copy-assets', function () {
-  return gulp.src(['!' + config.paths.assets + 'sass{,/**/*}',
-    config.paths.assets + '/**'])
+  return gulp.src([
+    `${config.paths.assets}/**`,
+    `!${config.paths.assets}/sass/**`
+  ])
     .pipe(gulp.dest(config.paths.public))
 })
 
 gulp.task('copy-assets-documentation', function () {
-  return gulp.src(['!' + config.paths.docsAssets + 'sass{,/**/*}',
-    config.paths.docsAssets + '/**'])
+  return gulp.src([
+    `${config.paths.docsAssets}/**`,
+    `!${config.paths.docsAssets}/sass/**`
+  ])
     .pipe(gulp.dest(config.paths.public))
 })
 
 gulp.task('copy-assets-v6', function () {
-  return gulp.src(['!' + config.paths.v6Assets + 'sass{,/**/*}',
-    config.paths.v6Assets + '/**'])
+  return gulp.src([
+    `${config.paths.v6Assets}/**`,
+    `!${config.paths.v6Assets}/sass/**`
+  ])
     .pipe(gulp.dest(config.paths.public + '/v6'))
 })


### PR DESCRIPTION
Move the negative glob to exclude the sass directory after the broader ‘non-negative’ glob, as per the gulp documentation:

> Since globs are matched in array order, a negative glob must follow at least one non-negative glob in an array. The first finds a set of matches, then the negative glob removes a portion of those results. When excluding all files within a directory, you must add /** after the directory name, which the globbing library optimizes internally.
>
> – https://gulpjs.com/docs/en/getting-started/explaining-globs/#special-character--negative

The `{,/**/*}` expansion doesn’t seem to do anything versus including `${config.paths.assets}/**`, so simplify it to remove the expansion.

Fixes #932 