### PR TITLE
Fix wording in examples of user applications

### DIFF
--- a/docs/documentation/make-first-prototype/show-users-answers.md
+++ b/docs/documentation/make-first-prototype/show-users-answers.md
@@ -92,7 +92,7 @@ Your code should now look like this:
 
       <h2 class="govuk-heading-m">Now send your application</h2>
 
-      <p>By submitting this notification you are confirming that, to the best of your knowledge, the details you are providing are correct.</p>
+      <p>By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.</p>
 
       <form action="/confirmation" method="post" novalidate>
 

--- a/docs/views/templates/check-your-answers.html
+++ b/docs/views/templates/check-your-answers.html
@@ -143,7 +143,7 @@
 
       <h2 class="govuk-heading-m">Now send your application</h2>
 
-      <p>By submitting this notification you are confirming that, to the best of your knowledge, the details you are providing are correct.</p>
+      <p>By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.</p>
 
       <form action="/confirmation" method="post" novalidate>
 


### PR DESCRIPTION
This PR replaces the word 'notification' with 'application'  in examples on our:

- [Show user's answers page](https://github.com/alphagov/govuk-prototype-kit/blob/main/docs/documentation/make-first-prototype/show-users-answers.md)
- [Check your answers page](https://github.com/alphagov/govuk-prototype-kit/blob/main/docs/views/templates/check-your-answers.html)
