### PR TITLE
Bump outdated libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "npm run lint && gulp generate-assets && jest"
   },
   "dependencies": {
-    "acorn": "^7.1.1",
+    "acorn": "^8.5.0",
     "ansi-colors": "^4.1.1",
     "basic-auth": "^2.0.0",
     "basic-auth-connect": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "browser-sync": "^2.11.1",
     "client-sessions": "^0.8.0",
     "cross-spawn": "^7.0.2",
-    "del": "^5.1.0",
+    "del": "^6.0.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-session": "^1.13.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "glob": "^7.1.4",
     "jest": "^25.2.7",
     "standard": "^14.3.3",
-    "supertest": "^4.0.2"
+    "supertest": "^6.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "gulp": "^4.0.0",
     "gulp-nodemon": "^2.5.0",
     "gulp-sass": "^5.0.0",
-    "gulp-sourcemaps": "^2.6.0",
+    "gulp-sourcemaps": "^3.0.0",
     "inquirer": "^7.1.0",
     "keypather": "^3.0.0",
     "marked": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "require-dir": "^1.0.0",
     "sync-request": "^6.0.0",
     "universal-analytics": "^0.4.16",
-    "uuid": "^7.0.3"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "glob": "^7.1.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "gulp-nodemon": "^2.5.0",
     "gulp-sass": "^5.0.0",
     "gulp-sourcemaps": "^3.0.0",
-    "inquirer": "^7.1.0",
+    "inquirer": "^8.2.0",
     "keypather": "^3.0.0",
     "marked": "^2.0.0",
     "node-sass": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "gulp-sourcemaps": "^3.0.0",
     "inquirer": "^8.2.0",
     "keypather": "^3.0.0",
-    "marked": "^2.0.0",
+    "marked": "^3.0.8",
     "node-sass": "^6.0.1",
     "notifications-node-client": "^4.7.2",
     "nunjucks": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "client-sessions": "^0.8.0",
     "cross-spawn": "^7.0.2",
     "del": "^6.0.0",
-    "dotenv": "^8.2.0",
+    "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "express-session": "^1.13.0",
     "fancy-log": "^1.3.3",


### PR DESCRIPTION
Bumps a load of less critical libraries to the latest versions, squashing a whole load of errors.

I've read through the release notes for each, the only breaking changes are dropping support for older versions of Node (including v10).

- Bump marked from 2.1.3 to 3.0.8
- Bump dotenv from 8.2.0 to 10.0.0
- Bump del from 5.1.0 to 6.0.0
- Bump inquirer from 7.1.0 to 8.2.0
- Bump inquirer from 7.3.3 to 8.2.0
- Bump supertest from 4.0.2 to 6.1.6
- Bump acorn from 7.4.1 to 8.5.0
- Bump gulp-sourcemaps from 2.6.5 to 3.0.0