### PR TITLE
Allow Node 15 to be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Fixes
 
 - [Pull request #987: Import the cookie banner macro as part of the layout](https://github.com/alphagov/govuk-prototype-kit/pull/987)
+- [Pull request #995: Allow Node 15 to be used](https://github.com/alphagov/govuk-prototype-kit/pull/995)
 
 # 9.12.0 (Feature release)
 

--- a/docs/documentation/install/requirements.md
+++ b/docs/documentation/install/requirements.md
@@ -13,7 +13,7 @@ GDS staff can install the software themselves with the Self Service app.
 
 You'll need:
 
-* Node.js 14.x.x (if you’re using a Mac, see below)
+* Node.js 14.x.x
 * Git Bash (if you're using Windows, see below)
 
 ## Terminal
@@ -23,10 +23,6 @@ You'll need a terminal application to install, start and stop the kit. Using a t
 ### Mac users
 
 Macs come with `Terminal.app`. It’s located in the `Utilities` folder in the `Applications` folder. You can also find it using spotlight (magnifying glass icon in the top right) and typing 'terminal'.
-
-#### M1 Chip
-
-If you have a new Mac with the M1 Chip, you will need to use Node.js version 15.
 
 ### Windows users
 

--- a/docs/documentation/install/requirements.md
+++ b/docs/documentation/install/requirements.md
@@ -13,7 +13,7 @@ GDS staff can install the software themselves with the Self Service app.
 
 You'll need:
 
-* Node.js 14.x.x
+* Node.js 14.x.x (if you’re using a Mac, see below)
 * Git Bash (if you're using Windows, see below)
 
 ## Terminal
@@ -23,6 +23,10 @@ You'll need a terminal application to install, start and stop the kit. Using a t
 ### Mac users
 
 Macs come with `Terminal.app`. It’s located in the `Utilities` folder in the `Applications` folder. You can also find it using spotlight (magnifying glass icon in the top right) and typing 'terminal'.
+
+#### M1 Chip
+
+If you have a new Mac with the M1 Chip, you will need to use Node.js version 15.
 
 ### Windows users
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "9.12.1",
   "private": true,
   "engines": {
-    "node": ">=10.0.0 <15.0.0"
+    "node": ">=10.0.0 <16.0.0"
   },
   "scripts": {
     "start": "node start.js",


### PR DESCRIPTION
This upgrades the list of supported Node versions to include v15. This is useful as currently only version 15 is supported by Macs using the new M1 ARM chips (see https://github.com/nodejs/node/issues/36161).

I've been running it locally using version 15 fine, and have [upgraded our prototype](https://github.com/DFE-Digital/apply-for-teacher-training-prototype/pull/454) to node 15 running on Heroku.