### PR TITLE
Add info about M1 Macs to Kit install guidance

### DIFF
--- a/docs/documentation/install/requirements.md
+++ b/docs/documentation/install/requirements.md
@@ -2,6 +2,7 @@
 
 The kit runs on Mac, Windows and Linux. At a minimum you’ll need Node.js (install instructions below) and a web browser.
 
+If you're using an M1 Mac, you might experience issues when you run the Prototype Kit. To get support, please [contact the Design System team](https://design-system.service.gov.uk/get-in-touch/).
 
 ## Software you need
 

--- a/docs/documentation/install/requirements.md
+++ b/docs/documentation/install/requirements.md
@@ -2,7 +2,7 @@
 
 The GOV.UK Prototype Kit runs on Mac, Windows and Linux. At a minimum you’ll need Node.js (install instructions below) and a web browser.
 
-If you're using an M1 Mac, you might experience issues when you run the Prototype Kit. To get support, please [contact the Design System team](https://design-system.service.gov.uk/get-in-touch/).
+If you're using an M1 Mac ([certain Macs launched in 2020 and later](https://en.wikipedia.org/wiki/Apple_M1#Products_that_include_the_Apple_M1)), you might experience issues when you run the Prototype Kit. To get support, please [contact the Design System team](https://design-system.service.gov.uk/get-in-touch/).
 
 ## Software you need
 

--- a/docs/documentation/install/requirements.md
+++ b/docs/documentation/install/requirements.md
@@ -1,6 +1,6 @@
 # Requirements
 
-The kit runs on Mac, Windows and Linux. At a minimum you’ll need Node.js (install instructions below) and a web browser.
+The GOV.UK Prototype Kit runs on Mac, Windows and Linux. At a minimum you’ll need Node.js (install instructions below) and a web browser.
 
 If you're using an M1 Mac, you might experience issues when you run the Prototype Kit. To get support, please [contact the Design System team](https://design-system.service.gov.uk/get-in-touch/).
 


### PR DESCRIPTION
This PR updates the Kit guidance to:
- explain that M1 Macs have issues running the Kit
- advise users to contact us if they need support