### PR TITLE
Update link text in use-components tutorial

### DIFF
--- a/docs/documentation/make-first-prototype/use-components.md
+++ b/docs/documentation/make-first-prototype/use-components.md
@@ -12,8 +12,8 @@ In the Design System, components have both Nunjucks and HTML example code. Eithe
 
 ## Add radios to question 1
 
-1. Go to the [inline radios](https://design-system.service.gov.uk/components/radios/#inline-radios) section of the Design System.
-2. Select the **Nunjucks** tab, then **Copy code**.
+1. Go to the [radios component](https://design-system.service.gov.uk/components/radios/#inline-radios) in the Design System.
+2. Select the **Nunjucks** tab under the first example, then **Copy code**.
 3. Open `juggling-balls.html` in your `app/views` folder.
 4. Replace the 2 example `<p>...</p>` paragraphs with the code you copied.
 5. The example comes with a heading that is connected to the answers for accessibility, so delete the old `<h1>` tag with "How many balls can you juggle?".


### PR DESCRIPTION
Fixes [#1090](https://github.com/alphagov/govuk-prototype-kit/issues/1090).

This PR updates some link text in our ['Use components from the Design System' tutorial](https://govuk-prototype-kit.herokuapp.com/docs/make-first-prototype/use-components).

The previous link incorrectly directed users to the 'Inline radios' section, if they wanted to add radios to question 1. Instead, this update directs them to use the first example on the [radios component page](https://design-system.service.gov.uk/components/radios/).