### PR TITLE
Update GOV.UK Frontend to 3.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Fixes
 
+- [Pull request #1036: Update to GOV.UK Frontend v3.13.1](https://github.com/alphagov/govuk-prototype-kit/pull/1069)
 - [Pull request #1050: Don’t swallow errors from session-data-defaults.js](https://github.com/alphagov/govuk-prototype-kit/pull/1050)
 
 ## 9.14.1 (Patch release)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "express-writer": "0.0.4",
     "fancy-log": "^1.3.3",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^3.13.0",
+    "govuk-frontend": "^3.13.1",
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "gulp": "^4.0.0",


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-prototype-kit/issues/1058

# Release notes for GOV.UK Frontend
## 3.13.1 (Fix release)

### Fixes

We’ve made fixes to GOV.UK Frontend in the following pull requests:

- [#2264: Improve focus state for radio and checkbox controls in forced colors mode (for example, Windows High Contrast Mode)](https://github.com/alphagov/govuk-frontend/pull/2264) – thanks to [@adamliptrot-oc](https://github.com/adamliptrot-oc) for reporting this issue
- [#2265: Do not remove focus outline from disabled link buttons in forced colors mode](https://github.com/alphagov/govuk-frontend/pull/2265)
- [#2273: Fix invisible footer on Open Government Licence logo in forced colors mode](https://github.com/alphagov/govuk-frontend/pull/2273) – thanks to [@oscarduignan](https://github.com/oscarduignan) for reporting this issue
- [#2277: Fix invisible start button chevron in forced colors mode](https://github.com/alphagov/govuk-frontend/pull/2277)
- [#2290: Improve support for Internet Explorer 11 with Windows High Contrast Mode](https://github.com/alphagov/govuk-frontend/pull/2290)
- [#2306: Add `max-width` to file upload component](https://github.com/alphagov/govuk-frontend/pull/2306)
- [#2312: Remove `padding-right` from details component](https://github.com/alphagov/govuk-frontend/pull/2312)