### PR TITLE
HUB-963: Remove the Verify support email address from public pages

### DIFF
--- a/docs/documentation/using-verify.md
+++ b/docs/documentation/using-verify.md
@@ -4,4 +4,4 @@
 
 If you'd like to test the use of Verify in your prototype, there is a GOV.UK Verify stable prototype you can use.
 
-To use it, you'll need to contact idasupport@digital.cabinet-office.gov.uk and request access.
+To use it, you'll need to [request access](https://www.signin.service.gov.uk/feedback?).


### PR DESCRIPTION
Use the support form instead

I wish to update this page - https://govuk-prototype-kit.herokuapp.com/docs/using-verify
I assume this PR will update the page I want to change.