### PR TITLE
Update marked to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "gulp-sourcemaps": "^2.6.0",
     "inquirer": "^7.1.0",
     "keypather": "^3.0.0",
-    "marked": "^1.2.0",
+    "marked": "^2.0.0",
     "notifications-node-client": "^4.7.2",
     "nunjucks": "^3.2.1",
     "portscanner": "^2.1.1",


### PR DESCRIPTION
Marked 1.2.0 had a security vulnerability which was [flagged by dependabot.](https://github.com/alphagov/govuk-prototype-kit/security/dependabot/package.json/marked/open) This was patched in v2.0.0.

This is a major update - I've run the tests and checked a few pages of the prototype kit locally and it seemed to work as expected.