### PR TITLE
Disable npm audit

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+audit=false


### PR DESCRIPTION
We re-enabled npm audit to check what came up when we added a package-lock file. We don't want users to get these warnings, so this disables npm audit again.

We can always test locally by removing this flag.