### PR TITLE
Align image alt text with image contents

### DIFF
--- a/docs/documentation/publishing-on-heroku.md
+++ b/docs/documentation/publishing-on-heroku.md
@@ -10,7 +10,7 @@ You'll need to have [put your code on GitHub](/docs/github-desktop) to use this 
 
 2. In the top right click **New** then **Create new app**.
 
-![Screenshot of Heroku Create App page](/public/images/docs/heroku-create-app.png)
+![Screenshot of Heroku Create New App page](/public/images/docs/heroku-create-app.png)
 
 3. Enter a name for your prototype app. App names in Heroku have to be unique across all the users of Heroku. It can be helpful to add your name or organisation to the start of the name to make it unique. For example joelanman-juggling-prototype.
 
@@ -22,7 +22,7 @@ You'll need to have [put your code on GitHub](/docs/github-desktop) to use this 
 
 1. For **Deployment method** choose **GitHub**. ‘Deploy’ means publish.
 
-![Screenshot of Heroku deploy page](/public/images/docs/heroku-deploy.png)
+![Screenshot of section of page headed Deployment method](/public/images/docs/heroku-deploy.png)
 
 2. Scroll down and click **Connect to GitHub**.
 


### PR DESCRIPTION
Fixes [#1072](https://github.com/alphagov/govuk-prototype-kit/issues/1072).

This PR updates the alt text in 2 screenshots on our [Publishing on Heroku page](https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku).

The previous alt text did not match the text displayed in either screenshot. This inconsistency might have confused users of assistive tech, because different words were used to describe the same thing.