### PR TITLE
Update link styles

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -1,5 +1,6 @@
 // global styles for <a> and <p> tags
 $govuk-global-styles: true;
+$govuk-new-link-styles: true;
 
 // We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework.
 $govuk-assets-path: '/govuk/assets/';

--- a/app/assets/sass/patterns/_step-by-step-nav.scss
+++ b/app/assets/sass/patterns/_step-by-step-nav.scss
@@ -94,10 +94,10 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
 
 .app-step-nav__button--controls {
   @include step-nav-font(14, $line-height: 1);
+  @include govuk-link-common;
   position: relative;
   z-index: 1; // this and relative position stops focus outline underlap with border of accordion
   padding: .5em 0;
-  text-decoration: underline;
 
   .app-step-nav--large & {
     @include step-nav-font(14, $tablet-size: 16, $line-height: 1);
@@ -271,7 +271,8 @@ $top-border: solid 2px govuk-colour("mid-grey", $legacy: "grey-3");
     }
 
     .app-step-nav__toggle-link {
-      text-decoration: underline;
+      @include govuk-link-common;
+      @include govuk-link-hover-decoration;
     }
   }
 

--- a/docs/assets/sass/docs.scss
+++ b/docs/assets/sass/docs.scss
@@ -1,6 +1,8 @@
 // We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework.
 $govuk-assets-path: '/govuk/assets/';
 
+$govuk-new-link-styles: true;
+
 @import "node_modules/govuk-frontend/govuk/all";
 
 img{


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-prototype-kit/issues/1012

**NOTE: This PR currently points at a pre-release of GOV.UK Frontend. This commit should be removed and replaced by a separate PR to bump GOV.UK Frontend to v3.12.0 before this PR is merged.**

## What
Update the prototype kit to opt into the new link styles.
Update the step-by-step navigation template to make use of the new link styles.

## Why
The new link and hover styles will be opt-in until the next major release of GOV.UK Frontend. However, we'd like the prototype kit to take advantage of the new styles when 3.12.0 is released in order to present the most up-to-date version of GOV.UK Frontend.