### PR TITLE
Update tutorials page about use of step-by-step

### DIFF
--- a/docs/views/tutorials-and-examples.html
+++ b/docs/views/tutorials-and-examples.html
@@ -190,11 +190,7 @@
       </ul>
 
       <p>
-        Your prototype folder also contains the following page templates.
-      </p>
-      <p>
-        You cannot adjust the design of these pages, but you can use them to help
-        you prototype realistic journeys connecting your service with GOV.UK content.
+        Your prototype folder also contains the following page templates:
       </p>
 
       <ul class="govuk-list govuk-list--bullet">
@@ -216,12 +212,25 @@
       </ul>
 
       <p>
+        You cannot adjust the design of these pages, but you can use them to help
+        you prototype realistic journeys connecting your service with GOV.UK content.
+      </p>
+      <p>
         Read more about how to get a <a href="https://design-system.service.gov.uk/patterns/start-pages/">
         Start page</a> or <a href="https://design-system.service.gov.uk/patterns/step-by-step-navigation/">
         Step by step navigation</a> for your service in the GOV.UK Design System.
       </p>
     </div>
   </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h3 class="govuk-heading-m">When not to use step by step navigation</h3>
+      <p>
+      Remember that step by step navigation is not for use within transactional services. We have included it in the Prototype Kit only so you can prototype your journeys. Unlike most other components and patterns in the Design System, we do not provide the code for step by step navigation in `govuk-frontend`.
+    </p>
+  </div>
+</div>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
Partly addresses [#1426](https://github.com/alphagov/govuk-design-system/issues/1426).

This PR updates the [Prototype Kit's 'Tutorials and page templates' page](https://govuk-prototype-kit.herokuapp.com/docs/tutorials-and-examples) to make it clear that:
- the pattern is only for use on GOV.UK 
- the pattern is only included in the Prototype Kit so users can prototype their journeys
- we do not actually provide the code for the pattern (unlike most of our other components and patterns)