### PR TITLE
Replace keypather with lodash.get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Fixes
+
+[Pull request #1155: Replace lodash with keypather.get](https://github.com/alphagov/govuk-prototype-kit/pull/1155)
+
 # 11.0.0 (Fix release)
 
 ## Fixes

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,7 +2,7 @@
 const fs = require('fs')
 
 // NPM dependencies
-const getKeypath = require('keypather/get')
+const { get: getKeypath } = require('lodash')
 const marked = require('marked')
 const path = require('path')
 const portScanner = require('portscanner')

--- a/lib/utils.test.js
+++ b/lib/utils.test.js
@@ -1,0 +1,48 @@
+/* eslint-env jest */
+
+const nunjucks = require('nunjucks')
+
+const utils = require('./utils.js')
+
+describe('checked', () => {
+  var ctx, checked
+
+  beforeAll(() => {
+    var env = new nunjucks.Environment()
+    utils.addCheckedFunction(env)
+    ctx = { data: {} }
+    checked = env.getGlobal('checked').bind({ ctx })
+  })
+
+  it('can be added as global function to a nunjucks env', () => {
+    var env = new nunjucks.Environment()
+    utils.addCheckedFunction(env)
+    expect(env.getGlobal('checked')).toBeDefined()
+  })
+
+  it('returns a string', () => {
+    expect(checked('foo', 'bar')).toBe('')
+  })
+
+  it('returns checked if data has specified value', () => {
+    ctx.data.foo = 'bar'
+    expect(checked('foo', 'bar')).toBe('checked')
+  })
+
+  it('returns empty string if data does not has specified value', () => {
+    ctx.data.foo = 'baz'
+    expect(checked('foo', 'bar')).toBe('')
+  })
+
+  it('allows deep access into objects', () => {
+    ctx.data.foo = 'bar'
+    expect(checked('foo', 'bar')).toBe('checked')
+    ctx.data.foo = { bar: 'baz' }
+    expect(checked("['foo']['bar']", 'baz')).toBe('checked')
+  })
+
+  it('allows deep access using dot notation (undocumented)', () => {
+    ctx.data.foo = { bar: 'baz' }
+    expect(checked('foo.bar', 'baz')).toBe('checked')
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "gulp-sass": "^5.0.0",
         "gulp-sourcemaps": "^3.0.0",
         "inquirer": "^8.2.0",
-        "keypather": "^3.0.0",
+        "lodash": "^4.17.21",
         "marked": "^3.0.8",
         "node-sass": "^6.0.1",
         "notifications-node-client": "^5.1.0",
@@ -1525,32 +1525,6 @@
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
     },
-    "node_modules/101": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/101/-/101-1.6.3.tgz",
-      "integrity": "sha512-4dmQ45yY0Dx24Qxp+zAsNLlMF6tteCyfVzgbulvSyC7tCyd3V8sW76sS0tHq8NpcbXfWTKasfyfzU1Kd86oKzw==",
-      "dependencies": {
-        "clone": "^1.0.2",
-        "deep-eql": "^0.1.3",
-        "keypather": "^1.10.2"
-      }
-    },
-    "node_modules/101/node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/101/node_modules/keypather": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/keypather/-/keypather-1.10.2.tgz",
-      "integrity": "sha1-4ESWMtSz5RbyHMAUznxWRP3c5hQ=",
-      "dependencies": {
-        "101": "^1.0.0"
-      }
-    },
     "node_modules/a-sync-waterfall": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
@@ -2018,15 +1992,6 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dependencies": {
         "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-err": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assert-err/-/assert-err-1.1.0.tgz",
-      "integrity": "sha1-wFBieZodl9P16qJY4yQqq0mfyO8=",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
       }
     },
     "node_modules/assert-plus": {
@@ -3653,17 +3618,6 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
-    },
-    "node_modules/deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-      "dependencies": {
-        "type-detect": "0.1.1"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
@@ -10272,31 +10226,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/keypather": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/keypather/-/keypather-3.1.0.tgz",
-      "integrity": "sha512-DsxfrBVXlQihWmefW/lNvVgtzFoSoDd67mCsop7a+tK9h7ybpBF5YRUXg192GBmOc3gn4IEv3AV69HElXYuCLA==",
-      "dependencies": {
-        "101": "^1.6.2",
-        "debug": "^3.1.0",
-        "escape-string-regexp": "^1.0.5",
-        "shallow-clone": "^3.0.0",
-        "string-reduce": "^1.0.0"
-      }
-    },
-    "node_modules/keypather/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/keypather/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
     "node_modules/keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -13665,17 +13594,6 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
