### PR TITLE
Remove Mac build from Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ node_js:
 
 os:
   - linux
-  - osx
   - windows
 
 jobs:


### PR DESCRIPTION
Building in Mac OS now requires you to purchase credits. This is blocking our builds, so we're going to temporarily turn off Mac builds to get the latest release out.

Merging https://github.com/alphagov/govuk-prototype-kit/issues/952 is a more long-term fix for this problem, we'll do this asap once the release is out.