### PR TITLE
Add bash script `update.sh` to simplify updating existing prototypes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@ CONTRIBUTING.md export-ignore
 create-release.sh export-ignore
 README.md export-ignore
 internal_docs export-ignore
+update.sh export-ignore

--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -24,13 +24,20 @@ const headReleaseVersion = child_process.execSync(
 const headReleaseBasename = `govuk-prototype-kit-${headReleaseVersion}`
 const headReleaseArchiveFilename = `${headReleaseBasename}.zip`
 
+// When running tests using Windows GitHub runner, make sure to use gitbash.
+// Path is from https://github.com/actions/virtual-environments/blob/win19/20211110.1/images/win/Windows2019-Readme.md
+const bash = process.platform === 'win32' ? 'C:\\Program Files\\Git\\bin\\bash.exe' : '/bin/bash'
+
 /*
  * Test helpers
  */
 
 function runScriptSync (options) {
   const opts = { cwd: options.testDir, encoding: 'utf8' }
-  const ret = child_process.spawnSync(script, opts)
+
+  const args = [script]
+
+  const ret = child_process.spawnSync(bash, args, opts)
   if (ret.error) {
     throw (ret.error)
   }
@@ -95,7 +102,11 @@ describe('update.sh', () => {
     fs.writeFileSync(path.join(dirToArchive, 'foo'), '')
     fs.writeFileSync(path.join(dirToArchive, 'VERSION.txt'), '9999.99.99')
 
-    child_process.execSync(`zip -r ${archiveName} govuk-prototype-kit-foo`, { cwd: fixtureDir })
+    if (process.platform === 'win32') {
+      child_process.execSync(`7z a ${archiveName} govuk-prototype-kit-foo`, { cwd: fixtureDir })
+    } else {
+      child_process.execSync(`zip -r ${archiveName} govuk-prototype-kit-foo`, { cwd: fixtureDir })
+    }
   }
 
   function mktestArchiveSync (testDir) {

--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -291,6 +291,17 @@ describe('update.sh', () => {
         fs.accessSync(path.join(testDir, 'update', 'govuk-prototype-kit-empty.zip'))
       }).not.toThrowError()
     })
+
+    it('hides the update folder from git', () => {
+      const testDir = 'prepare-gitignore'
+      fs.mkdirSync(testDir)
+
+      runScriptSyncAndExpectSuccess('prepare', { testDir })
+
+      expect(
+        fs.readFileSync(path.join(testDir, 'update', '.gitignore'), 'utf8').trim()
+      ).toBe('*')
+    })
   })
 
   describe('fetch', () => {
@@ -397,12 +408,30 @@ describe('update.sh', () => {
         fs.readFileSync(path.join(testDir, 'update', 'update.log'), 'utf8')
       ).toMatch(/No such file or directory/)
     })
+
+    it('hides the update folder from git', () => {
+      const testDir = mktestPrototypeSync('copy-gitignore')
+
+      runScriptSyncAndExpectSuccess('copy', { testDir })
+
+      expect(
+        fs.readFileSync(path.join(testDir, 'update', '.gitignore'), 'utf8').trim()
+      ).toBe('*')
+    })
   })
 
   it('can be run as a piped script', () => {
     const testDir = mktestPrototypeSync('pipe')
 
     child_process.execSync(`cat '${script}' | bash`, { cwd: testDir, shell: bash, stdio: 'ignore' })
+  })
+
+  it('hides the update folder from git', () => {
+    const testDir = mktestPrototypeSync('gitignore')
+
+    runScriptSyncAndExpectSuccess({ testDir })
+
+    expect(execGitStatusSync(testDir)).not.toContain('?? update/')
   })
 
   it('does nothing if check fails', () => {

--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -370,6 +370,23 @@ describe('update.sh', () => {
         ' M app/assets/sass/patterns/_task-list.scss'
       ])
     })
