### PR TITLE
Change visually hidden footer title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Fixes
 
+- [Pull request #1104: Change visually hidden footer title](https://github.com/alphagov/govuk-prototype-kit/pull/1104)
 - [Pull request #1076: Update to Node.js v14.17.6 when using Node Version Manager](https://github.com/alphagov/govuk-prototype-kit/pull/1076)
 
 # 9.14.2 (Fix release)

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -64,7 +64,8 @@
             href: "/prototype-admin/clear-data",
             text: "Clear data"
           }
-        ]
+        ],
+        visuallyHiddenTitle: "Footer links"
       }
     }) }}
   {% endblock %}


### PR DESCRIPTION
"Support links" isn't very clear. "Footer links" is a bit more agnostic.

Fixes #1102 