### PR TITLE
Document issue with Gulp

### DIFF
--- a/docs/documentation/updating-the-kit.md
+++ b/docs/documentation/updating-the-kit.md
@@ -38,6 +38,28 @@
 
 If your prototype does not work, compare the new `package.json` file to the `package.json` file in the backup you made in step 3. Run `npm install PACKAGE-NAME` for each package that's missing in the new file.
 
+## Gulp error message
+
+If you use a GDS managed device, you no longer have permission to run Gulp (a JavaScript toolkit used by Prototype Kit). We’ve updated the Prototype Kit so if you install it now, it runs Gulp without having to install it separately.
+
+If you want to run an existing prototype made before July 2021, you may see an error message about not having permission to run Gulp.
+
+To fix this:
+
+1. open a code editor, like Atom
+2. from your prototype project folder, open the ‘start.js’ file
+3. go to the line that starts with: `var gulp = spawn`
+4. replace the entire line with:
+
+`var gulp = spawn ('node', ['./node_modules/gulp/bin/gulp.js', '--log-level', '-L'])`
+
+5. save the file
+
+If you need to restart the Prototype Kit after the fix:
+
+1. in your [terminal](https://govuk-prototype-kit.herokuapp.com/docs/install/requirements.md#terminal), `cd` to your prototype folder
+2. run `npm start`
+
 ## Get help
 
 You can:


### PR DESCRIPTION
This change is for GDS users with a managed device who cannot run Gulp.

fixes #1048