### PR TITLE
fix 'add questions' redirect

### DIFF
--- a/docs/documentation_routes.js
+++ b/docs/documentation_routes.js
@@ -73,7 +73,7 @@ router.get('/making-pages', function (req, res) {
   res.redirect('/docs/make-first-prototype/create-pages')
 })
 
-router.get('/add-questions', function (req, res) {
+router.get('/make-first-prototype/add-questions', function (req, res) {
   res.redirect('/docs/make-first-prototype/use-components')
 })
 


### PR DESCRIPTION
the old redirect is wrong - it doesn't include the 'make-first-prototype' path, see this issue: 
https://github.com/alphagov/prototype-kit-training/issues/65