### PR TITLE
Add PDFs to title and content of Basic usage doc

### DIFF
--- a/docs/documentation/adding-css-javascript-and-images.md
+++ b/docs/documentation/adding-css-javascript-and-images.md
@@ -1,6 +1,6 @@
-# Adding CSS, JavaScript and Images
+# Adding CSS, JavaScript, images and PDFs
 
-The Prototype Kit comes with standard GOV.UK Frontend styles and components for you to use in your prototypes. However if you need to add your own CSS (Cascading Style Sheets), JavaScript or images, use the `/app/assets` folder.
+The Prototype Kit comes with standard GOV.UK Frontend styles and components for you to use in your prototypes. However, if you need to add your own CSS (Cascading Style Sheets), JavaScript, images or other files (for example, PDFs), use the `/app/assets` folder.
 
 The Prototype Kit processes all the files in the `/app/assets` folder, and puts the processed files in `/public`.
 

--- a/docs/views/tutorials-and-examples.html
+++ b/docs/views/tutorials-and-examples.html
@@ -91,7 +91,7 @@
           <a href="/docs/usage-data">Sending kit usage data</a>
         </li>
         <li>
-          <a href="/docs/adding-css-javascript-and-images">Adding CSS, JavaScript and Images</a>
+          <a href="/docs/adding-css-javascript-and-images">Adding CSS, JavaScript, images and PDFs</a>
         </li>
         <li>
           <a href="/docs/github-desktop">Storing your code online with GitHub and GitHub Desktop</a>


### PR DESCRIPTION
Fixes [#1042](https://github.com/alphagov/govuk-prototype-kit/issues/1042).

This PR adds the word 'PDFs' to the doc title 'Adding CSS, JavaScript and Images' and the doc's first paragraph. 

It also updates the link-text for the doc title in the [Tutorials and examples (table of contents) homepage](https://govuk-prototype-kit.herokuapp.com/docs/tutorials-and-examples).

We've made these changes because several users have struggled to find our guidance on downloadable files.