### PR TITLE
Differentiate link text in About and Tutorial docs

### DIFF
--- a/docs/views/about.html
+++ b/docs/views/about.html
@@ -24,21 +24,17 @@ About - GOV.UK Prototype Kit
       <p class="govuk-body-l">
         The GOV.UK Prototype Kit provides a simple way to make interactive prototypes that look like pages on GOV.UK. These prototypes can be used to show ideas to people you work with, and to do user research
       </p>
-      
+
       <h2 class="govuk-heading-m">Support</h2>
-      
+
       <p>The GOV.UK Prototype Kit is maintained by the Government Digital Service. If you’ve got a question or need support you can:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>email 
+        <li>email
           <a href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" class="govuk-link">
             govuk-design-system-support@digital.cabinet-office.gov.uk
           </a>
         </li>
-        <li>
-          <a href="https://ukgovernmentdigital.slack.com/messages/prototype-kit" class="govuk-link">
-            get in touch on Slack
-          </a> 
-          (<a class="govuk-link" href="slack://channel?team=T04V6EBTR&amp;id=C0647LW4R">open in app</a>)
+        <li><a class="govuk-link" href="slack://channel?team=T04V6EBTR&amp;id=C0647LW4R">get in touch on the Prototype Kit's Slack channel</a>
         </li>
         <li>
           <a href="https://github.com/alphagov/govuk-prototype-kit/issues" class="govuk-link">
@@ -48,14 +44,10 @@ About - GOV.UK Prototype Kit
       </ul>
 
       <h2 class="govuk-heading-m">Contributing</h2>
-      
+
       <p>If you’ve got an idea or suggestion you can:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>
-          <a href="https://ukgovernmentdigital.slack.com/messages/prototype-kit-dev" class="govuk-link">
-            get in touch on the developer Slack channel
-          </a> 
-          (<a class="govuk-link" href="slack://channel?team=T04V6EBTR&amp;id=C0E1063DW">open in app</a>)
+        <li><a class="govuk-link" href="slack://channel?team=T04V6EBTR&amp;id=C0E1063DW">get in touch on the developer Slack channel</a>
         </li>
         <li>
           <a href="https://github.com/alphagov/govuk-prototype-kit/issues" class="govuk-link">

--- a/docs/views/tutorials-and-examples.html
+++ b/docs/views/tutorials-and-examples.html
@@ -213,9 +213,7 @@
         you prototype realistic journeys connecting your service with GOV.UK content.
       </p>
       <p>
-        Read more about how to get a <a href="https://design-system.service.gov.uk/patterns/start-pages/">
-        Start page</a> or <a href="https://design-system.service.gov.uk/patterns/step-by-step-navigation/">
-        Step by step navigation</a> for your service in the GOV.UK Design System.
+        Read the <a href="https://design-system.service.gov.uk/patterns/start-pages/">start pages guidance</a> and the <a href="https://design-system.service.gov.uk/patterns/step-by-step-navigation/">step by step navigation guidance</a> to learn how to make these pages live for your service.
       </p>
     </div>
   </div>


### PR DESCRIPTION
Fixes [#1074](https://github.com/alphagov/govuk-prototype-kit/issues/1074).

This PR adds new link-text to our [About](https://govuk-prototype-kit.herokuapp.com/docs/about) and [Tutorials and examples](https://govuk-prototype-kit.herokuapp.com/docs/tutorials-and-examples) pages.

We've added this text because, currently, we have instances of the same link-text (like "start page") pointing to different places. For example, depending on where the link-text displays, either to the [start pages guidance](https://design-system.service.gov.uk/patterns/start-pages/) or to the [page template](https://govuk-prototype-kit.herokuapp.com/docs/templates/start). So, this PR adds text to clarify where we're directing users.