### PR TITLE
Fix code sample accessibility issues

### DIFF
--- a/docs/assets/sass/docs.scss
+++ b/docs/assets/sass/docs.scss
@@ -42,15 +42,21 @@ figure {
 }
 
 .app-code {
-  font-size: 16px;
+  @include govuk-font($size: 19);
   position: relative;
   margin: 0;
   padding: govuk-spacing(3);
   overflow: auto;
-  border: 1px solid $govuk-border-colour;
+  border: $govuk-focus-width solid transparent;
+  outline: 1px solid $govuk-border-colour;
   background-color: govuk-colour("light-grey", $legacy: "grey-4");
   max-width: 38em;
   @include govuk-responsive-margin(5, "bottom");
+
+  &:focus {
+    border: $govuk-focus-width solid $govuk-input-border-colour;
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+  }
 }
 
 .app-prose-scope {

--- a/docs/views/examples/override-service-name.html
+++ b/docs/views/examples/override-service-name.html
@@ -28,7 +28,7 @@
         Use this code:
       </p>
 
-      <pre class="app-code"><code>{% raw %}{% set serviceName %}
+      <pre class="app-code" tabindex="0"><code>{% raw %}{% set serviceName %}
   Report a smokey vehicle
 {% endset%}{% endraw %}</code></pre>
 

--- a/docs/views/examples/pass-data/index.html
+++ b/docs/views/examples/pass-data/index.html
@@ -33,7 +33,7 @@
         The code for the example is in this folder in the Prototype Kit:
       </p>
 
-      <pre class="app-code"><code>/docs/views/examples/pass-data</code></pre>
+      <pre class="app-code" tabindex="0"><code>/docs/views/examples/pass-data</code></pre>
 
       <h2 class="govuk-heading-m">How to use</h2>
 
@@ -41,15 +41,15 @@
 
       <p>For example, if you have this input:</p>
 
-      <pre class="app-code"><code>&lt;input name="first-name"&gt;</code></pre>
+      <pre class="app-code" tabindex="0"><code>&lt;input name="first-name"&gt;</code></pre>
 
       <p>You can show what the user entered later on like this:</p>
 
-      <pre class="app-code"><code>&lt;p&gt;{%raw%}{{ data['first-name'] }}{%endraw%}&lt;/p&gt;</code></pre>
+      <pre class="app-code" tabindex="0"><code>&lt;p&gt;{%raw%}{{ data['first-name'] }}{%endraw%}&lt;/p&gt;</code></pre>
 
       <p>Or with nested fields:</p>
 
-      <pre class="app-code"><code>&lt;p&gt;{%raw%}{{ data['claimant']['first-name'] }}{%endraw%}&lt;/p&gt;</code></pre>
+      <pre class="app-code" tabindex="0"><code>&lt;p&gt;{%raw%}{{ data['claimant']['first-name'] }}{%endraw%}&lt;/p&gt;</code></pre>
 
       <h3 class="govuk-heading-s">
         Clearing data
@@ -69,15 +69,15 @@
 
       <p>For a text input:</p>
 
-      <pre class="app-code"><code>&lt;input name="first-name" value="{%raw%}{{ data['first-name'] }}{%endraw%}"&gt;</code></pre>
+      <pre class="app-code" tabindex="0"><code>&lt;input name="first-name" value="{%raw%}{{ data['first-name'] }}{%endraw%}"&gt;</code></pre>
 
       <p>For a radio or checkbox input you need to use the 'checked' function:</p>
 
-      <pre class="app-code"><code>&lt;input type="radio" name="over-18" value="yes" {%raw%}{{ checked("over-18", "yes") }}{%endraw%}&gt;</code></pre>
+      <pre class="app-code" tabindex="0"><code>&lt;input type="radio" name="over-18" value="yes" {%raw%}{{ checked("over-18", "yes") }}{%endraw%}&gt;</code></pre>
 
       <p>Or with nested fields:</p>
 
-      <pre class="app-code"><code>&lt;input type="radio" name="claimant[over-18]" value="yes" {%raw%}{{ checked("['claimant']['over-18']", "yes") }}{%endraw%}&gt;</code></pre>
+      <pre class="app-code" tabindex="0"><code>&lt;input type="radio" name="claimant[over-18]" value="yes" {%raw%}{{ checked("['claimant']['over-18']", "yes") }}{%endraw%}&gt;</code></pre>
 
       <h3 class="govuk-heading-s">
         Setting default data
@@ -85,7 +85,7 @@
 
       <p>You can set default values in this file in your prototype folder:
 
-      <pre class="app-code"><code>app/data/session-data-defaults.js</code></pre>
+      <pre class="app-code" tabindex="0"><code>app/data/session-data-defaults.js</code></pre>
 
       <h2 class="govuk-heading-m">Advanced features</h2>
 
@@ -95,7 +95,7 @@
 
       <p>Example using the 'checked' function in a checkbox component macro:</p>
 
-<pre class="app-code"><code>{% raw %}
+<pre class="app-code" tabindex="0"><code>{% raw %}
 {{ govukCheckboxes({
   name: "vehicle-features",
   fieldset: {
@@ -135,7 +135,7 @@
 
       <p>Example using the 'checked' function in a checkbox component macro (nested fields for multiple vehicles):</p>
 
-<pre class="app-code"><code>{% raw %}
+<pre class="app-code" tabindex="0"><code>{% raw %}
 {{ govukCheckboxes({
   name: "vehicle1[vehicle-features]",
   fieldset: {
@@ -177,7 +177,7 @@
 
       <p>For example for an input with name="first-name":</p>
 
-      <pre class="app-code"><code>var firstName = req.session.data['first-name']</code></pre>
+      <pre class="app-code" tabindex="0"><code>var firstName = req.session.data['first-name']</code></pre>
 
       <h3 class="govuk-heading-s">
         Using the data on the server (nested fields)
@@ -185,7 +185,7 @@
 
       <p>For example for an input with name="claimant[first-name]":</p>
 
-      <pre class="app-code"><code>var firstName = req.session.data['claimant']['first-name']</code></pre>
+      <pre class="app-code" tabindex="0"><code>var firstName = req.session.data['claimant']['first-name']</code></pre>
 
       <h3 class="govuk-heading-s">
         Ignoring inputs
@@ -193,7 +193,7 @@
 
       <p>To prevent an input being stored, use an underscore at the start of the name.</p>
 
-      <pre class="app-code"><code>&lt;input name="_secret"&gt;</code></pre>
+      <pre class="app-code" tabindex="0"><code>&lt;input name="_secret"&gt;</code></pre>
 
     </div>
   </div>

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,6 +12,20 @@ const matter = require('gray-matter')
 // Local dependencies
 const config = require('../app/config.js')
 
+// Tweak the Markdown renderer
+const defaultMarkedRenderer = marked.defaults.renderer || new marked.Renderer()
+
+marked.use({
+  renderer: {
+    code (code, infostring, escaped) {
+      let rawHtml = defaultMarkedRenderer.code(code, infostring, escaped)
+      // Add a tabindex to the <pre> element, to allow keyboard focus / scrolling
+      rawHtml = rawHtml.replace('<pre>', '<pre tabindex="0">')
+      return rawHtml
+    }
+  }
+})
+
 // Require core and custom filters, merges to one object
 // and then add the methods to Nunjucks environment
 exports.addNunjucksFilters = function (env) {

--- a/lib/utils.test.js
+++ b/lib/utils.test.js
@@ -69,4 +69,17 @@ describe('getRenderOptions', () => {
       utils.getRenderOptions(md, 'docs/documentation/this-is-a-header.md')
     }).toThrow(expectedError)
   })
+
+  it('allows keyboard focus for code blocks', () => {
+    const md = '---\n' +
+      'title: test\n' +
+      '---\n' +
+      '```\n' +
+      'This is a code block\n' +
+      '```\n'
+
+    const { document } = utils.getRenderOptions(md)
+
+    expect(document).toContain('<pre tabindex="0">')
+  })
 })


### PR DESCRIPTION
Fixes #1075 

## What
Using the GOV.UK Design System [`example`](https://github.com/alphagov/govuk-design-system/blob/main/src/stylesheets/components/_example.scss) as a basis:

Adds a `tabindex` attribute to code samples in order to make them focusable, so keyboard-only users can scroll to see all the text with the `<code>` element. This includes more obvious focus styling.

Additionally, uses `govuk-frontend` font styles to ensure font size resizes when the browser text size is set larger.

## Scope
It'd be possible to more closely follow the Design System's code examples, but the `example` macro relies on the existence of separate example files and is wrapped up with a tab system to allow viewing both HTML and Nunjucks. That all seemed like a separate thing to consider vs just fixing the accessibility flags.

## Screens
### Before: Incorrectly unresized text
![Prototype Kit code samples with incorrectly unresized text](https://user-images.githubusercontent.com/22524634/137344154-2aabf153-6339-40d7-be89-b5ed4ce7bf5e.png)

### After: correctly resized text
![Prototype Kit code samples with correctly resized text](https://user-images.githubusercontent.com/22524634/137344490-3a231278-a703-4787-8d42-b708261f890f.png)

### New focus style
![Code sample which has focus](https://user-images.githubusercontent.com/22524634/137344657-d2efc287-5f67-4372-a7c3-059a088bcbf5.png)


