### PR TITLE
Run Gulp using the Node executable to fix permissions problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Fixes
+
+- [Pull request #1039: Run Gulp using the Node executable to fix permissions problem](https://github.com/alphagov/govuk-prototype-kit/pull/1039)
+
 # 9.14.0 (Feature release)
 
 ## New features

--- a/start.js
+++ b/start.js
@@ -68,7 +68,7 @@ function runGulp () {
   const spawn = require('cross-spawn')
 
   process.env.FORCE_COLOR = 1
-  var gulp = spawn('./node_modules/.bin/gulp', ['--log-level', '-L'])
+  var gulp = spawn('node', ['./node_modules/gulp/bin/gulp.js', '--log-level', '-L'])
   gulp.stdout.pipe(process.stdout)
   gulp.stderr.pipe(process.stderr)
   process.stdin.pipe(gulp.stdin)


### PR DESCRIPTION
Run gulp using the node executable

GDS Managed devices cannot run anything that isn't installed via Self Service. This change runs node to run gulp indirectly so does not need permissions.