### PR TITLE
Update 'Create Pages', add 'Open prototype in editor'

### DIFF
--- a/docs/documentation/make-first-prototype/create-pages.md
+++ b/docs/documentation/make-first-prototype/create-pages.md
@@ -1,39 +1,30 @@
 # Create pages
 
-## Open your project
+Create pages by copying template files that come with the Prototype Kit.
 
-### Mac
+### Create a start page
 
-In Atom, select **File** then **Open**. Then select your project folder.
+Copy the `start.html` file from `docs/views/templates` to `app/views`.
 
-### Windows
-
-In Atom, select **File** then **Open Folder**. Then select your project folder.
-
-## Create pages by copying templates
-
-Create pages by copying template files.
 
 To copy a file in Atom:
 
 1. Right-click a file in the folders list on the left and select **Copy**.
 2. Right-click the folder you want to copy the file into and select **Paste**.   
 
-### Create a start page
-
-Copy the `start.html` file from `docs/views/templates` to `app/views`.
-
 Preview the pages in your prototype by going to ht<span>tp</span>://localhost:3000/NAME-OF-HTML-FILE in your web browser. For example, go to [http://localhost:3000/start](http://localhost:3000/start) to preview `start.html`.
 
 #### Change the service name
 
+You'll normally edit the HTML to make changes to pages, but the service name is in a config file. This is so we can change it in one place to update it on every page in your prototype.
+
 1. Open the `config.js` file in your `app` folder.
-2. Change the value of the `serviceName` variable from `My service name` to `Apply for a juggling licence`.
+2. Change `serviceName` from `Service name goes here` to `Apply for a juggling licence`.
 3. Press Cmd+S on Mac or Ctrl+S on Windows to save your change.
 
-This will change the service name on every page.
+You must save every time you make a change to a file. In Atom, a dot appears in the tab for any file that has unsaved changes.
 
-You must save every time you make a change to a file. Your changes will automatically show in your browser when you refresh the page.
+Normally your changes will automatically show in the browser without refreshing. But for this config change, you need to refresh the page. You should see your service name change on the Start page.
 
 ### Question pages
 
@@ -49,9 +40,9 @@ Go to the following URLs to check your pages:
 - http://localhost:3000/juggling-balls
 - http://localhost:3000/juggling-trick
 
-In the ‘juggling-balls.html’ file, change the text inside the `h1` tag from `Heading or question goes here` to `How many balls can you juggle?`.
+In the `juggling-balls.html` file, change the text inside the `h1` tag from `Heading or question goes here` to `How many balls can you juggle?`.
 
-In the ‘juggling-trick.html’ file, change the text inside the `h1` tag to `What is your most impressive juggling trick?`.
+In the `juggling-trick.html` file, change the text inside the `h1` tag to `What is your most impressive juggling trick?`.
 
 ### 'Check your answers' page
 

--- a/docs/documentation/make-first-prototype/open-prototype-in-editor.md
+++ b/docs/documentation/make-first-prototype/open-prototype-in-editor.md
@@ -1,0 +1,19 @@
+# Open your prototype in your editor
+
+### Mac
+
+In Atom, select **File** then **Open**. Then select your prototype folder.
+
+### Windows
+
+In Atom, select **File** then **Open Folder**. Then select your prototype folder.
+
+## Overview of folders in the Prototype Kit
+
+ - `/app` is for your work. Inside that folder:
+  - `views` is for HTML pages
+  - `assets` is for CSS, JavaScript, images and downloadable files
+  - `routes.js` is for advanced logic - for example, if a user should go to one page or another based on their answers. We'll cover it later.
+ - `/docs/views/templates` has template pages for you to copy into your prototype
+
+[Next (create pages)](create-pages)

--- a/docs/documentation/make-first-prototype/start.md
+++ b/docs/documentation/make-first-prototype/start.md
@@ -20,11 +20,12 @@ You'll also need a code editor. You can use any editor, but the instructions in 
 
 [Install Atom code editor](https://atom.io/)
 
-[Next (create pages)](create-pages)
+[Next (open your prototype in your editor)](open-prototype-in-editor)
 
 <hr>
 
 ## Give feedback
+
 If you would like to give feedback about this tutorial, or you’ve got a question, get in touch with the GOV.UK Design System team:
 
 - on the <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/app_redirect?channel=prototype-kit" data-hsupport="slack">#prototype-kit channel on cross-government Slack</a>.

--- a/docs/views/tutorials-and-examples.html
+++ b/docs/views/tutorials-and-examples.html
@@ -56,6 +56,9 @@
           <a href="/docs/make-first-prototype/start">Build a basic prototype</a>
           <ol class="govuk-list govuk-list--number">
             <li>
+              <a href="/docs/make-first-prototype/open-prototype-in-editor">Open your prototype in your editor</a>
+            </li>
+            <li>
               <a href="/docs/make-first-prototype/create-pages">Create pages</a>
             </li>
             <li>


### PR DESCRIPTION
- Move 'Open your prototype in your editor' to its own page, add the folder overview
- Move 'copying in Atom' instructions - people find it confusing in the abstract
- Explain config a bit more, fix wrong default service name