### PR TITLE
Use npm ci to install dependencies

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
+    - run: npm ci
     - run: npm test
       env:
         CI: true


### PR DESCRIPTION
Now that we have a package-lock file, we should use `npm ci` over `npm install` in automated environments, because:

- it's significantly faster
- if dependencies in the package lock do not match those in package.json, npm ci will exit with an error, instead of updating the package lock
- it will never write to package.json or any of the package-locks: installs are essentially frozen

See https://docs.npmjs.com/cli/v7/commands/npm-ci for more information.