### PR TITLE
Fix documentation bugs in branching page of tutorial

### DIFF
--- a/docs/documentation/make-first-prototype/branching.md
+++ b/docs/documentation/make-first-prototype/branching.md
@@ -32,11 +32,11 @@ Currently, the `juggling-balls` page sends the user directly to question 2. Inst
 // Run this code when a form is submitted to 'juggling-balls-answer'
 router.post('/juggling-balls-answer', function (req, res) {
 
-  // Make a variable and give it the value from 'juggling-balls'
-  var jugglingBalls = req.session.data['juggling-balls']
+  // Make a variable and give it the value from 'how-many-balls'
+  var howManyBalls = req.session.data['how-many-balls']
 
   // Check whether the variable matches a condition
-  if (jugglingBalls == "3 or more"){
+  if (howManyBalls == "3 or more"){
     // Send user to next page
     res.redirect('/juggling-trick')
   } else {

--- a/docs/documentation/make-first-prototype/branching.md
+++ b/docs/documentation/make-first-prototype/branching.md
@@ -2,7 +2,7 @@
 
 Our first question asks the user how many balls they can juggle. We’re going to send them to an ‘ineligible’ page if they can only juggle 2 balls or less. Sending users to different pages based on their input is called branching.
 
-To do this, we’re going to need an ‘ineligible.html’ page, and some logic to decide when to send users there.
+To do this, we’re going to need an `ineligible.html` page, and some logic to decide when to send users there.
 
 This kind of logic goes in a file called `app/routes.js`, which is written in JavaScript. Routes tell the kit what to do when the user goes to specific pages.
 
@@ -22,7 +22,7 @@ We’re going to write some logic to process the user’s answer to question 1. 
 
 Currently, the `juggling-balls` page sends the user directly to question 2. Instead, we’re going to send them to a special URL where we can run some code to check their answer.
 
-1. In juggling-balls.html change the form action to `/juggling-balls-answer`.
+1. In `juggling-balls.html` change the form action to `/juggling-balls-answer`.
 
 2. Open `/app/routes.js`.
 

--- a/docs/documentation/make-first-prototype/branching.md
+++ b/docs/documentation/make-first-prototype/branching.md
@@ -10,7 +10,7 @@ The route takes the answer the user gave to the first question and either sends 
 
 ## Create an ineligible page
 
-1. Make an `ineligible.html` page by copying `template-content-page.html`.
+1. Make an `ineligible.html` page by copying `content.html` from `docs/views/templates` to `app/views`.
 
 2. Update the content to tell the user why they’re ineligible and what they can do next.
 


### PR DESCRIPTION
Fixes issue #1040, by changing the example code as suggested.

I also found while following the documentation that step 1 was incorrect, as there is no file called `template-content-page.html`; this PR also updates step 1 to refer to `docs/views/templates/content.html`.