### PR TITLE
Update listen-on-port console message

### DIFF
--- a/listen-on-port.js
+++ b/listen-on-port.js
@@ -16,7 +16,7 @@ utils.findAvailablePort(server, function (port) {
     console.log('Listening on port ' + port + '   url: http://localhost:' + port)
     server.listen(port)
   } else {
-    const newPort = port - 50;
+    const newPort = port - 50
     console.log('Listening on port ' + newPort + '   url: http://localhost:' + newPort)
     server.listen(newPort, function () {
       browserSync({

--- a/listen-on-port.js
+++ b/listen-on-port.js
@@ -12,13 +12,15 @@ var useBrowserSync = config.useBrowserSync.toLowerCase()
 var env = (process.env.NODE_ENV || 'development').toLowerCase()
 
 utils.findAvailablePort(server, function (port) {
-  console.log('Listening on port ' + port + '   url: http://localhost:' + port)
   if (env === 'production' || useBrowserSync === 'false') {
+    console.log('Listening on port ' + port + '   url: http://localhost:' + port)
     server.listen(port)
   } else {
-    server.listen(port - 50, function () {
+    const newPort = port - 50;
+    console.log('Listening on port ' + newPort + '   url: http://localhost:' + newPort)
+    server.listen(newPort, function () {
       browserSync({
-        proxy: 'localhost:' + (port - 50),
+        proxy: 'localhost:' + (newPort),
         port: port,
         ui: false,
         files: ['public/**/*.*', 'app/views/**/*.*'],


### PR DESCRIPTION
The default [config](https://github.com/alphagov/govuk-prototype-kit/blob/master/app/config.js) has `useBrowserSync: 'true'`, which when developing locally results in the current log giving you incorrect port.