### PR TITLE
Rename default branch to `main`

### DIFF
--- a/.github/workflows/create-release-tag.yaml
+++ b/.github/workflows/create-release-tag.yaml
@@ -1,6 +1,6 @@
 # Create release tag
 #
-# If package.json is updated on the master branch, check to see if there is a
+# If package.json is updated on the main branch, check to see if there is a
 # tag matching the version in package.json.
 #
 # If there is not:
@@ -12,7 +12,7 @@
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths: [package.json]
 
 name: Create release tag

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,5 +47,5 @@ branches.
 
 ### Commit hygiene
 
-Please see our [git style guide](https://github.com/alphagov/styleguides/blob/master/git.md)
+Please see our [git style guide](https://gds-way.cloudapps.digital/standards/source-code.html#commit-messages)
 which describes how we prefer git history and commit messages to read.

--- a/docs/documentation/install/introduction.md
+++ b/docs/documentation/install/introduction.md
@@ -8,7 +8,7 @@ If you already installed a previous version of the Prototype Kit, you can [updat
 
 If you’re comfortable using git and the terminal, you may prefer the [developer friendly instructions](developer-install-instructions).
 
-> This guide is a work in progress. Please help [contribute](https://github.com/alphagov/govuk-prototype-kit/blob/master/CONTRIBUTING.md) to make it even better.
+> This guide is a work in progress. Please help [contribute](https://github.com/alphagov/govuk-prototype-kit/blob/main/CONTRIBUTING.md) to make it even better.
 
 ## Introduction
 

--- a/docs/documentation/publishing-on-heroku-terminal.md
+++ b/docs/documentation/publishing-on-heroku-terminal.md
@@ -61,9 +61,12 @@ Make sure any changes you've made to your prototype have been committed to git.
 
 From your prototype folder:
 ```
-git push heroku master
+git push heroku main
 ```
 This will push your work to Heroku. Deploying may take a minute or so.
+
+In this example, `main` is the name of the default branch for the repo. So you
+may need to run the command with your own default branch name instead of `main`.
 
 ## 8) View your prototype on the web
 

--- a/docs/documentation/setting-up-git.md
+++ b/docs/documentation/setting-up-git.md
@@ -75,7 +75,7 @@ git commit -m "First commit"
 ```
 The message you put in the speech marks should be descriptive of the changes you are committing. This will help in the future if you or someone else needs to look back at your changes and know why you made them.
 
-More information on [writing good commit messages](https://github.com/alphagov/styleguides/blob/master/git.md#commit-messages) is in the GDS styleguide.
+More information on [writing good commit messages](https://gds-way.cloudapps.digital/standards/source-code.html#commit-messages) is in The GDS Way.
 
 ## 5) Check Git status again
 

--- a/docs/documentation/setting-up-git.md
+++ b/docs/documentation/setting-up-git.md
@@ -35,6 +35,11 @@ git init
 
 This sets up git to track the files in your prototype folder.
 
+The default branch created by the `git init` command is called `master`, which is a [potentially offensive term](https://sfconservancy.org/news/2020/jun/23/gitbranchname/). Rename the current branch to `main` instead:
+```
+git branch -M main
+```
+
 ## 3) Check the Git status
 
 It’s a good idea to run `git status` frequently. This tells you the current status - for example, if you made changes to files that haven’t been committed.

--- a/internal_docs/releasing.md
+++ b/internal_docs/releasing.md
@@ -1,6 +1,6 @@
 # Releasing a new version of the prototype kit
 
-1. Checkout master and pull latest changes.
+1. Checkout main and pull latest changes.
 
 2. Decide on a new version number. Do this by looking at the [current "Unreleased" CHANGELOG](../CHANGELOG.md) changes and updating the previous release number depending on the kind of entries:
 

--- a/internal_docs/releasing.md
+++ b/internal_docs/releasing.md
@@ -29,7 +29,7 @@ v8.0.0 // After implementing backwards incompatible changes
 
 3. Checkout a new branch called release-[new version number].
 
-4. Update the version number in [VERSION.txt](https://github.com/alphagov/govuk-prototype-kit/blob/master/VERSION.txt) and update "version" in [package.json](https://github.com/alphagov/govuk-prototype-kit/blob/master/package.json#L4).
+4. Update the version number in [VERSION.txt](/VERSION.txt) and update "version" in [package.json](/package.json#L4).
 
 5. Commit your changes and open a new pull request on GitHub - copy the relevant Changelog section into the description.
 


### PR DESCRIPTION
Part of #989.

## What

Replace instances of "master" with "main" in preparation for the default branch renaming work

## Why

Many communities on GitHub are considering renaming the default branch name of their repository from master, as this terminology can be offensive. Statements and guidance have been published by Git [here](https://sfconservancy.org/news/2020/jun/23/gitbranchname/) and GitHub [here](https://github.com/github/renaming).

New GitHub repositories use `main` as the name for the default branch, so it makes sense that we should follow this convention, as well as matching what other teams within GDS are doing so we are consistent.
We are renaming the default branch to `main`, we need to update documentation and tooling to reflect this.