### PR TITLE
Add internal documentation on deployments

### DIFF
--- a/internal_docs/deploys.md
+++ b/internal_docs/deploys.md
@@ -1,0 +1,12 @@
+# Deploys
+
+This repo uses [Heroku automatic deploys] to deploy the latest code in the
+`main` branch directly to https://govuk-prototype-kit.herokuapp.com/.
+
+Deployments are configured manually using the dashboard for the
+[govuk-prototype-kit pipeline]. To check the configuration or any deployment
+issues, log into Heroku using the [team credentials].
+
+[Heroku automatic deploys]: https://devcenter.heroku.com/articles/github-integration#automatic-deploys
+[govuk-prototype-kit pipeline]: https://dashboard.heroku.com/pipelines/f0879aaf-21f5-4430-a1d5-7adc4740a066
+[team credentials]: https://github.com/alphagov/design-system-team-credentials/tree/main/heroku


### PR DESCRIPTION
We use a Heroku pipeline to automatically deploy to govuk-prototype-kit.herokuapp.com, and the pipeline is configured manually and not documented anywhere.

This commit adds documentation to the internal docs in this repo, so know where to look when there are issues, and what the configuration should be.