### PR TITLE
Remove greenkeeper from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,11 +45,6 @@
     "universal-analytics": "^0.4.16",
     "uuid": "^7.0.3"
   },
-  "greenkeeper": {
-    "ignore": [
-      "nunjucks"
-    ]
-  },
   "devDependencies": {
     "glob": "^7.1.4",
     "jest": "^25.2.7",


### PR DESCRIPTION
Greenkeeper [ceased operations in 2020](https://twitter.com/greenkeeperio/status/1268228650593386496), and the bot's last PR on this repo was #505 in May 2018.

It doesn't look like we need the `greenkeeper` property in package.json, which was added to prevent the bot from bumping `nunjucks` above v2 (https://github.com/alphagov/govuk-prototype-kit/pull/392/commits/1373ae884c4eaf49c9d638890565cd5da2ed1e40).