### PR TITLE
Use govuk-frontend 3.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # 9.11.0 (Feature release)
 
+## New features
+
+- [Pull request #962: Update to GOV.UK Frontend v3.10.0](https://github.com/alphagov/govuk-prototype-kit/pull/962)
+
 ## Fixes
 
 - [Pull request #938: Update Marked module to fix security issue](https://github.com/alphagov/govuk-prototype-kit/pull/938)

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "express-writer": "0.0.4",
     "fancy-log": "^1.3.3",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^3.9.1",
+    "govuk-frontend": "^3.10.0",
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "gulp": "^4.0.0",


### PR DESCRIPTION
Updates `govuk-frontend` to the new release (`3.10.0`)