### PR TITLE
Fix typo

### DIFF
--- a/docs/documentation/make-first-prototype/use-components.md
+++ b/docs/documentation/make-first-prototype/use-components.md
@@ -12,7 +12,7 @@ In the Design System, components have both Nunjucks and HTML example code. Eithe
 
 ## Add radios to question 1
 
-1. Go to the [radios component](https://design-system.service.gov.uk/components/radios/#inline-radios) in the Design System.
+1. Go to the [radios component](https://design-system.service.gov.uk/components/radios/) in the Design System.
 2. Select the **Nunjucks** tab under the first example, then **Copy code**.
 3. Open `juggling-balls.html` in your `app/views` folder.
 4. Replace the 2 example `<p>...</p>` paragraphs with the code you copied.


### PR DESCRIPTION
We no longer use inline radios in the juggling licence (#1107), but changing the URL was missed.