### PR TITLE
Make sass errors stop Gulp to make them clearer

### DIFF
--- a/gulp/sass.js
+++ b/gulp/sass.js
@@ -24,7 +24,7 @@ gulp.task('sass-extensions', function (done) {
 gulp.task('sass', function () {
   return gulp.src(config.paths.assets + '/sass/*.scss')
     .pipe(sourcemaps.init())
-    .pipe(sass({ outputStyle: 'expanded' }).on('error', sass.logError))
+    .pipe(sass({ outputStyle: 'expanded' }))
     .pipe(sourcemaps.write())
     .pipe(gulp.dest(config.paths.public + '/stylesheets/'))
 })

--- a/start.js
+++ b/start.js
@@ -73,7 +73,13 @@ function runGulp () {
   gulp.stderr.pipe(process.stderr)
   process.stdin.pipe(gulp.stdin)
 
-  gulp.on('exit', function (code) {
-    console.log('gulp exited with code ' + code.toString())
+  gulp.on('exit', function (code, signal) {
+    if (code) {
+      console.log('gulp exited with code ' + code.toString())
+      process.exit(0)
+    } else {
+      console.log('gulp exited with signal ' + signal.toString())
+      process.exit(0)
+    }
   })
 }


### PR DESCRIPTION
attempt to fix #295 

on a sass error, the Prototype Kit now exits (no prototype will appear in the browser)

please note there are 2 other approaches discussed in the comments below

it would be nice to clean up the error, I think we just need `messageFormatted`, it currently looks like this:

<img width="831" alt="screenshot: sass error written to terminal and the kit exits" src="https://user-images.githubusercontent.com/1132904/104027838-e0f9c200-51bf-11eb-9ff1-a6d4a07e9efe.png">
