### PR TITLE
Remove repeated 'the'

### DIFF
--- a/docs/documentation/make-first-prototype/let-user-change-answers.md
+++ b/docs/documentation/make-first-prototype/let-user-change-answers.md
@@ -4,8 +4,8 @@
 
 Make the **Change** links on the ‘Check your answers’ page work by adding the right links.
 
-1. In the the `<a>` tag under `{{ data['how-many-balls'] }}`, change the href attribute from `#` to `/juggling-balls`
-2. In the the `<a>` tag under `{{ data['most-impressive-trick'] }}`, change the href attribute from `#` to `/juggling-trick`
+1. In the `<a>` tag under `{{ data['how-many-balls'] }}`, change the href attribute from `#` to `/juggling-balls`
+2. In the `<a>` tag under `{{ data['most-impressive-trick'] }}`, change the href attribute from `#` to `/juggling-trick`
 
 If you select a **Change** link, you’ll go back to the right question page, but your answer will not appear yet.
 


### PR DESCRIPTION
Fixes typo spotted by user on page https://govuk-prototype-kit.herokuapp.com/docs/make-first-prototype/let-user-change-answers (see Zendesk ticket https://govuk.zendesk.com/agent/tickets/4643784).