### PR TITLE
Replace back link placeholder URLs with javascript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [Pull request #1104: Change visually hidden footer title](https://github.com/alphagov/govuk-prototype-kit/pull/1104)
 - [Pull request #1076: Update to Node.js v14.17.6 when using Node Version Manager](https://github.com/alphagov/govuk-prototype-kit/pull/1076)
+- [Pull request #1103: Replace back link placeholder URLs with javascript](https://github.com/alphagov/govuk-prototype-kit/pull/1103)
 
 # 9.14.2 (Fix release)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,23 @@
 # Unreleased
+ 
+## New features
+
+### Replace back link placeholder URLs with javascript
+
+Previously, users had to manually replace the `href` for each back link in the page templates.
+
+Now, we use JavaScript to make the back link take you to the previous page by default.
+
+This approach is not appropriate for production scenarios, where you cannot rely on JavaScript being available at all times.
+
+You can still override the `href` attribute if you need different behaviour.
+
+This was added in [Pull request #1103: Replace back link placeholder URLs with javascript](https://github.com/alphagov/govuk-prototype-kit/pull/1103)
 
 ## Fixes
 
 - [Pull request #1104: Change visually hidden footer title](https://github.com/alphagov/govuk-prototype-kit/pull/1104)
 - [Pull request #1076: Update to Node.js v14.17.6 when using Node Version Manager](https://github.com/alphagov/govuk-prototype-kit/pull/1076)
-- [Pull request #1103: Replace back link placeholder URLs with javascript](https://github.com/alphagov/govuk-prototype-kit/pull/1103)
 
 # 9.14.2 (Fix release)
 

--- a/docs/views/templates/check-your-answers.html
+++ b/docs/views/templates/check-your-answers.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="/url/of/previous/page">Back</a>
+  <a class="govuk-back-link" href="javascript:window.history.back()">Back</a>
 {% endblock %}
 
 {% block content %}

--- a/docs/views/templates/content.html
+++ b/docs/views/templates/content.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="/url/of/previous/page">Back</a>
+  <a class="govuk-back-link" href="javascript:window.history.back()">Back</a>
 {% endblock %}
 
 {% block content %}

--- a/docs/views/templates/question.html
+++ b/docs/views/templates/question.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="/url/of/previous/page">Back</a>
+  <a class="govuk-back-link" href="javascript:window.history.back()">Back</a>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
In most cases, the back button should simply go back to the referring page, so we can use `window.history`.

Closes #494

There is a small potential issue when hovering on the link, as browsers will display the `href` property in the status bar, which in this case is just some javascript (as shown in the image below).

![Screenshot 2021-09-30 at 09 10 08](https://user-images.githubusercontent.com/22524634/135416266-f13e75b2-87ca-40c5-8975-9e034b1f61c7.png)

I'm not sure how much of an issue this is for prototyping.