-    "node_modules/shallow-clone": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-      "dependencies": {
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -14291,14 +14209,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/string-reduce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string-reduce/-/string-reduce-1.0.0.tgz",
-      "integrity": "sha1-GfvQUoKsTTomQXISm1l1BujpWAI=",
-      "dependencies": {
-        "assert-err": "^1.1.0"
       }
     },
     "node_modules/string-width": {
@@ -15049,14 +14959,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-      "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/type-fest": {
@@ -16038,31 +15940,6 @@
     }
   },
   "dependencies": {
-    "101": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/101/-/101-1.6.3.tgz",
-      "integrity": "sha512-4dmQ45yY0Dx24Qxp+zAsNLlMF6tteCyfVzgbulvSyC7tCyd3V8sW76sS0tHq8NpcbXfWTKasfyfzU1Kd86oKzw==",
-      "requires": {
-        "clone": "^1.0.2",
-        "deep-eql": "^0.1.3",
-        "keypather": "^1.10.2"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-        },
-        "keypather": {
-          "version": "1.10.2",
-          "resolved": "https://registry.npmjs.org/keypather/-/keypather-1.10.2.tgz",
-          "integrity": "sha1-4ESWMtSz5RbyHMAUznxWRP3c5hQ=",
-          "requires": {
-            "101": "^1.0.0"
-          }
-        }
-      }
-    },
     "@babel/code-frame": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
@@ -17559,15 +17436,6 @@
         "safer-buffer": "~2.1.0"
       }
     },
-    "assert-err": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assert-err/-/assert-err-1.1.0.tgz",
-      "integrity": "sha1-wFBieZodl9P16qJY4yQqq0mfyO8=",
-      "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
-      }
-    },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -18832,14 +18700,6 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
-    },
-    "deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-      "requires": {
-        "type-detect": "0.1.1"
-      }
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -23887,33 +23747,6 @@
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.3.tgz",
       "integrity": "sha512-/PpesirAIfaklxUzp4Yb7xBper9MwP6hNRA6BGGUFCgbJ+BM5CKBtsoxinNXkLHAr+GXS1/lSlF2rP7cv5Fl+g=="
     },
-    "keypather": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/keypather/-/keypather-3.1.0.tgz",
-      "integrity": "sha512-DsxfrBVXlQihWmefW/lNvVgtzFoSoDd67mCsop7a+tK9h7ybpBF5YRUXg192GBmOc3gn4IEv3AV69HElXYuCLA==",
-      "requires": {
-        "101": "^1.6.2",
-        "debug": "^3.1.0",
-        "escape-string-regexp": "^1.0.5",
-        "shallow-clone": "^3.0.0",
-        "string-reduce": "^1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        }
-      }
-    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -26487,14 +26320,6 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
-    "shallow-clone": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-      "requires": {
-        "kind-of": "^6.0.2"
-      }
-    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -27017,14 +26842,6 @@
             "ansi-regex": "^5.0.1"
           }
         }
-      }
-    },
-    "string-reduce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string-reduce/-/string-reduce-1.0.0.tgz",
-      "integrity": "sha1-GfvQUoKsTTomQXISm1l1BujpWAI=",
-      "requires": {
-        "assert-err": "^1.1.0"
       }
     },
     "string-width": {
@@ -27614,11 +27431,6 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
-    },
-    "type-detect": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-      "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
     },
     "type-fest": {
       "version": "0.20.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "gulp-sass": "^5.0.0",
     "gulp-sourcemaps": "^3.0.0",
     "inquirer": "^8.2.0",
-    "keypather": "^3.0.0",
+    "lodash": "^4.17.21",
     "marked": "^3.0.8",
     "node-sass": "^6.0.1",
     "notifications-node-client": "^5.1.0",


### PR DESCRIPTION
keypather is a bit unloved and Dependabot complains about it. We can replace it with the `_.get` function from lodash [[1]]. This also saves a little bit of disk space, as we have to install lodash loads anyway.

This PR checks that everything is a-okay by adding some small tests for `checked`, which uses keypather, and then doing the switch.

[1]: https://lodash.com/docs/4.17.15#get