### PR TITLE
Replace basic auth with a custom authentication process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ lib/extensions/_extensions.scss
 public
 node_modules/
 .tmuxp.*
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Fixes
+
+- [#1182: Replace basic auth with a custom authentication process](https://github.com/alphagov/govuk-prototype-kit/pull/1182)
+
 # 12.0.2 (Fix release)
 
 ## Fixes

--- a/lib/middleware/authentication/authentication.js
+++ b/lib/middleware/authentication/authentication.js
@@ -1,43 +1,84 @@
-/**
- * Simple basic auth middleware for use with Express 4.x.
- *
- * Based on template found at: http://www.danielstjules.com/2014/08/03/basic-auth-with-express-4/
- *
- * @example
- * const authentication = required('authentication.js')
- * app.use(authentication)
- *
- * @param   {string}   req Express Request object
- * @param   {string}   res Express Response object
- * @returns {function} Express 4 middleware requiring the given credentials
- */
+// Core dependencies
+const url = require('url')
 
-module.exports = function (req, res, next) {
-  // NPM Dependencies
-  const basicAuth = require('basic-auth')
+// Local dependencies
+const config = require('../../../app/config')
+const encryptPassword = require('../../utils').encryptPassword
 
-  // Local dependencies
-  const config = require('../../../app/config.js')
+// Local variables
+const allowedPathsWhenUnauthenticated = [
+  '/prototype-admin/password',
+  '/public/stylesheets/unbranded.css',
+  '/public/stylesheets/unbranded-ie8.css',
+  '/extension-assets/govuk-frontend/govuk/all.js']
 
-  // Local Variables
-  const glitchEnv = (process.env.PROJECT_REMIX_CHAIN) ? 'production' : false // glitch.com
-  const env = (process.env.NODE_ENV || glitchEnv || 'development').toLowerCase()
-  const useAuth = (process.env.USE_AUTH || config.useAuth).toLowerCase()
-  const username = process.env.USERNAME
-  const password = process.env.PASSWORD
-
-  if (env === 'production' && useAuth === 'true') {
-    if (!username || !password) {
-      console.error('Username or password is not set.')
-      return res.send('<h1>Error:</h1><p>Username or password not set. <a href="https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku#6-set-a-username-and-password">See guidance for setting these</a>.</p>')
-    }
-
-    const user = basicAuth(req)
-
-    if (!user || user.name !== username || user.pass !== password) {
-      res.set('WWW-Authenticate', 'Basic realm=Authorization Required')
-      return res.sendStatus(401)
+function authentication () {
+  if (!shouldUseAuth()) {
+    return function doNothing (req, res, next) {
+      next()
     }
   }
-  next()
+
+  if (!process.env.PASSWORD) {
+    return function showErrors (req, res, next) {
+      showNoPasswordError(res)
+    }
+  }
+
+  // password is encrypted because we store it in a cookie
+  // we store the password to compare in case it is changed server-side
+  // changing the password should require users to re-authenticate
+  const password = encryptPassword(process.env.PASSWORD)
+
+  return function authentication (req, res, next) {
+    if (allowedPathsWhenUnauthenticated.includes(req.path)) {
+      next()
+    } else if (isAuthenticated(password, req)) {
+      next()
+    } else {
+      sendUserToPasswordPage(req, res)
+    }
+  }
+}
+
+module.exports = authentication
+
+function shouldUseAuth () {
+  const useAuth = (process.env.USE_AUTH || config.useAuth || 'not set').toLowerCase()
+  if (useAuth !== 'true') {
+    return false
+  }
+
+  const isRunningInGlitch = process.env.PROJECT_REMIX_CHAIN !== undefined
+  if (isRunningInGlitch) {
+    return true
+  }
+
+  const safeNodeEnv = process.env.NODE_ENV || 'not set'
+  const isRunningInProduction = safeNodeEnv.toLowerCase() === 'production'
+  if (isRunningInProduction) {
+    return true
+  }
+  return false
+}
+
+function showNoPasswordError (res) {
+  console.error('Password is not set.')
+  return res.send('<h1>Error:</h1><p>Password not set. <a href="https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku#6-set-a-password">See guidance for setting a password</a>.</p>')
+}
+
+function sendUserToPasswordPage (req, res) {
+  const returnURL = url.format({
+    pathname: req.path,
+    query: req.query
+  })
+  const passwordPageURL = url.format({
+    pathname: '/prototype-admin/password',
+    query: { returnURL }
+  })
+  res.redirect(passwordPageURL)
+}
+
+function isAuthenticated (encryptedPassword, req) {
+  return req.cookies.authentication === encryptedPassword
 }

--- a/lib/middleware/authentication/authentication.test.js
+++ b/lib/middleware/authentication/authentication.test.js
@@ -1,138 +1,227 @@
 /* eslint-env jest */
 // NPM dependencies
-jest.mock('basic-auth')
-jest.mock('express/lib/response')
-const basicAuth = require('basic-auth')
+const url = require('url')
 
 // Local dependencies
-const authentication = require('./authentication.js')
+const authentication = require('./authentication')
+const config = require('../../../app/config')
 
 // Local variables
-const userDetails = {
-  name: 'secret-username',
-  pass: 'secure-password'
-}
+const userPassword = 'secure-password'
+const encryptedUserPassword = '3885c3c07cfdd4bc7d08ded0f4e39b7300b2ae872d18e3c8c192926c9d6e6636'
 const next = jest.fn()
 
 const res = require('express/lib/response')
 
+const examplePath = url.format({
+  pathname: '/abc/def'
+})
+const exampleQuery = {
+  ghi: 'jkl',
+  mno: 'pqr'
+}
+const unauthenticatedCookie = {}
+const authenticatedCookie = {
+  authentication: encryptedUserPassword
+}
+
+const originalEnvironmentVariables = process.env
+
 // Mock console.log so we can check any output
 console.error = jest.fn()
 
+jest.mock('express/lib/response')
+jest.mock('../../../app/config')
+
 describe('authentication', () => {
+  beforeEach(function () {
+    process.env = {}
+    jest.clearAllMocks()
+  })
+  afterEach(function () {
+    process.env = originalEnvironmentVariables
+  })
+  const assume = expect
   it('should be a function', () => {
     expect(authentication).toBeInstanceOf(Function)
   })
 
+  it('returns a middleware function', () => {
+    expect(authentication()).toBeInstanceOf(Function)
+  })
+
   describe('when it runs in production', () => {
-    beforeAll(() => {
+    beforeEach(() => {
       process.env.NODE_ENV = 'production'
       process.env.USE_AUTH = 'true'
     })
 
-    describe('server with no username/password set', () => {
-      beforeAll(() => {
-        delete process.env.USERNAME
-        delete process.env.PASSWORD
-      })
-
+    describe('server with no password set', () => {
       beforeEach(() => {
+        delete process.env.PASSWORD
         // Jest mocks stores each call to the mocked function
         // so we want to clear them before running the authentication again.
         console.error.mockClear()
-        authentication({}, res, next)
+        authentication()({ path: examplePath }, res, next)
       })
 
       it('should return a console error', () => {
         const consoleErrorMessage = console.error.mock.calls[0][0]
-        expect(consoleErrorMessage).toBe('Username or password is not set.')
+        expect(consoleErrorMessage).toBe('Password is not set.')
       })
 
-      it('should send marked up error message', () => {
+      it('should return a user friendly error to the browser', () => {
         const errorDisplayedToUser = res.send.mock.calls[0][0]
-        expect(errorDisplayedToUser).toBe('<h1>Error:</h1><p>Username or password not set. <a href="https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku#6-set-a-username-and-password">See guidance for setting these</a>.</p>')
+        expect(errorDisplayedToUser).toBe('<h1>Error:</h1><p>Password not set. <a href="https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku#6-set-a-password">See guidance for setting a password</a>.</p>')
       })
     })
 
-    describe('server with username/password set', () => {
-      beforeAll(() => {
-        process.env.USERNAME = 'secret-username'
-        process.env.PASSWORD = 'secure-password'
+    describe('server with password set', () => {
+      beforeEach(() => {
+        process.env.PASSWORD = userPassword
       })
 
-      describe('when a user supplies correct username/password', () => {
+      describe('when a user is not authenticated', () => {
+        function callMiddleware () {
+          authentication()({
+            path: examplePath,
+            query: exampleQuery,
+            cookies: unauthenticatedCookie
+          }, res, next)
+        }
+
+        it('should redirect to password page when USE_AUTH is lowercase true', () => {
+          process.env.USE_AUTH = 'true'
+
+          callMiddleware()
+
+          expect(res.redirect).toHaveBeenCalledWith(
+            '/prototype-admin/password?returnURL=%2Fabc%2Fdef%3Fghi%3Djkl%26mno%3Dpqr')
+        })
+        it('should redirect to password page when USE_AUTH is uppercase TRUE', () => {
+          process.env.USE_AUTH = 'TRUE'
+
+          callMiddleware()
+
+          expect(res.redirect).toHaveBeenCalledWith(
+            '/prototype-admin/password?returnURL=%2Fabc%2Fdef%3Fghi%3Djkl%26mno%3Dpqr')
+        })
+        it('should redirect to password page when NODE_ENV is uppercase PRODUCTION', () => {
+          process.env.NODE_ENV = 'PRODUCTION'
+
+          callMiddleware()
+
+          expect(res.redirect).toHaveBeenCalledWith(
+            '/prototype-admin/password?returnURL=%2Fabc%2Fdef%3Fghi%3Djkl%26mno%3Dpqr')
+        })
+        it('should redirect to password page when NODE_ENV is lowercase production', () => {
+          process.env.NODE_ENV = 'production'
+
+          callMiddleware()
+
+          expect(res.redirect).toHaveBeenCalledWith(
+            '/prototype-admin/password?returnURL=%2Fabc%2Fdef%3Fghi%3Djkl%26mno%3Dpqr')
+        })
+        it('should redirect to password page when hosted on Glitch', () => {
+          process.env.PROJECT_REMIX_CHAIN = 'lasdkflkdsjf (any value here)'
+          delete process.env.NODE_ENV
+
+          callMiddleware()
+
+          expect(res.redirect).toHaveBeenCalledWith(
+            '/prototype-admin/password?returnURL=%2Fabc%2Fdef%3Fghi%3Djkl%26mno%3Dpqr')
+        })
+        it('should redirect to password page when config.js has useAuth="true"', () => {
+          delete process.env.USE_AUTH
+
+          config.useAuth = 'true'
+
+          callMiddleware()
+
+          expect(res.redirect).toHaveBeenCalledWith(
+            '/prototype-admin/password?returnURL=%2Fabc%2Fdef%3Fghi%3Djkl%26mno%3Dpqr')
+        })
+        it('should redirect to password page when USE_AUTH="true" even if config.js has useAuth="false"', () => {
+          process.env.USE_AUTH = 'true'
+          config.useAuth = 'false'
+
+          callMiddleware()
+
+          expect(res.redirect).toHaveBeenCalledWith(
+            '/prototype-admin/password?returnURL=%2Fabc%2Fdef%3Fghi%3Djkl%26mno%3Dpqr')
+        })
+        it('should not redirect to password page when USE_AUTH="false" even if config.js has useAuth="true"', () => {
+          process.env.USE_AUTH = 'false'
+          config.useAuth = 'true'
+
+          callMiddleware()
+
+          expect(res.redirect).not.toHaveBeenCalled()
+          expect(next).toHaveBeenCalled()
+        })
+        it('should not be able to load assets', () => {
+          authentication()({
+            path: '/public/stylesheets/unbranded2.css',
+            cookies: unauthenticatedCookie
+          }, res, next)
+
+          expect(res.redirect).toHaveBeenCalledWith('/prototype-admin/password?returnURL=%2Fpublic%2Fstylesheets%2Funbranded2.css')
+          expect(next).not.toHaveBeenCalled()
+        })
+        it('should be able to load styles for password page', () => {
+          authentication()({
+            path: '/public/stylesheets/unbranded.css',
+            cookies: unauthenticatedCookie
+          }, res, next)
+
+          assume(res.redirect).not.toHaveBeenCalled()
+          expect(next).toHaveBeenCalled()
+        })
+        it('should be able to load styles for IE8 password page', () => {
+          authentication()({
+            path: '/public/stylesheets/unbranded-ie8.css',
+            cookies: unauthenticatedCookie
+          }, res, next)
+
+          assume(res.redirect).not.toHaveBeenCalled()
+          expect(next).toHaveBeenCalled()
+        })
+      })
+
+      describe('when a user is authenticated', () => {
         beforeEach(() => {
-          jest.clearAllMocks()
-          basicAuth.mockReturnValue(userDetails)
-          authentication({}, res, next)
+          authentication()({
+            path: examplePath,
+            query: exampleQuery,
+            cookies: authenticatedCookie
+          }, res, next)
+        })
+
+        it('should not redirect to the password page', () => {
+          expect(res.redirect).not.toBeCalled()
         })
 
         it('should not return a console error', () => {
           expect(console.error).not.toBeCalled()
-        })
-
-        it('should call basic-auth and return username/password', () => {
-          expect(basicAuth).toReturnWith(userDetails)
         })
 
         it('should not set authentication header', () => {
           expect(res.set).not.toBeCalled()
         })
 
-        it('should not return a status', () => {
-          expect(res.sendStatus).not.toBeCalled()
-        })
-
         it('should progress to the next middleware', () => {
           expect(next).toBeCalled()
-        })
-      })
-
-      describe('when a user supplies incorrect username/password', () => {
-        beforeEach(() => {
-          jest.clearAllMocks()
-          basicAuth.mockReturnValue(undefined)
-          authentication({}, res, next)
-        })
-
-        it('should not return a console error', () => {
-          expect(console.error).not.toBeCalled()
-        })
-
-        it('should not send error message to the browser', () => {
-          expect(res.send).not.toBeCalled()
-        })
-
-        it('should call basic-auth and return username/password', () => {
-          expect(basicAuth).toReturnWith(undefined)
-        })
-
-        it('should set authentication header', () => {
-          expect(res.set).toHaveBeenCalledWith('WWW-Authenticate', 'Basic realm=Authorization Required')
-        })
-
-        it('should return 401/UnAuthorized', () => {
-          expect(res.sendStatus).toHaveBeenCalledWith(401)
-        })
-
-        it('should not progress to the next middleware', () => {
-          expect(next).not.toBeCalled()
         })
       })
     })
   })
 
-  describe('when it runs in non-production enviroment (dev by default)', () => {
-    beforeAll(() => {
-      // Jest automatically sets NODE_ENV to 'test'
-      // but we want to test when there is no NODE_ENV and it defaults
-      // to development
-      delete process.env.NODE_ENV
-    })
-
+  describe('when it runs in non-production environment (dev by default)', () => {
     beforeEach(() => {
-      jest.clearAllMocks()
-      authentication({}, res, next)
+      authentication()({
+        path: examplePath,
+        query: exampleQuery
+      }, res, next)
     })
 
     it('should not call console error', () => {
@@ -143,19 +232,50 @@ describe('authentication', () => {
       expect(res.send).not.toBeCalled()
     })
 
-    it('should not call basic-auth', () => {
-      expect(basicAuth).not.toBeCalled()
+    it('should progress to the next middleware', () => {
+      expect(next).toBeCalled()
     })
+  })
 
-    it('should not set authentication header', () => {
-      expect(res.set).not.toBeCalled()
-    })
+  describe('authentication is off', () => {
+    function callMiddleware () {
+      authentication()({
+        path: examplePath,
+        query: exampleQuery
+      }, res, next)
+    }
 
-    it('should not return 401/UnAuthorized', () => {
-      expect(res.sendStatus).not.toBeCalled()
+    it('should progress to the next middleware', () => {
+      process.env.NODE_ENV = 'production'
+      process.env.USE_AUTH = 'false'
+
+      callMiddleware()
+
+      assume(console.error).not.toBeCalled()
+      assume(res.send).not.toBeCalled()
+      expect(next).toBeCalled()
     })
 
     it('should progress to the next middleware', () => {
+      process.env.NODE_ENV = 'production'
+      process.env.USE_AUTH = 'FALSE'
+
+      callMiddleware()
+
+      assume(console.error).not.toBeCalled()
+      assume(res.send).not.toBeCalled()
+      expect(next).toBeCalled()
+    })
+    it('should redirect to password page when config says useAuth="false"', () => {
+      process.env.NODE_ENV = 'production'
+      delete process.env.USE_AUTH
+
+      config.useAuth = 'false'
+
+      callMiddleware()
+
+      assume(console.error).not.toBeCalled()
+      assume(res.send).not.toBeCalled()
       expect(next).toBeCalled()
     })
   })

--- a/lib/prototype-admin-routes.js
+++ b/lib/prototype-admin-routes.js
@@ -1,0 +1,42 @@
+// NPM dependencies
+const express = require('express')
+const router = express.Router()
+
+// Local dependencies
+const encryptPassword = require('./utils').encryptPassword
+
+const password = process.env.PASSWORD
+
+// Clear all data in session
+router.post('/clear-data', function (req, res) {
+  req.session.data = {}
+  res.render('prototype-admin/clear-data-success')
+})
+
+// Render password page with a returnURL to redirect people to where they came from
+router.get('/password', function (req, res) {
+  const returnURL = req.query.returnURL || '/'
+  const error = req.query.error
+  res.render('prototype-admin/password', { returnURL, error })
+})
+
+// Check authentication password
+router.post('/password', function (req, res) {
+  const submittedPassword = req.body._password
+  const returnURL = req.body.returnURL
+
+  if (submittedPassword === password) {
+    // see lib/middleware/authentication.js for explanation
+    res.cookie('authentication', encryptPassword(password), {
+      maxAge: 1000 * 60 * 60 * 24 * 30, // 30 days
+      sameSite: 'None', // Allows GET and POST requests from other domains
+      httpOnly: true,
+      secure: true
+    })
+    res.redirect(returnURL)
+  } else {
+    res.redirect('/prototype-admin/password?error=wrong-password&returnURL=' + encodeURIComponent(returnURL))
+  }
+})
+
+module.exports = router

--- a/lib/prototype-admin/password.html
+++ b/lib/prototype-admin/password.html
@@ -1,0 +1,71 @@
+
+{% extends "layout_unbranded.html" %}
+
+{% set serviceName %}
+{% endset %}
+
+{% block pageTitle %}
+  {% if error == "wrong-password" %}
+    Error:
+  {% endif %}
+  Sign in - GOV.UK Prototype Kit
+{% endblock %}
+
+{% block scripts %}
+  <!-- We only need Frontend js in order to focus the error summary -->
+  <script src="/extension-assets/govuk-frontend/govuk/all.js"></script>
+  <script>
+    window.GOVUKFrontend.initAll()
+  </script>
+{% endblock %}
+
+
+{% block content %}
+
+<form method="post" action="/prototype-admin/password">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+
+      {% if error == "wrong-password" %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: [
+            {
+              text: "The password is not correct",
+              href: "#password"
+            }
+          ]
+        })}}
+      {% endif %}
+
+      <h1 class="govuk-heading-xl">
+        This is a prototype used for research
+      </h1>
+
+      <p>
+          It is not a real service. You should only continue if you have been invited to test this prototype.
+      </p>
+
+      {{ govukInput({
+        classes: "govuk-input--width-10",
+        name: "_password",
+        id: "password",
+        type: "password",
+        errorMessage: {
+          text: "The password is not correct"
+        } if error == "wrong-password",
+        label:{
+            text: "Password"
+        }
+      }) }}
+
+      <input type="hidden" name="returnURL" value="{{returnURL}}">
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+    </div>
+  </div>
+</form>
+
+{% endblock %}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 // Core dependencies
+const crypto = require('crypto')
 const fs = require('fs')
 
 // NPM dependencies
@@ -277,4 +278,10 @@ exports.autoStoreData = function (req, res, next) {
   }
 
   next()
+}
+
+exports.encryptPassword = function (password) {
+  const hash = crypto.createHash('sha256')
+  hash.update(password)
+  return hash.digest('hex')
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,10 @@
       "dependencies": {
         "acorn": "^8.5.0",
         "ansi-colors": "^4.1.1",
-        "basic-auth": "^2.0.0",
-        "basic-auth-connect": "^1.0.0",
         "body-parser": "^1.14.1",
         "browser-sync": "^2.11.1",
         "client-sessions": "^0.8.0",
+        "cookie-parser": "^1.4.6",
         "cross-spawn": "^7.0.2",
         "del": "^6.0.0",
         "dotenv": "^10.0.0",
@@ -2291,22 +2290,6 @@
         "node": "^4.5.0 || >= 5.9"
       }
     },
-    "node_modules/basic-auth": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-      "dependencies": {
-        "safe-buffer": "5.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/basic-auth-connect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
-      "integrity": "sha1-/bC0OWLKe0BFanwrtI/hc9otISI="
-    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -3213,6 +3196,18 @@
       "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/cookie-signature": {
@@ -16624,19 +16619,6 @@
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
       "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
     },
-    "basic-auth": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
-    "basic-auth-connect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
-      "integrity": "sha1-/bC0OWLKe0BFanwrtI/hc9otISI="
-    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -17338,6 +17320,15 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+    },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      }
     },
     "cookie-signature": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -9,16 +9,16 @@
   "scripts": {
     "start": "node start.js",
     "lint": "standard",
+    "rapidtest": "jest --bail",
     "test": "npm run lint && gulp generate-assets && jest"
   },
   "dependencies": {
     "acorn": "^8.5.0",
     "ansi-colors": "^4.1.1",
-    "basic-auth": "^2.0.0",
-    "basic-auth-connect": "^1.0.0",
     "body-parser": "^1.14.1",
     "browser-sync": "^2.11.1",
     "client-sessions": "^0.8.0",
+    "cookie-parser": "^1.4.6",
     "cross-spawn": "^7.0.2",
     "del": "^6.0.0",
     "dotenv": "^10.0.0",


### PR DESCRIPTION
[Browsers no longer always support basic auth](https://github.com/alphagov/govuk-prototype-kit/issues/1019) so this PR replaces it with:

 - middleware to check `req.session.authentication` is the current encrypted password
 - if not, redirect to a new `prototype-admin/password` page
 - a route to check the `password` POSTed from the page matches the `PASSWORD` set in the environment
 - if so, set `req.session.authentication` to the current encrypted password
 - redirect back to the page initially requested

to test this branch, run:
```
NODE_ENV=production USE_HTTPS=false PASSWORD=test npm start
```

Screenshot:
![This is a prototype used for research. It is not a real service. You should only continue if you have been invited to test this prototype. Password text input, Continue button](https://user-images.githubusercontent.com/1132904/143592747-90034b25-c2af-4905-8ecd-c2a056821372.png)

