### PR TITLE
Add release notes for Kit v9.14.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Unreleased
 
+# 9.14.2 (Fix release)
+
 ## Fixes
 
 - [Pull request #1036: Update to GOV.UK Frontend v3.13.1](https://github.com/alphagov/govuk-prototype-kit/pull/1069)
-- [Pull request #1050: Don’t swallow errors from session-data-defaults.js](https://github.com/alphagov/govuk-prototype-kit/pull/1050)
+- [Pull request #1050: Do not swallow errors from `session-data-defaults.js`](https://github.com/alphagov/govuk-prototype-kit/pull/1050)
 
-## 9.14.1 (Patch release)
+# 9.14.1 (Patch release)
 
 ## Fixes
 


### PR DESCRIPTION
Closes [#1057](https://github.com/alphagov/govuk-prototype-kit/issues/1057).