+
+    it('it outputs errors and logs them to a file', () => {
+      const testDir = mktestDirSync('error-logging')
+      mktestArchiveSync(testDir)
+
+      runScriptSyncAndExpectSuccess('extract', { testDir })
+      const ret = runScriptSync('copy', { testDir })
+
+      // we expect this to fail because the test archive doesn't have a docs folder
+      expect(ret.status).toBe(1)
+
+      expect(ret.stderr).toMatch(/No such file or directory/)
+      expect(ret.stderr).toMatch(/ERROR/)
+      expect(
+        fs.readFileSync(path.join(testDir, 'update', 'update.log'), 'utf8')
+      ).toMatch(/No such file or directory/)
+    })
   })
 
   afterAll(() => {

--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -359,6 +359,7 @@ describe('update.sh', () => {
       const testDir = mktestPrototypeSync('preserve-app-folder')
 
       const updateDir = path.join(testDir, 'update', headReleaseBasename)
+      fs.unlinkSync(path.join(updateDir, 'app', 'assets', 'sass', 'patterns', '_related-items.scss'))
       fs.writeFileSync(path.join(updateDir, 'app', 'assets', 'sass', 'patterns', '_task-list.scss'), 'foobar')
       fs.writeFileSync(path.join(updateDir, 'app', 'routes.js'), 'arglebargle')
 

--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -230,7 +230,7 @@ describe('update.sh', () => {
       const testDir = 'empty'
       fs.mkdirSync(testDir)
 
-      runScriptSyncAndExpectError('check', { testDir })
+      runScriptSyncAndExpectError({ testDir })
     })
 
     it('exits with error if folder does not contain a package.json file', () => {
@@ -239,21 +239,21 @@ describe('update.sh', () => {
       fs.writeFileSync(path.join(testDir, 'foo'), 'my important data about govuk-prototype-kit')
       fs.writeFileSync(path.join(testDir, 'bar'), "don't delete my data!")
 
-      runScriptSyncAndExpectError('check', { testDir })
+      runScriptSyncAndExpectError({ testDir })
     })
 
     it('exits with error if package.json file does not contain string govuk-prototype-kit', () => {
       const testDir = mktestDirSync('no-govuk-prototype-kit')
       fs.writeFileSync(path.join(testDir, 'package.json'), '{\n  "name": "test"\n}')
 
-      runScriptSyncAndExpectError('check', { testDir })
+      runScriptSyncAndExpectError({ testDir })
     })
 
     it('exits with error if package.json file contains string containing govuk-prototype-kit', () => {
       const testDir = mktestDirSync('name-contains-govuk-prototype-kit')
       fs.writeFileSync(path.join(testDir, 'package.json'), '{\n  "name": "govuk-prototype-kit-test"\n}')
 
-      runScriptSyncAndExpectError('check', { testDir })
+      runScriptSyncAndExpectError({ testDir })
     })
   })
 
@@ -403,6 +403,18 @@ describe('update.sh', () => {
     const testDir = mktestPrototypeSync('pipe')
 
     child_process.execSync(`cat '${script}' | bash`, { cwd: testDir, shell: bash, stdio: 'ignore' })
+  })
+
+  it('does nothing if check fails', () => {
+    const testDir = mktestPrototypeSync('if-check-fails')
+    child_process.execSync('rm -rf update', { cwd: testDir })
+
+    fs.writeFileSync(path.join(testDir, 'package.json'), '{\n  "name": "my-very-customised-prototype" \n}')
+    child_process.execSync('git commit -q -m "Customise my prototype" -a', { cwd: testDir })
+
+    runScriptSyncAndExpectError({ testDir })
+
+    expect(execGitStatusSync(testDir)).toEqual([])
   })
 
   afterAll(() => {

--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -214,6 +214,7 @@ describe('update.sh', () => {
 
   beforeAll(() => {
     process.chdir(tmpDir)
+    console.log('Running tests in temporary directory', process.cwd())
 
     // setup fixtures - running this now saves time later
     fs.mkdirSync(fixtureDir)

--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -1,0 +1,289 @@
+/* eslint-env jest */
+const child_process = require('child_process') // eslint-disable-line camelcase
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const process = require('process')
+
+/*
+ * Constants
+ */
+
+const repoDir = path.resolve(__dirname, '..', '..')
+const script = path.join(repoDir, 'update.sh')
+
+const latestReleaseVersion = fs.readFileSync(
+  path.join(repoDir, 'VERSION.txt'), { encoding: 'utf8' }
+).trim()
+const latestReleaseBasename = `govuk-prototype-kit-${latestReleaseVersion}`
+const latestReleaseArchiveFilename = `${latestReleaseBasename}.zip`
+
+const headReleaseVersion = child_process.execSync(
+  'git rev-parse HEAD', { encoding: 'utf8' }
+).trim()
+const headReleaseBasename = `govuk-prototype-kit-${headReleaseVersion}`
+const headReleaseArchiveFilename = `${headReleaseBasename}.zip`
+
+/*
+ * Test helpers
+ */
+
+function runScriptSync (options) {
+  const opts = { cwd: options.testDir, encoding: 'utf8' }
+  const ret = child_process.spawnSync(script, opts)
+  if (ret.error) {
+    throw (ret.error)
+  }
+  return ret
+}
+
+function runScriptSyncAndExpectSuccess (options) {
+  const ret = runScriptSync(options)
+  if (ret.status !== 0) {
+    throw new Error(`update.sh in ${path.join(process.cwd(), options.testDir)} failed with status ${ret.status}:\n${ret.stderr}`)
+  }
+  return ret
+}
+
+function runScriptSyncAndExpectError (options) {
+  const oldStat = fs.statSync(options.testDir)
+
+  const ret = runScriptSync(options)
+
+  expect(ret.status).not.toBe(0)
+  expect(ret.stderr).toMatch(/ERROR/)
+
+  // tests that no files have been added or removed in test directory
+  const newStat = fs.statSync(options.testDir)
+  expect(newStat.mtimeMs).toBe(oldStat.mtimeMs)
+
+  return ret
+}
+
+function execGitStatusSync (testDir) {
+  return child_process.execSync(
+    'git status --porcelain', { cwd: testDir, encoding: 'utf8' }
+  ).split('\n').slice(0, -1)
+}
+
+describe('update.sh', () => {
+  const _cwd = process.cwd()
+
+  // Following tests will run in a temporary directory, to avoid messing up the project
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jest-'))
+  const fixtureDir = path.resolve(tmpDir, '__fixtures__')
+
+  /*
+   * Fixture helpers
+   */
+
+  function mktestDirSync (testDir) {
+    fs.mkdirSync(testDir)
+
+    fs.writeFileSync(path.join(testDir, 'package.json'), '{\n  "name": "govuk-prototype-kit"\n}')
+    fs.writeFileSync(path.join(testDir, 'VERSION.txt'), '0.0.0')
+
+    return testDir
+  }
+
+  // Create a test archive fixture
+  function _mktestArchiveSync (archive) {
+    const archiveName = path.basename(archive)
+    const dirToArchive = path.join(fixtureDir, 'govuk-prototype-kit-foo')
+
+    fs.mkdirSync(dirToArchive)
+    fs.writeFileSync(path.join(dirToArchive, 'foo'), '')
+    fs.writeFileSync(path.join(dirToArchive, 'VERSION.txt'), '9999.99.99')
+
+    child_process.execSync(`zip -r ${archiveName} govuk-prototype-kit-foo`, { cwd: fixtureDir })
+  }
+
+  function mktestArchiveSync (testDir) {
+    const archive = path.resolve(fixtureDir, 'foo.zip')
+
+    try {
+      fs.accessSync(archive)
+    } catch (error) {
+      _mktestArchiveSync(archive)
+    }
+
+    if (testDir) {
+      const dest = path.join(testDir, 'update', 'govuk-prototype-kit-foo.zip')
+      fs.mkdirSync(path.dirname(dest), { recursive: true })
+      fs.copyFileSync(archive, path.join(testDir, 'update', 'govuk-prototype-kit-foo.zip'))
+      return dest
+    } else {
+      return archive
+    }
+  }
+
+  function _mktestPrototypeSync (src) {
+    // Create a release archive from the HEAD we are running tests in
+    child_process.execSync(
+      `git archive --prefix=${headReleaseBasename}/ --output=${fixtureDir}/${headReleaseArchiveFilename} HEAD`,
+      { cwd: repoDir }
+    )
+
+    // Create a git repo from the new release archive so we can see changes.
+    child_process.execSync(`unzip -q ${headReleaseArchiveFilename}`, { cwd: fixtureDir })
+    child_process.execSync(`mv ${headReleaseBasename} ${src}`, { cwd: fixtureDir })
+
+    child_process.execFileSync('git', ['init'], { cwd: src })
+    child_process.execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: src })
+    child_process.execFileSync('git', ['config', 'user.name', 'Jest Tests'], { cwd: src })
+
+    child_process.execFileSync('git', ['add', '.'], { cwd: src })
+    child_process.execFileSync('git', ['commit', '-m', 'Initial commit'], { cwd: src })
+
+    // let's imagine our prototype has been customised slightly
+    let config = fs.readFileSync(path.join(src, 'app', 'config.js'), 'utf8')
+    config = config.replace('Service name goes here', 'Jest test service')
+    fs.writeFileSync(path.join(src, 'app', 'config.js'), config, 'utf8')
+
+    // and it has been run
+    fs.writeFileSync(path.join(src, 'usage-data-config.json'), '{}')
+
+    child_process.execFileSync('git', ['commit', '-m', 'Test', '-a'], { cwd: src })
+
+    // populate the update folder to speed up tests
+    fs.mkdirSync(path.join(src, 'update'))
+    child_process.execSync(`unzip -q ${fixtureDir}/${headReleaseArchiveFilename}`, { cwd: path.join(src, update) })
+    fs.copyFileSync(path.join(fixtureDir, headReleaseArchiveFilename), path.join(src, 'update', headReleaseArchiveFilename))
+  }
+
+  function mktestPrototypeSync (dest) {
+    const src = path.resolve(fixtureDir, 'prototype')
+    try {
+      fs.accessSync(src)
+    } catch (error) {
+      _mktestPrototypeSync(src)
+    }
+
+    if (dest) {
+      child_process.execSync(`cp -r ${src} ${dest}`)
+      return dest
+    } else {
+      return src
+    }
+  }
+
+  beforeAll(() => {
+    process.chdir(tmpDir)
+
+    // setup fixtures - running this now saves time later
+    fs.mkdirSync(fixtureDir)
+    mktestArchiveSync()
+    mktestPrototypeSync()
+  })
+
+  /*
+   * Tests
+   */
+
+  describe('check', () => {
+    it('exits with error if run in an empty folder', () => {
+      const testDir = 'empty'
+      fs.mkdirSync(testDir)
+
+      runScriptSyncAndExpectError({ testDir })
+    })
+
+    it('exits with error if folder does not contain a package.json file', () => {
+      const testDir = 'no-package-json'
+      fs.mkdirSync(testDir)
+      fs.writeFileSync(path.join(testDir, 'foo'), 'my important data about govuk-prototype-kit')
+      fs.writeFileSync(path.join(testDir, 'bar'), "don't delete my data!")
+
+      runScriptSyncAndExpectError({ testDir })
+    })
+
+    it('exits with error if package.json file does not contain string govuk-prototype-kit', () => {
+      const testDir = mktestDirSync('no-govuk-prototype-kit')
+      fs.writeFileSync(path.join(testDir, 'package.json'), '{\n  "name": "test"\n}')
+
+      runScriptSyncAndExpectError({ testDir })
+    })
+  })
+
+  describe('fetch', () => {
+    it('downloads the latest release of the prototype kit into the update folder', () => {
+      const testDir = mktestDirSync('download')
+
+      runScriptSync({ testDir })
+
+      fs.accessSync(path.join(testDir, 'update'))
+      fs.accessSync(path.join(testDir, 'update', latestReleaseArchiveFilename))
+    })
+  })
+
+  describe('extract', () => {
+    it('extracts the release into the update folder', () => {
+      const testDir = mktestDirSync('extract')
+      fs.mkdirSync(path.join(testDir, 'update'), { recursive: true })
+      mktestArchiveSync(testDir)
+
+      runScriptSync({ testDir })
+
+      fs.accessSync(path.join(testDir, 'update', 'govuk-prototype-kit-foo', 'foo'))
+    })
+  })
+
+  describe('copy', () => {
+    it('updating an existing up-to-date prototype does nothing', () => {
+      const testDir = mktestPrototypeSync('up-to-date')
+
+      runScriptSyncAndExpectSuccess({ testDir })
+
+      // expect that `git status` reports no files added, changed, or removed
+      expect(execGitStatusSync(testDir)).toEqual([])
+    })
+
+    it('does not remove the analytics consent', () => {
+      const testDir = mktestPrototypeSync('usage-data-config')
+
+      const oldStat = fs.statSync(path.join(testDir, 'usage-data-config.json'))
+
+      runScriptSyncAndExpectSuccess({ testDir })
+
+      const newStat = fs.statSync(path.join(testDir, 'usage-data-config.json'))
+      expect(newStat.mtimeMs).toBe(oldStat.mtimeMs)
+    })
+
+    it('removes files that have been removed from docs, gulp and lib folders', () => {
+      const testDir = mktestPrototypeSync('remove-dangling-files')
+
+      const updateDir = path.join(testDir, 'update', headReleaseBasename)
+      fs.unlinkSync(path.join(updateDir, 'docs', 'documentation', 'session.md'))
+      fs.unlinkSync(path.join(updateDir, 'gulp', 'clean.js'))
+      fs.unlinkSync(path.join(updateDir, 'lib', 'v6', 'govuk_template_unbranded.html'))
+      fs.rmdirSync(path.join(updateDir, 'lib', 'v6'))
+
+      runScriptSyncAndExpectSuccess({ testDir })
+
+      expect(execGitStatusSync(testDir)).toEqual([
+        ' D docs/documentation/session.md',
+        ' D gulp/clean.js',
+        ' D lib/v6/govuk_template_unbranded.html'
+      ])
+    })
+
+    it('does not change files in apps folder, except for in assets/sass/patterns', () => {
+      const testDir = mktestPrototypeSync('preserve-app-folder')
+
+      const updateDir = path.join(testDir, 'update', headReleaseBasename)
+      fs.writeFileSync(path.join(updateDir, 'app', 'assets', 'sass', 'patterns', '_task-list.scss'), 'foobar')
+      fs.writeFileSync(path.join(updateDir, 'app', 'routes.js'), 'arglebargle')
+
+      runScriptSyncAndExpectSuccess({ testDir })
+
+      expect(execGitStatusSync(testDir)).toEqual([
+        ' D app/assets/sass/patterns/_related-items.scss',
+        ' M app/assets/sass/patterns/_task-list.scss'
+      ])
+    })
+  })
+
+  afterAll(() => {
+    process.chdir(_cwd)
+  })
+})

--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -399,6 +399,12 @@ describe('update.sh', () => {
     })
   })
 
+  it('can be run as a piped script', () => {
+    const testDir = mktestPrototypeSync('pipe')
+
+    child_process.execSync(`cat '${script}' | bash`, { cwd: testDir, shell: bash, stdio: 'ignore' })
+  })
+
   afterAll(() => {
     process.chdir(_cwd)
   })

--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -248,6 +248,13 @@ describe('update.sh', () => {
 
       runScriptSyncAndExpectError('check', { testDir })
     })
+
+    it('exits with error if package.json file contains string containing govuk-prototype-kit', () => {
+      const testDir = mktestDirSync('name-contains-govuk-prototype-kit')
+      fs.writeFileSync(path.join(testDir, 'package.json'), '{\n  "name": "govuk-prototype-kit-test"\n}')
+
+      runScriptSyncAndExpectError('check', { testDir })
+    })
   })
 
   describe('prepare', () => {

--- a/update.sh
+++ b/update.sh
@@ -8,80 +8,125 @@ msg () {
 	1>&2 echo $*
 }
 
-# check that we are in a prototype
-if ! grep -q govuk-prototype-kit package.json 2> /dev/null; then
-	msg 'ERROR you must run update.sh in a folder containing a GOV.UK Prototype Kit installation'
-	msg 'Exiting'
-	exit 1
+# Set global vars ARCHIVE_FILE ARCHIVE_ROOT
+get_archive_vars () {
+	# choose the archive file with the largest version number, use this to update from
+	ARCHIVE_FILE="$(find . -name 'govuk-prototype-kit*.zip' -exec basename '{}' ';' | sort -V | tail -n1)"
+	ARCHIVE_ROOT="${ARCHIVE_FILE//.zip}"
+}
+
+# Hide update folder from git
+update_gitignore () {
+	cd update
+
+	if [[ -f .gitignore ]]; then
+		cp .gitignore .gitignore.bak
+	fi
+
+	echo '*' > .gitignore
+
+	cd ..
+}
+
+# Check whether it is safe for the script to run
+check () {
+	if ! grep -q 'govuk-prototype-kit' package.json 2> /dev/null; then
+		msg 'ERROR you must run update.sh in a folder containing a GOV.UK Prototype Kit installation'
+		msg 'Exiting'
+		exit 1
+	fi
+}
+
+# Lay the ground work
+prepare () {
+	# Clean any old update folder, in case the script has been run before and the
+	# user did not remove the old update files. If for some reason cleaning is
+	# not desired, run with envvar CLEAN=0.
+	CLEAN="${CLEAN:-1}"
+
+	if [[ "$CLEAN" -eq 1 ]]; then
+		rm -rf update
+	fi
+
+	# make the update folder
+	mkdir -p update
+	update_gitignore
+}
+
+# Download the latest Prototype Kit release archive to the update folder
+fetch () {
+	cd update
+
+	if ! ls govuk-prototype-kit*.zip > /dev/null 2>&1; then
+		msg 'Downloading latest version of GOV.UK Prototye Kit...'
+		curl -LJO https://govuk-prototype-kit.herokuapp.com/docs/download
+		msg 'Done'
+	fi
+
+	cd ..
+}
+
+# Extract the downloaded release archive into the update folder
+extract () {
+	get_archive_vars
+
+	cd update
+
+	# unzip the release archive into the 'update' folder
+	if [ ! -d "$ARCHIVE_ROOT" ]; then
+		msg -n 'Extracting latest files and folders into update folder...'
+		unzip -qn "$ARCHIVE_FILE"
+		msg 'Done'
+	fi
+
+	cd ..
+}
+
+# Copy 'core files' from the update folder into the current prototype folder
+copy () {
+	get_archive_vars
+
+	OLD_VERSION="$(cat VERSION.txt)"
+	NEW_VERSION="$(cat update/"$ARCHIVE_ROOT"/VERSION.txt)"
+
+	# remove node_modules folder to ensure new packages will be installed cleanly
+	rm -rf node_modules
+
+	msg -n 'Updating your prototype files... '
+
+	{
+		echo "Updating from $OLD_VERSION to $NEW_VERSION"
+
+		# Replace core folders, making sure to remove any old files
+		rm -rvf docs gulp lib
+		cp -Rv "update/$ARCHIVE_ROOT/docs" "update/$ARCHIVE_ROOT/gulp" "update/$ARCHIVE_ROOT/lib" .
+
+		# Update core files (copy only the files in the update folder, not files in app/)
+		find "update/$ARCHIVE_ROOT" -type f -depth 1 -print0 | xargs -0 -I % cp -v % .
+
+		# specific workaround for old step 9, yuck
+		cp -Rv "update/$ARCHIVE_ROOT/app/assets/sass/patterns" "app/assets/sass/"
+
+		echo "Done"
+	} >> update/update.log
+
+	msg 'Done'
+
+	msg
+	msg "Your prototype kit files have now been updated, from ${OLD_VERSION} to ${NEW_VERSION}."
+	msg 'There are still some configuration changes needed, please follow the steps at'
+	msg 'https://govuk-prototype-kit.herokuapp.com/docs/updating-the-kit'
+	msg "to complete the update. You can find the files for the new version at \`update/${ARCHIVE_ROOT}\`."
+	msg
+
+	update_gitignore
+}
+
+if [ "$0" == "${BASH_SOURCE[0]}" ]
+then
+	check
+	prepare
+	fetch
+	extract
+	copy
 fi
-
-OLD_VERSION="$(cat VERSION.txt)"
-
-# Clean any old update folder, in case the script has been run before and the
-# user did not remove the old update files. If for some reason cleaning is
-# not desired, run with envvar CLEAN=0.
-CLEAN="${CLEAN:-1}"
-
-if [[ "$CLEAN" -eq 1 ]]; then
-  rm -rf update
-fi
-
-# make the update folder
-mkdir -p update
-# stop git from committing the update folder
-echo '*' > update/.gitignore
-
-# download the latest Prototype Kit release archive to the update folder
-cd update
-
-if ! ls govuk-prototype-kit*.zip > /dev/null 2>&1; then
-  msg 'Downloading latest version of GOV.UK Prototye Kit...'
-  curl -LJO https://govuk-prototype-kit.herokuapp.com/docs/download
-  msg 'Done'
-fi
-
-# choose the archive file with the largest version number, use this to update from
-ARCHIVE_FILE="$(find . -name 'govuk-prototype-kit*.zip' | sort -V | tail -n1)"
-ARCHIVE_ROOT="${ARCHIVE_FILE//.zip}"
-NEW_VERSION="${ARCHIVE_ROOT#govuk-prototype-kit-}"
-
-# unzip the release archive into the 'update' folder
-if [ ! -d "$ARCHIVE_ROOT" ]; then
-  msg -n 'Extracting latest files and folders into update folder...'
-  unzip -qn "$ARCHIVE_FILE"
-  msg 'Done'
-fi
-
-# Go back to the prototype folder
-cd ..
-
-# remove node_modules folder to ensure new packages will be installed cleanly
-rm -rf node_modules
-
-# copy from the update folder into the current prototype folder
-msg -n 'Updating your prototype files... '
-
-{
-  echo "Updating from $OLD_VERSION to $NEW_VERSION"
-
-  # Replace core folders, making sure to remove any old files
-  rm -rvf docs gulp lib
-  cp -Rv "update/$ARCHIVE_ROOT/docs" "update/$ARCHIVE_ROOT/gulp" "update/$ARCHIVE_ROOT/lib" .
-
-  # Update core files (copy only the files in the update folder, not files in app/)
-  find "update/$ARCHIVE_ROOT" -type f -depth 1 -print0 | xargs -0 -I % cp -v % .
-
-  # specific workaround for old step 9, yuck
-  cp -Rv "update/$ARCHIVE_ROOT/app/assets/sass/patterns" "app/assets/sass/"
-
-  echo "Done"
-} >> update/update.log
-
-msg 'Done'
-
-msg
-msg "Your prototype kit files have now been updated, from ${OLD_VERSION} to ${NEW_VERSION}."
-msg 'There are still some configuration changes needed, please follow the steps at'
-msg 'https://govuk-prototype-kit.herokuapp.com/docs/updating-the-kit'
-msg "to complete the update. You can find the files for the new version at \`update/${ARCHIVE_ROOT}\`."
-msg

--- a/update.sh
+++ b/update.sh
@@ -118,7 +118,7 @@ copy () {
 		cp -Rv "update/$ARCHIVE_ROOT/docs" "update/$ARCHIVE_ROOT/gulp" "update/$ARCHIVE_ROOT/lib" .
 
 		# Update core files (copy only the files in the update folder, not files in app/)
-		find "update/$ARCHIVE_ROOT" -type f -depth 1 -print0 | xargs -0 -I % cp -v % .
+		find "update/$ARCHIVE_ROOT" -maxdepth 1 -type f -print0 | xargs -0 -I % cp -v % .
 
 		# specific workaround for old step 9, yuck
 		rm -rvf app/assets/sass/patterns

--- a/update.sh
+++ b/update.sh
@@ -30,7 +30,7 @@ update_gitignore () {
 
 # Check whether it is safe for the script to run
 check () {
-	if ! grep -q 'govuk-prototype-kit' package.json 2> /dev/null; then
+	if ! grep -q '"govuk-prototype-kit"' package.json 2> /dev/null; then
 		msg 'ERROR you must run update.sh in a folder containing a GOV.UK Prototype Kit installation'
 		msg 'Exiting'
 		exit 1

--- a/update.sh
+++ b/update.sh
@@ -151,7 +151,7 @@ copy () {
 	update_gitignore
 }
 
-if [ "$0" == "${BASH_SOURCE[0]}" ]
+if [ "$0" == "${BASH_SOURCE:-$0}" ]
 then
 	check
 	prepare

--- a/update.sh
+++ b/update.sh
@@ -114,6 +114,8 @@ copy () {
 	{
 		echo "Updating from $OLD_VERSION to $NEW_VERSION"
 
+		set -x
+
 		# Replace core folders, making sure to remove any old files
 		rm -rvf docs gulp lib
 		cp -Rv "update/docs" "update/gulp" "update/lib" .
@@ -129,6 +131,8 @@ copy () {
 		# specific workaround for old step 9, yuck
 		rm -rvf app/assets/sass/patterns
 		cp -Rv "update/app/assets/sass/patterns" "app/assets/sass/"
+
+		set +x
 
 		echo "Done"
 	} >> update/update.log 3>&2 2>&1

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# Use unofficial bash strict mode
+set -euo pipefail
+
+msg () {
+	# shellcheck disable=SC2048,2086 # we want to expand words to allow -n flag
+	1>&2 echo $*
+}
+
+# check that we are in a prototype
+if ! grep -q govuk-prototype-kit package.json 2> /dev/null; then
+	msg 'ERROR you must run update.sh in a folder containing a GOV.UK Prototype Kit installation'
+	msg 'Exiting'
+	exit 1
+fi
+
+OLD_VERSION="$(cat VERSION.txt)"
+
+# make the update folder
+mkdir -p update
+# stop git from committing the update folder
+echo '*' > update/.gitignore
+
+# download the latest Prototype Kit release archive to the update folder
+cd update
+
+if ! ls govuk-prototype-kit*.zip > /dev/null 2>&1; then
+  msg 'Downloading latest version of GOV.UK Prototye Kit...'
+  curl -LJO https://govuk-prototype-kit.herokuapp.com/docs/download
+  msg 'Done'
+fi
+
+# choose the archive file with the largest version number, use this to update from
+ARCHIVE_FILE="$(find . -name 'govuk-prototype-kit*.zip' | sort -V | tail -n1)"
+ARCHIVE_ROOT="${ARCHIVE_FILE//.zip}"
+NEW_VERSION="${ARCHIVE_ROOT#govuk-prototype-kit-}"
+
+# unzip the release archive into the 'update' folder
+if [ ! -d "$ARCHIVE_ROOT" ]; then
+  msg -n 'Extracting latest files and folders into update folder...'
+  unzip -qn "$ARCHIVE_FILE"
+  msg 'Done'
+fi
+
+# Go back to the prototype folder
+cd ..
+
+# remove node_modules folder to ensure new packages will be installed cleanly
+rm -rf node_modules
+
+# copy from the update folder into the current prototype folder
+msg -n 'Updating your prototype files... '
+
+{
+  echo "Updating from $OLD_VERSION to $NEW_VERSION"
+
+  # Replace core folders, making sure to remove any old files
+  rm -rvf docs gulp lib
+  cp -Rv "update/$ARCHIVE_ROOT/docs" "update/$ARCHIVE_ROOT/gulp" "update/$ARCHIVE_ROOT/lib" .
+
+  # Update core files (copy only the files in the update folder, not files in app/)
+  find "update/$ARCHIVE_ROOT" -type f -depth 1 -print0 | xargs -0 -I % cp -v % .
+
+  # specific workaround for old step 9, yuck
+  cp -Rv "update/$ARCHIVE_ROOT/app/assets/sass/patterns" "app/assets/sass/"
+
+  echo "Done"
+} >> update/update.log
+
+msg 'Done'
+
+msg
+msg "Your prototype kit files have now been updated, from ${OLD_VERSION} to ${NEW_VERSION}."
+msg 'There are still some configuration changes needed, please follow the steps at'
+msg 'https://govuk-prototype-kit.herokuapp.com/docs/updating-the-kit'
+msg "to complete the update. You can find the files for the new version at \`update/${ARCHIVE_ROOT}\`."
+msg

--- a/update.sh
+++ b/update.sh
@@ -58,7 +58,7 @@ fetch () {
 	cd update
 
 	if ! ls govuk-prototype-kit*.zip > /dev/null 2>&1; then
-		msg 'Downloading latest version of GOV.UK Prototye Kit...'
+		msg 'Downloading latest version of GOV.UK Prototype Kit...'
 		curl -LJO https://govuk-prototype-kit.herokuapp.com/docs/download
 		msg 'Done'
 	fi
@@ -142,10 +142,10 @@ copy () {
 	trap - ERR
 
 	msg
-	msg "Your prototype kit files have now been updated, from ${OLD_VERSION} to ${NEW_VERSION}."
-	msg 'There are still some configuration changes needed, please follow the steps at'
+	msg "Your prototype kit files have now been updated, from version ${OLD_VERSION} to ${NEW_VERSION}."
+	msg 'If you need to make configuration changes, follow the steps at'
 	msg 'https://govuk-prototype-kit.herokuapp.com/docs/updating-the-kit'
-	msg "to complete the update. You can find the files for the new version at \`update\`."
+	msg "The files for the new version are at \`update\`."
 	msg
 
 	update_gitignore

--- a/update.sh
+++ b/update.sh
@@ -17,6 +17,15 @@ fi
 
 OLD_VERSION="$(cat VERSION.txt)"
 
+# Clean any old update folder, in case the script has been run before and the
+# user did not remove the old update files. If for some reason cleaning is
+# not desired, run with envvar CLEAN=0.
+CLEAN="${CLEAN:-1}"
+
+if [[ "$CLEAN" -eq 1 ]]; then
+  rm -rf update
+fi
+
 # make the update folder
 mkdir -p update
 # stop git from committing the update folder

--- a/update.sh
+++ b/update.sh
@@ -105,6 +105,7 @@ copy () {
 		find "update/$ARCHIVE_ROOT" -type f -depth 1 -print0 | xargs -0 -I % cp -v % .
 
 		# specific workaround for old step 9, yuck
+		rm -rvf app/assets/sass/patterns
 		cp -Rv "update/$ARCHIVE_ROOT/app/assets/sass/patterns" "app/assets/sass/"
 
 		echo "Done"


### PR DESCRIPTION
We want to make it easier for users to update existing prototypes to use the latest code from GitHub; the current method is entirely manual and difficult for even developers to follow.

This is especially important for the (currently unreleased) changes to add a package lockfile; for existing installations to be able to use a package lockfile some hidden files need to be updated, which is difficult to do manually.

This commit adds a small bash script to simplify some (but not all) of the steps required to update an existing prototype. It covers steps 1, 2, 4, and 5 (not 3) in the existing process [[1]]. The hypothesis is that it will be easier for users to run the script than do these steps manually, and easier to write a script that is robust and can do these steps without breaking. Note that we don't include step 3, make a backup copy of your prototype folder, because we felt that it is more useful for the user to do this so they know where the backup is, and it reduces the risk of the script somehow messing up the backup.

The script is currently quite 'chatty'; the theory behind this is that it will be helpful for our users to see what the script is doing, and it will also be helpful for us if we need to debug problems. It also logs the final step of copying files from the new folder to the old in a file `update/update.log`, again to aid with debugging.

We also tried to make sure that the script was relatively safe; it will not run if the current working directory does not contain a prototype, it avoids running commands twice (if for instance the script has already been run), and it will exit immediately if any commands result in an error.

---

Note to Linux users: this script is currently targeted at users of the latest versions of macOS and Git for Windows, and uses commands which are included as standard in those systems but are not included as standard on Linux. You may need to ensure that curl and unzip are installed on your system before the script will run correctly.

[1]: https://github.com/alphagov/govuk-prototype-kit/blob/ca3561625c03e1bbbb9a8b588bea5e5336bb14f8/docs/documentation/updating-the-kit.md