### PR TITLE
Link Prototype Kit repo README to security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Prototype Kit provides a simple way to make interactive prototypes that look
 
 Read the [project principles](https://govuk-prototype-kit.herokuapp.com/docs/principles).
 
-## Security
+## Make sure prototypes are password-protected
 
 If you publish your prototypes online, they **must** be protected by a [username and password](https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku). This is to prevent members of the public finding prototypes and thinking they are real services.
 
@@ -23,13 +23,19 @@ You must protect user privacy at all times, even when using prototypes. Prototyp
 
 The GOV.UK Prototype Kit is maintained by the Government Digital Service. If you’ve got a question or need support you can:
 
-* email [govuk-design-system-support@digital.cabinet-office.gov.uk](mailto:govuk-design-system-support@digital.cabinet-office.gov.uk) 
-* [get in touch on Slack](https://ukgovernmentdigital.slack.com/messages/prototype-kit)([open in app](slack://channel?team=T04V6EBTR&amp;id=C0647LW4R)) 
+* email [govuk-design-system-support@digital.cabinet-office.gov.uk](mailto:govuk-design-system-support@digital.cabinet-office.gov.uk)
+* [get in touch on Slack](https://ukgovernmentdigital.slack.com/messages/prototype-kit)([open in app](slack://channel?team=T04V6EBTR&amp;id=C0647LW4R))
 * [view known issues on GitHub](https://github.com/alphagov/govuk-prototype-kit/issues)
-        
+
 ## Contributing
 
 If you’ve got an idea or suggestion you can:
 
 * [get in touch on the developer Slack channel](https://ukgovernmentdigital.slack.com/messages/prototype-kit-dev)([open in app](slack://channel?team=T04V6EBTR&amp;id=C0E1063DW))
 * [create a GitHub issue](https://github.com/alphagov/govuk-prototype-kit/issues)
+
+### Security
+
+GDS is an advocate of responsible vulnerability disclosure. If you’ve found a vulnerability, we would like to know so we can fix it.
+
+For full details on how to tell us about vulnerabilities, [see our security policy](https://github.com/alphagov/govuk-prototype-kit/security/policy).


### PR DESCRIPTION
Partly addresses [#1692](https://github.com/alphagov/govuk-design-system/issues/1692).

This PR updates the [repo README](https://github.com/alphagov/govuk-prototype-kit/blob/main/README.md) with info and link text for our [security policy](https://github.com/alphagov/govuk-design-system/security/policy).

Hopefully this will make the security policy more visible to researchers who want to report vulnerabilities.