### PR TITLE
Don’t swallow errors from session-data-defaults.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Fixes
+
+- [Pull request #1050: Don’t swallow errors from session-data-defaults.js](https://github.com/alphagov/govuk-prototype-kit/pull/1050)
+
 ## 9.14.1 (Patch release)
 
 ## Fixes

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -226,7 +226,8 @@ const sessionDataDefaultsFile = path.join(__dirname, '/../app/data/session-data-
 try {
   sessionDataDefaults = require(sessionDataDefaultsFile)
 } catch (e) {
-  console.error('Could not load the session data defaults from app/data/session-data-defaults.js. Might be a syntax error?')
+  console.error('Could not load the session data defaults from app/data/session-data-defaults.js')
+  console.error(e)
 }
 
 // Middleware - store any data sent in session, and pass it to all views


### PR DESCRIPTION
If the code generating `session-data-defaults` is fairly complex, spotting and fixing those errors is a common problem, and is more than fixing simple syntax issues.

This change still allows the app to run, but will show the original error in the console alongside the warning about loading the defaults. By showing the full error it also highlights where there's a problem – the single line "Could not load…" message can be easily missed in a busy log.

Showing the error in the log allows a developer to debug and fix the problem.