### PR TITLE
Replace redundant link with link to inline radios

### DIFF
--- a/docs/documentation/make-first-prototype/use-components.md
+++ b/docs/documentation/make-first-prototype/use-components.md
@@ -12,7 +12,7 @@ In the Design System, components have both Nunjucks and HTML example code. Eithe
 
 ## Add radios to question 1
 
-1. Go to the [stacked radios](https://design-system.service.gov.uk/components/radios/#stacked-radios) section of the Design System.
+1. Go to the [inline radios](https://design-system.service.gov.uk/components/radios/#inline-radios) section of the Design System.
 2. Select the **Nunjucks** tab, then **Copy code**.
 3. Open `juggling-balls.html` in your `app/views` folder.
 4. Replace the 2 example `<p>...</p>` paragraphs with the code you copied.


### PR DESCRIPTION
Fixes [#1090](https://github.com/alphagov/govuk-prototype-kit/issues/1090).

This PR replaces a redundant link in our ['Use components from the Design System' page](https://govuk-prototype-kit.herokuapp.com/docs/make-first-prototype/use-components).

The old link pointed to a 'Stacked radios' section in the [Design System's radios guidance](https://design-system.service.gov.uk/components/radios/). However, this section no longer exists.

The new link points to [the guidance's 'Inline radios' section](https://design-system.service.gov.uk/components/radios/#inline-radios).