### PR TITLE
Fix: make documentation links relative

### DIFF
--- a/docs/documentation/make-first-prototype/link-index-page-start-page.md
+++ b/docs/documentation/make-first-prototype/link-index-page-start-page.md
@@ -5,4 +5,4 @@ You can route users from your service's index page to your start page. The index
 1. Open the `index.html` file in your `app/views` folder.
 2. Add an `<a>` tag that links to `/start`.
 
-You can now find out how to [publish your prototype online](https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku), so you can share it with your team or do user research.
+You can now find out how to [publish your prototype online](/docs/publishing-on-heroku), so you can share it with your team or do user research.

--- a/docs/documentation/make-first-prototype/make-first-prototype.md
+++ b/docs/documentation/make-first-prototype/make-first-prototype.md
@@ -9,7 +9,7 @@ This tutorial shows you how to prototype a fictional 'Apply for a juggling licen
 It will take up to 60 minutes to finish this tutorial, after you install the Prototype Kit.
 
 ## Before you start
-Before you start, you must [install and run the GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs/install/introduction).
+Before you start, you must [install and run the GOV.UK Prototype Kit](/docs/install/introduction).
 
 [Next (create pages)](create-pages)
 

--- a/docs/documentation/updating-the-kit.md
+++ b/docs/documentation/updating-the-kit.md
@@ -30,7 +30,7 @@
 
     If your prototype has not been updated for a long time, you should also follow any guidance in [release notes](https://github.com/alphagov/govuk-prototype-kit/releases) between the version you're updating from and the latest version. You can find out the version you're updating from in the `VERSION.txt` file in your backup folder.
 
-14. In your [terminal](https://govuk-prototype-kit.herokuapp.com/docs/install/requirements.md#terminal), `cd` to your prototype folder.
+14. In your [terminal](/docs/install/requirements.md#terminal), `cd` to your prototype folder.
 
 15. Run `npm install`.
 


### PR DESCRIPTION
When reviewing #999 I was momentarily thrown by one of the links in the documentation going to the live version, rather than staying within the review app. This fixes that, and 2 other instances.