### PR TITLE
Add info about install location to install guide

### DIFF
--- a/docs/documentation/install/install-the-kit.md
+++ b/docs/documentation/install/install-the-kit.md
@@ -6,12 +6,13 @@ The simplest way to get the kit is to <a href="/docs/download" data-link="downlo
 
 You'll use a new copy of the kit for each new prototype you make. That way your prototypes don’t interfere with each other.
 
+Make sure you are installing the kit on a local drive. Do not install the kit on a cloud-based drive (for example, Dropbox, Microsoft OneDrive), as this may cause permissions issues.
+
 ### Make a folder for your prototypes
 
 We recommend keeping all your prototypes in one folder called `prototypes`.
 
 Create a folder called `prototypes` in your `Documents` folder.
-
 
 ### Unzip the kit and move it
 


### PR DESCRIPTION
Fixes [#1065](https://github.com/alphagov/govuk-prototype-kit/issues/1065).

This PR adds content to [our 'Install the kit' page](https://govuk-prototype-kit.herokuapp.com/docs/install/install-the-kit.md#unzip-the-kit-and-move-it).

This new content tells users to install the kit on a local drive, not on a cloud-based drive. We've added this because a user told us they had permissions issues during a fresh kit-install. The issues occurred because the files were on iCloud instead of on the user's local drive.