### PR TITLE
Use npx for gulp

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "govuk-frontend": "^3.12.0",
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
-    "gulp": "^4.0.0",
     "gulp-nodemon": "^2.5.0",
     "gulp-sass": "^4.0.1",
     "gulp-sourcemaps": "^2.6.0",

--- a/start.js
+++ b/start.js
@@ -68,7 +68,7 @@ function runGulp () {
   const spawn = require('cross-spawn')
 
   process.env.FORCE_COLOR = 1
-  var gulp = spawn('./node_modules/.bin/gulp', ['--log-level', '-L'])
+  var gulp = spawn('npx', ['gulp', '--log-level', '-L'])
   gulp.stdout.pipe(process.stdout)
   gulp.stderr.pipe(process.stderr)
   process.stdin.pipe(gulp.stdin)


### PR DESCRIPTION
So users dont need permission to run gulp.

GDS Managed devices cannot run anything that isn't installed via Self Service. This change runs npx (part of Node/npm that is already installed) so does not need permissions.

Since npx runs gulp globally, we no longer need gulp as a dependency in package.json

**Update**
This also seems to work and maybe it's less risk as it's a smaller change
```
var gulp = spawn('node', ['./node_modules/gulp/bin/gulp.js', '--log-level', '-L'])
```