### PR TITLE
Remove 'new' section from home page as it is no longer new

### DIFF
--- a/docs/views/index.html
+++ b/docs/views/index.html
@@ -22,23 +22,6 @@ GOV.UK Prototype Kit
 
   <hr class="govuk-section-break govuk-section-break--visible">
 
-  <div class="govuk-grid-row govuk-!-margin-top-6 govuk-!-margin-bottom-4">
-    <div class="govuk-grid-column-two-thirds">
-
-      <h2 class="govuk-heading-m">What’s new</h2>
-      <p>
-        From version 7 the GOV.UK Prototype Kit uses the new GOV.UK Design System which replaces GOV.UK Elements.
-      </p>
-
-      <p>
-        Visit the <a href="https://design-system.service.gov.uk">GOV.UK Design System</a> for guidance and examples.
-      </p>
-
-    </div>
-  </div>
-
-  <hr class="govuk-section-break govuk-section-break--visible">
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third govuk-!-margin-top-6">
 


### PR DESCRIPTION
We added a section telling people about the move from Elements to the Design System. I don't think that's necessary any more as its been a few years