### PR TITLE
Remove line about considering removing package lockfile

### DIFF
--- a/internal_docs/releasing.md
+++ b/internal_docs/releasing.md
@@ -1,7 +1,5 @@
 # Releasing a new version of the prototype kit
 
-**Consider removing package-lock.json and disabling npm auditing in a .npmrc file**
-
 1. Checkout main and pull latest changes.
 
 2. Decide on a new version number. Do this by looking at the [current "Unreleased" CHANGELOG](../CHANGELOG.md) changes and updating the previous release number depending on the kind of entries:


### PR DESCRIPTION
We've decided to encourage users to use a lockfile. We've also already changed the npm audit configuration.