### PR TITLE
Simplify download link logic

### DIFF
--- a/docs/documentation_routes.js
+++ b/docs/documentation_routes.js
@@ -31,14 +31,24 @@ router.get('/install/:page', function (req, res) {
   res.render('install_template', { document: html })
 })
 
-// Redirect to download the current release zip from GitHub, based on the
-// version number from package.json
+// When in 'promo mode', redirect to download the current release zip from
+// GitHub, based on the version number from package.json
+//
+// Otherwise, redirect to the latest release page on GitHub, to avoid just
+// linking to the same version being run by someone referring to the copy of the
+// docs running in their kit
 router.get('/download', function (req, res) {
-  const version = require('../package.json').version
+  if (req.app.locals.promoMode === 'true') {
+    const version = require('../package.json').version
 
-  res.redirect(
-    `https://github.com/alphagov/govuk-prototype-kit/archive/v${version}.zip`
-  )
+    res.redirect(
+      `https://github.com/alphagov/govuk-prototype-kit/archive/v${version}.zip`
+    )
+  } else {
+    res.redirect(
+      'https://github.com/alphagov/govuk-prototype-kit/releases/latest'
+    )
+  }
 })
 
 // Examples - examples post here

--- a/docs/documentation_routes.js
+++ b/docs/documentation_routes.js
@@ -7,9 +7,6 @@ const express = require('express')
 const marked = require('marked')
 const router = express.Router()
 
-// Local dependencies
-const utils = require('../lib/utils.js')
-
 // Page routes
 
 // Docs index
@@ -34,10 +31,14 @@ router.get('/install/:page', function (req, res) {
   res.render('install_template', { document: html })
 })
 
-// Redirect to the zip of the latest release of the Prototype Kit on GitHub
+// Redirect to download the current release zip from GitHub, based on the
+// version number from package.json
 router.get('/download', function (req, res) {
-  var url = utils.getLatestRelease()
-  res.redirect(url)
+  const version = require('../package.json').version
+
+  res.redirect(
+    `https://github.com/alphagov/govuk-prototype-kit/archive/v${version}.zip`
+  )
 })
 
 // Examples - examples post here

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,13 +7,9 @@ const marked = require('marked')
 const path = require('path')
 const portScanner = require('portscanner')
 const inquirer = require('inquirer')
-const request = require('sync-request')
 
 // Local dependencies
 const config = require('../app/config.js')
-
-// Variables
-var releaseUrl = null
 
 // Require core and custom filters, merges to one object
 // and then add the methods to Nunjucks environment
@@ -129,38 +125,6 @@ exports.forceHttps = function (req, res, next) {
   // Mark proxy as secure (allows secure cookies)
   req.connection.proxySecure = true
   next()
-}
-
-// Synchronously get the URL for the latest release on GitHub and cache it
-exports.getLatestRelease = function () {
-  if (releaseUrl !== null) {
-    // Release URL already exists
-    console.log('Release url cached:', releaseUrl)
-    return releaseUrl
-  } else {
-    // Release URL doesn't exist
-    try {
-      console.log('Getting latest release from GitHub')
-
-      var res = request(
-        'GET',
-        'https://api.github.com/repos/alphagov/govuk-prototype-kit/releases/latest',
-        {
-          headers: { 'user-agent': 'node.js' }
-        }
-      )
-      var data = JSON.parse(res.getBody('utf8'))
-
-      // Cache releaseUrl before we return it
-      releaseUrl = `https://github.com/alphagov/govuk-prototype-kit/archive/${data.name}.zip`
-
-      console.log('Release URL is', releaseUrl)
-      return releaseUrl
-    } catch (err) {
-      console.log("Couldn't retrieve release URL")
-      return 'https://github.com/alphagov/govuk-prototype-kit/releases/latest'
-    }
-  }
 }
 
 // Try to match a request to a template, for example a request for /test


### PR DESCRIPTION
At the minute the tests hang when running on macOS:

```
Jest did not exit one second after the test run has completed.

This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
```

If you run `jest —detectOpenHandles` this seems to suggest the issue is with sync-request:

```
Jest has detected the following 1 open handle potentially keeping Jest from exiting:

  ●  PROCESSWRAP

      at start (node_modules/sync-rpc/lib/index.js:33:13)
      at sendMessage (node_modules/sync-rpc/lib/index.js:133:17)
      at createClient (node_modules/sync-rpc/lib/index.js:173:27)
      at Object.<anonymous> (node_modules/sync-request/lib/index.js:16:14)
```

`sync-request` is only used to fetch the latest version of the kit from the GitHub API. We currently have to do this becuase, [although GitHub provides a `/latest/` endpoint to link to the latest release][1], you can only link to assets if you know the asset filename, and the asset filenames are currently based on the version numbers and so not predictable unless you know the latest version number.

However, we can avoid calling the API at all by instead using the version number as defined in the package.json file. This allows us to simplify the code and remove the sync-request library entirely.

This does rely on the most recent release having been tagged (and thus the release created in GitHub) before the equivalent version is deployed to Heroku. As we have ‘Wait for CI to pass before deploy’ enabled in the Heroku settings I believe this should be the case.

[1]: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/linking-to-releases#:~:text=To%20link%20directly%20to%20a%20download%20of%20your%20latest%20release%20asset%2C%20link%20to%20%2Fowner%2Fname%2Freleases%2Flatest%2Fdownload%2Fasset-name.zip