### PR TITLE
Import the cookie banner macro as part of the layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Fixes
+
+- [Pull request #987: Import the cookie banner macro as part of the layout](https://github.com/alphagov/govuk-prototype-kit/pull/987)
+
 # 9.12.0 (Feature release)
 
 ## New features

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -9,6 +9,7 @@
 {% from "govuk/components/button/macro.njk"              import govukButton %}
 {% from "govuk/components/character-count/macro.njk"     import govukCharacterCount %}
 {% from "govuk/components/checkboxes/macro.njk"          import govukCheckboxes %}
+{% from "govuk/components/cookie-banner/macro.njk"       import govukCookieBanner %}
 {% from "govuk/components/date-input/macro.njk"          import govukDateInput %}
 {% from "govuk/components/details/macro.njk"             import govukDetails %}
 {% from "govuk/components/error-message/macro.njk"       import govukErrorMessage %}


### PR DESCRIPTION
Import the cookie banner so that users can include it in the prototype kit without needing to import it themselves, as we tell them to do in the [‘Getting Started’ documentation in the Design System](design-system.service.gov.uk/get-started/prototyping/#:~:text=When%20using%20Nunjucks%20macros%20in%20the%20Prototype%20Kit%20leave%20out%20the%20first%20line%20that%20starts%20with%20%7B%25%20from%20....)