### PR TITLE
Bump Node Sass and Gulp Sass dependencies to close vulnerability in `tar`

### DIFF
--- a/gulp/sass.js
+++ b/gulp/sass.js
@@ -6,7 +6,7 @@
 */
 
 const gulp = require('gulp')
-const sass = require('gulp-sass')
+const sass = require('gulp-sass')(require('node-sass'))
 const sourcemaps = require('gulp-sourcemaps')
 const path = require('path')
 const fs = require('fs')

--- a/package.json
+++ b/package.json
@@ -32,11 +32,12 @@
     "govuk_template_jinja": "^0.24.1",
     "gulp": "^4.0.0",
     "gulp-nodemon": "^2.5.0",
-    "gulp-sass": "^4.0.1",
+    "gulp-sass": "^5.0.0",
     "gulp-sourcemaps": "^2.6.0",
     "inquirer": "^7.1.0",
     "keypather": "^3.0.0",
     "marked": "^2.0.0",
+    "node-sass": "^4.14.1",
     "notifications-node-client": "^4.7.2",
     "nunjucks": "^3.2.1",
     "portscanner": "^2.1.1",
@@ -53,7 +54,6 @@
   "devDependencies": {
     "glob": "^7.1.4",
     "jest": "^25.2.7",
-    "node-sass": "^4.14.1",
     "standard": "^14.3.3",
     "supertest": "^4.0.2"
   }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "inquirer": "^7.1.0",
     "keypather": "^3.0.0",
     "marked": "^2.0.0",
-    "node-sass": "^4.14.1",
+    "node-sass": "^5.0.0",
     "notifications-node-client": "^4.7.2",
     "nunjucks": "^3.2.1",
     "portscanner": "^2.1.1",


### PR DESCRIPTION
Updates node-sass and gulp-sass; this is necessary to make sure that users are installing a version of `tar` which is not vulnerable to an arbitrary code execution attack [[1](https://github.blog/2021-09-08-github-security-update-vulnerabilities-tar-npmcli-arborist/)].

Bumps [node-sass](https://github.com/sass/node-sass) from 4.14.1 to 5.0.0:
  - [Release notes](https://github.com/sass/node-sass/releases/tag/v5.0.0)
  - [Changelog](https://github.com/sass/node-sass/blob/master/CHANGELOG.md)
  - [Commits](sass/node-sass@v4.14.1...v5.0.0)

Bumps [gulp-sass](https://github.com/dlmanning/gulp-sass) from 4.0.1 to 5.0.0:
  - [Release notes](https://github.com/dlmanning/gulp-sass/releases/tag/v5.0.0)
  - [Changelog](https://github.com/dlmanning/gulp-sass/blob/master/CHANGELOG.md)
  - [Commits](dlmanning/gulp-sass@v4.0.1...v5.0.0)

---

~Note the major version bump for node-sass includes a breaking change dropping support for Node.js versions less than 10. According to our test matrix and PR #942 bumping the preferred version to v14, this is fine. However, we still want to support Node.js v10, so we can't bump node-sass to v6.~