### PR TITLE
Add release notes for GOV.UK Prototype Kit 9.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Unreleased
 
+## 9.14.1 (Patch release)
+
 ## Fixes
 
-- [Pull request #1039: Run Gulp using the Node executable to fix permissions problem](https://github.com/alphagov/govuk-prototype-kit/pull/1039)
+- [Pull request #1039: Run Gulp using the Node executable to fix permissions problem on GDS-managed devices](https://github.com/alphagov/govuk-prototype-kit/pull/1039)
 
 # 9.14.0 (Feature release)
 


### PR DESCRIPTION
This PR is to tell users about a fix that will enable them to run the Kit on GDS-managed devices. See [#1039](https://github.com/alphagov/govuk-prototype-kit/pull/1039).