### PR TITLE
Update page titles

### DIFF
--- a/__tests__/spec/sanity-checks.js
+++ b/__tests__/spec/sanity-checks.js
@@ -10,6 +10,7 @@ const sass = require('node-sass')
 
 const app = require('../../server.js')
 const gulpConfig = require('../../gulp/config.json')
+const utils = require('../../lib/utils')
 
 const sassRender = util.promisify(sass.render)
 
@@ -137,6 +138,14 @@ describe('The Prototype Kit', () => {
   describe(`${gulpConfig.paths.assets}sass/`, () => {
     it.each(sassFiles)('%s renders to CSS without errors', (file) => {
       return sassRender({ file: file })
+    })
+  })
+
+  describe('Documentation markdown page titles', () => {
+    const markdownFiles = glob.sync('docs/documentation/**/*.md')
+    it.each(markdownFiles)('%s has a title', (filepath) => {
+      const file = readFile(filepath)
+      utils.getRenderOptions(file, filepath)
     })
   })
 })

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -2,7 +2,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  GOV.UK Prototype Kit
+  Home – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block content %}
@@ -10,7 +10,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-        The GOV.UK Prototype Kit
+        Prototype your service using GOV.UK Prototype Kit
         <span class="govuk-caption-xl">{{releaseVersion}}</span>
       </h1>{{releaseVersion | log }}
       <p>

--- a/docs/documentation/accessibility.md
+++ b/docs/documentation/accessibility.md
@@ -1,3 +1,6 @@
+---
+title: Accessibility
+---
 # Accessibility
 
 The GOV.UK Prototype Kit website is maintained by a team at the Government Digital Service (GDS).

--- a/docs/documentation/adding-css-javascript-and-images.md
+++ b/docs/documentation/adding-css-javascript-and-images.md
@@ -1,4 +1,7 @@
-# Adding CSS, JavaScript, images and PDFs
+---
+title: Add CSS, JavaScript, images and other files
+---
+# Add CSS, JavaScript, images and other files
 
 The Prototype Kit comes with standard GOV.UK Frontend styles and components for you to use in your prototypes. However, if you need to add your own CSS (Cascading Style Sheets), JavaScript, images or other files (for example, PDFs), use the `/app/assets` folder.
 

--- a/docs/documentation/backwards-compatibility.md
+++ b/docs/documentation/backwards-compatibility.md
@@ -1,4 +1,7 @@
-# Using backwards compatibility
+---
+title: Use backwards compatibility to upgrade from version 6
+---
+# Use backwards compatibility to upgrade from version 6
 
 Version 7 of the Prototype Kit uses the new GOV.UK Design System. It is not compatible with prototypes built with older versions by default.
 

--- a/docs/documentation/creating-routes.md
+++ b/docs/documentation/creating-routes.md
@@ -1,4 +1,7 @@
-# Creating routes
+---
+title: Create routes
+---
+# Create routes
 
 You may want to make prototypes that are more complex than simple HTML files. For example, you may want to respond to input from a form, and show different pages based on answers given by the user.
 

--- a/docs/documentation/extension-system.md
+++ b/docs/documentation/extension-system.md
@@ -1,3 +1,6 @@
+---
+title: Extension system
+---
 # Extension system
 
 The extension system information should go here before it's adopted into GOVUK.

--- a/docs/documentation/github-desktop.md
+++ b/docs/documentation/github-desktop.md
@@ -1,4 +1,7 @@
-# Storing your code online with GitHub and GitHub Desktop
+---
+title: Store your code online with GitHub or GitHub Desktop
+---
+# Store your code online with GitHub or GitHub Desktop
 
 GitHub is a way to store code online so you can collaborate with other people. It also makes it easier to publish your prototype online with Heroku.
 

--- a/docs/documentation/install/developer-install-instructions.md
+++ b/docs/documentation/install/developer-install-instructions.md
@@ -1,4 +1,7 @@
-# Instructions for developers
+---
+title: Installation guide for advanced users
+---
+# Installation guide for advanced users
 
 It's built on the [Express](http://expressjs.com/) framework, and uses [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend).
 

--- a/docs/documentation/install/install-the-kit.md
+++ b/docs/documentation/install/install-the-kit.md
@@ -1,4 +1,8 @@
-# Install the kit
+---
+title: How to install the kit
+caption: Installation guide for new users
+---
+# How to install the kit
 
 ## Download the kit as a zip
 

--- a/docs/documentation/install/introduction.md
+++ b/docs/documentation/install/introduction.md
@@ -1,3 +1,6 @@
+---
+title: Installation guide for new users
+---
 # Installation guide for new users
 
 This guide will walk you through installing and getting started with the kit. You don’t need any technical knowledge to follow along. If you get stuck, contact us using the [#prototype-kit Slack channel](https://ukgovernmentdigital.slack.com/messages/C0647LW4R/), or if you have a developer on your team, they should be able to help.

--- a/docs/documentation/install/requirements.md
+++ b/docs/documentation/install/requirements.md
@@ -1,4 +1,8 @@
-# Requirements
+---
+title: Prototype Kit requirements
+caption: Installation guide for new users
+---
+# Prototype Kit requirements
 
 The GOV.UK Prototype Kit runs on Mac, Windows and Linux. At a minimum you’ll need Node.js (install instructions below) and a web browser.
 

--- a/docs/documentation/install/run-the-kit.md
+++ b/docs/documentation/install/run-the-kit.md
@@ -1,4 +1,8 @@
-# Run the kit
+---
+title: How to run the kit
+caption: Installation guide for new users
+---
+# How to run the kit
 
 You’ll use the terminal to start and stop the kit.
 

--- a/docs/documentation/make-first-prototype/branching.md
+++ b/docs/documentation/make-first-prototype/branching.md
@@ -1,3 +1,7 @@
+---
+title: Show different pages depending on user input (branching)
+caption: Build a basic prototype
+---
 # Show different pages depending on user input (branching)
 
 Our first question asks the user how many balls they can juggle. We’re going to send them to an ‘ineligible’ page if they can only juggle 2 balls or less. Sending users to different pages based on their input is called branching.

--- a/docs/documentation/make-first-prototype/create-pages.md
+++ b/docs/documentation/make-first-prototype/create-pages.md
@@ -1,3 +1,7 @@
+---
+title: Create pages
+caption: Build a basic prototype
+---
 # Create pages
 
 Create pages by copying template files that come with the Prototype Kit.

--- a/docs/documentation/make-first-prototype/let-user-change-answers.md
+++ b/docs/documentation/make-first-prototype/let-user-change-answers.md
@@ -1,3 +1,7 @@
+---
+title: Let the user change their answers
+caption: Build a basic prototype
+---
 # Let the user change their answers
 
 ## Make the ‘Change’ links work

--- a/docs/documentation/make-first-prototype/link-index-page-start-page.md
+++ b/docs/documentation/make-first-prototype/link-index-page-start-page.md
@@ -1,3 +1,7 @@
+---
+title: Linke your index page to your start page
+caption: Build a basic prototype
+---
 # Link your index page to your start page
 
 You can route users from your service's index page to your start page. The index page is the page that loads when users visit http://localhost:3000.

--- a/docs/documentation/make-first-prototype/link-pages-together.md
+++ b/docs/documentation/make-first-prototype/link-pages-together.md
@@ -1,3 +1,7 @@
+---
+title: Link your pages together
+caption: Build a basic prototype
+---
 # Link your pages together
 
 To take users from one page to another, you can use either:

--- a/docs/documentation/make-first-prototype/make-first-prototype.md
+++ b/docs/documentation/make-first-prototype/make-first-prototype.md
@@ -1,3 +1,6 @@
+---
+title: Build a basic prototype using the Prototype Kit
+---
 # Build a basic prototype using the Prototype Kit
 
 This tutorial shows you how to prototype a fictional 'Apply for a juggling licence' service that will:

--- a/docs/documentation/make-first-prototype/open-prototype-in-editor.md
+++ b/docs/documentation/make-first-prototype/open-prototype-in-editor.md
@@ -1,3 +1,7 @@
+---
+title: Open your prototype in your editor
+caption: Build a basic prototype
+---
 # Open your prototype in your editor
 
 ### Mac

--- a/docs/documentation/make-first-prototype/show-users-answers.md
+++ b/docs/documentation/make-first-prototype/show-users-answers.md
@@ -1,3 +1,7 @@
+---
+title: Show the user’s answers
+caption: Build a basic prototype
+---
 # Show the user’s answers on the ‘Check answers’ page
 
 The Prototype Kit stores answers that users enter. This means you can make more realistic prototypes, for example by showing answers for users to check.

--- a/docs/documentation/make-first-prototype/start.md
+++ b/docs/documentation/make-first-prototype/start.md
@@ -1,3 +1,6 @@
+---
+title: Build a basic prototype
+---
 # Build a basic prototype using the Prototype Kit
 
 This tutorial shows you how to prototype a fictional 'Apply for a juggling licence' service that will:

--- a/docs/documentation/make-first-prototype/use-components-2.md
+++ b/docs/documentation/make-first-prototype/use-components-2.md
@@ -1,3 +1,7 @@
+---
+title: Add a textarea to question 2
+caption: Build a basic prototype
+---
 # Add a textarea to question 2
 
 1. Go to the [textarea](https://design-system.service.gov.uk/components/textarea/) page of the Design System.

--- a/docs/documentation/make-first-prototype/use-components.md
+++ b/docs/documentation/make-first-prototype/use-components.md
@@ -1,3 +1,7 @@
+---
+title: Use components from the Design System
+caption: Build a basic prototype
+---
 # Use components from the Design System
 
 You can copy example code from the GOV.UK Design System to add page elements like radios and text inputs - we call these ‘components’.

--- a/docs/documentation/principles.md
+++ b/docs/documentation/principles.md
@@ -1,3 +1,6 @@
+---
+title: Principles
+---
 # Principles
 
 The GOV.UK Prototype Kit:

--- a/docs/documentation/publishing-on-heroku-terminal.md
+++ b/docs/documentation/publishing-on-heroku-terminal.md
@@ -1,4 +1,7 @@
-# Publishing on the web (Heroku) from the terminal
+---
+title: Publish on the web from the terminal
+---
+# Publish on the web (Heroku) from the terminal
 
 We recommend using [Heroku](http://www.heroku.com) to get your prototype online. It’s simple and fast to deploy new versions as you work.
 

--- a/docs/documentation/publishing-on-heroku.md
+++ b/docs/documentation/publishing-on-heroku.md
@@ -1,4 +1,7 @@
-# Publishing on the web (Heroku)
+---
+title: Publish on the web
+---
+# Publish on the web (Heroku)
 
 Heroku runs your prototype online, the same as it runs on your machine, but available to others at any time. Other similar services are available.
 

--- a/docs/documentation/session.md
+++ b/docs/documentation/session.md
@@ -1,4 +1,7 @@
-# Storing data in session
+---
+title: Store data in session
+---
+# Store data in session
 
 **Advanced topic**
 

--- a/docs/documentation/setting-up-git.md
+++ b/docs/documentation/setting-up-git.md
@@ -1,4 +1,7 @@
-# Setting up Git using the terminal
+---
+title: Set up Git using the Terminal
+---
+# Set up Git using the Terminal
 
 Git helps track changes in code and lets you undo mistakes or identify bugs. It’s also used to collaborate with other people - so you can share your code with other designers and developers on your team (or with other teams!). Git is a type of version control software.
 

--- a/docs/documentation/updating-the-kit.md
+++ b/docs/documentation/updating-the-kit.md
@@ -1,3 +1,6 @@
+---
+title: Update your Prototype Kit
+---
 # Update your Prototype Kit
 
 How to update your prototype and get help from the GOV.UK Prototype Kit team.

--- a/docs/documentation/usage-data.md
+++ b/docs/documentation/usage-data.md
@@ -1,4 +1,7 @@
-# Collecting usage data
+---
+title: Share usage data
+---
+# Share usage data
 
 You can choose to have the Prototype Kit send anonymous usage data for analysis.
 This helps the team working on the Kit understand how it's being used, in order

--- a/docs/documentation/using-notify.md
+++ b/docs/documentation/using-notify.md
@@ -1,4 +1,7 @@
-# Using GOV.UK Notify to prototype emails and text messages
+---
+title: Use GOV.UK Notify
+---
+# Use GOV.UK Notify to prototype emails and text messages
 
 You can use GOV.UK Notify to send text messages or emails when users
 interact with your prototype. For example you could send users a

--- a/docs/documentation/using-verify.md
+++ b/docs/documentation/using-verify.md
@@ -1,3 +1,6 @@
-## Using GOV.UK Verify
+---
+title: Use GOV.UK Verify
+---
+## Use GOV.UK Verify
 
 GOV.UK Verify is no longer accepting new services.

--- a/docs/documentation_routes.js
+++ b/docs/documentation_routes.js
@@ -4,8 +4,10 @@ const path = require('path')
 
 // NPM dependencies
 const express = require('express')
-const marked = require('marked')
 const router = express.Router()
+
+// Local dependencies
+const utils = require('../lib/utils')
 
 // Page routes
 
@@ -27,8 +29,8 @@ router.get('/install/:page', function (req, res) {
   }
   redirectMarkdown(req.params.page, res)
   var doc = fs.readFileSync(path.join(__dirname, '/documentation/install/', req.params.page + '.md'), 'utf8')
-  var html = marked(doc)
-  res.render('install_template', { document: html })
+  const renderOptions = utils.getRenderOptions(doc)
+  res.render('install_template', renderOptions)
 })
 
 // When in 'promo mode', redirect to download the current release zip from

--- a/docs/views/about.html
+++ b/docs/views/about.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-About - GOV.UK Prototype Kit
+About – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}

--- a/docs/views/cookies.html
+++ b/docs/views/cookies.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-About - GOV.UK Prototype Kit
+Cookies – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}

--- a/docs/views/documentation_template.html
+++ b/docs/views/documentation_template.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-Documentation - GOV.UK Prototype Kit
+{{ title or "Documentation" }} – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}

--- a/docs/views/examples/override-service-name.html
+++ b/docs/views/examples/override-service-name.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  GOV.UK Prototype Kit - override service name
+  Override the service name – GOV.UK Prototype Kit
 {% endblock %}
 
 {% set serviceName %}
@@ -18,7 +18,7 @@
     <div class="govuk-grid-column-two-thirds">
 
       <h1 class="govuk-heading-xl">
-        Override service name
+        Override the service name
       </h1>{{releaseVersion | log }}
       <p>
         This is an example of overriding the normal service name on one page.

--- a/docs/views/examples/pass-data/index.html
+++ b/docs/views/examples/pass-data/index.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Example - Passing data
+  Pass data from page to page – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}
@@ -14,7 +14,7 @@
     <div class="govuk-grid-column-two-thirds">
 
       <h1 class="govuk-heading-xl">
-        Passing data from page to page
+        Pass data from page to page
       </h1>
 
       <p>

--- a/docs/views/examples/pass-data/vehicle-check-answers.html
+++ b/docs/views/examples/pass-data/vehicle-check-answers.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-Check your answers
+  Check your answers before sending your application – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block content %}

--- a/docs/views/examples/pass-data/vehicle-features.html
+++ b/docs/views/examples/pass-data/vehicle-features.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Example - Passing data
+  Which of these applies to your vehicle? – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}

--- a/docs/views/examples/pass-data/vehicle-registration.html
+++ b/docs/views/examples/pass-data/vehicle-registration.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Example - Passing data
+  What is your vehicle registration number? – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}

--- a/docs/views/examples/pass-data/vehicle-type.html
+++ b/docs/views/examples/pass-data/vehicle-type.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Example - Passing data
+  What type of vehicle do you have? – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}

--- a/docs/views/examples/template-data.html
+++ b/docs/views/examples/template-data.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Example of using variables in pages
+  Pass data into a page – GOV.UK Protyotype Kit
 {% endblock %}
 
 {% block beforeContent %}
@@ -14,7 +14,7 @@
     <div class="govuk-grid-column-two-thirds">
 
       <h1 class="govuk-heading-xl">
-        Passing data into pages
+        Pass data into a page
       </h1>
 
       <p>

--- a/docs/views/install.html
+++ b/docs/views/install.html
@@ -34,9 +34,9 @@ Install the Prototype Kit – GOV.UK Prototype Kit
 
       <p>Choose from:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li><a href="/docs/install/introduction">simple install guide</a><br>for users new to Node.js, Git or the terminal</li>
-        <li><a href="/docs/install/developer-install-instructions">advanced install guide</a><br>for users familiar with Node.js, Git and the terminal</li>
-        <li><a href="/docs/updating-the-kit">update the Prototype Kit</a> if you've already installed an earlier version</li>
+        <li><a href="/docs/install/introduction">guide for new users</a> covers Node.js, Git and the terminal</li>
+        <li><a href="/docs/install/developer-install-instructions">guide for advanced users</a> familiar with Node.js, Git and the terminal</li>
+        <li><a href="/docs/updating-the-kit">update your Prototype Kit</a> if you've installed an earlier version</li>
       </ul>
 
   </div>

--- a/docs/views/install.html
+++ b/docs/views/install.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-Getting started - GOV.UK Prototype Kit
+Install the Prototype Kit – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}
@@ -20,7 +20,7 @@ Getting started - GOV.UK Prototype Kit
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">Installing the kit</h1>
+      <h1 class="govuk-heading-xl">Install the Prototype Kit</h1>
 
       <p class="govuk-body-l">
         Get up and running with the kit in 30 minutes.

--- a/docs/views/install_template.html
+++ b/docs/views/install_template.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-Install - GOV.UK Prototype Kit
+{{ title }} – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}

--- a/docs/views/privacy-policy.html
+++ b/docs/views/privacy-policy.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-About - GOV.UK Prototype Kit
+Privacy policy – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}

--- a/docs/views/templates/blank-govuk.html
+++ b/docs/views/templates/blank-govuk.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Blank page
+  GOV.UK page template
 {% endblock %}
 
 {% block content %}

--- a/docs/views/templates/blank-govuk.html
+++ b/docs/views/templates/blank-govuk.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  GOV.UK page template
+  GOV.UK page template – {{ serviceName }} – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block content %}

--- a/docs/views/templates/blank-unbranded.html
+++ b/docs/views/templates/blank-unbranded.html
@@ -1,13 +1,13 @@
 {% extends "layout_unbranded.html" %}
 
 {% block pageTitle %}
-  Example without branding
+  Unbranded page template – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block content %}
 
   <h1 class="govuk-heading-xl">
-    Example without GOV.UK branding
+    Unbranded page template
   </h1>
   <p class="govuk-body-l">
     This page doesn't use New Transport or display the GOV.UK header and footer.

--- a/docs/views/templates/blank-unbranded.html
+++ b/docs/views/templates/blank-unbranded.html
@@ -1,7 +1,7 @@
 {% extends "layout_unbranded.html" %}
 
 {% block pageTitle %}
-  Unbranded page template – GOV.UK Prototype Kit
+  Unbranded page template – {{ serviceName }} – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block content %}

--- a/docs/views/templates/check-answers.html
+++ b/docs/views/templates/check-answers.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Check your answers
+  Check your answers template – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}

--- a/docs/views/templates/check-answers.html
+++ b/docs/views/templates/check-answers.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Check your answers template – GOV.UK Prototype Kit
+  Check your answers template – {{ serviceName }} – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}

--- a/docs/views/templates/confirmation.html
+++ b/docs/views/templates/confirmation.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Confirmation page example
+  Confirmation page template – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block content %}

--- a/docs/views/templates/confirmation.html
+++ b/docs/views/templates/confirmation.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Confirmation page template – GOV.UK Prototype Kit
+  Confirmation page template – {{ serviceName }} – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block content %}

--- a/docs/views/templates/content.html
+++ b/docs/views/templates/content.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  Content page template – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}

--- a/docs/views/templates/content.html
+++ b/docs/views/templates/content.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Content page template – GOV.UK Prototype Kit
+  Content page template – {{ serviceName }} – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}

--- a/docs/views/templates/question.html
+++ b/docs/views/templates/question.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Question page
+  Question page template – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}

--- a/docs/views/templates/question.html
+++ b/docs/views/templates/question.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Question page template – GOV.UK Prototype Kit
+  Question page template – {{ serviceName }} – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}

--- a/docs/views/templates/start-with-step-by-step.html
+++ b/docs/views/templates/start-with-step-by-step.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %} {% block pageTitle %} Start page example {% endblock %} {% block header %}
+{% extends "layout.html" %} {% block pageTitle %} Start page with step by step template – GOV.UK Prototype Kit {% endblock %} {% block header %}
 <!-- Blank header with no service name for the start page -->
 {{ govukHeader() }} {% endblock %} {% block pageScripts %}
 <script src="/public/javascripts/step-by-step-nav.js"></script>

--- a/docs/views/templates/start-with-step-by-step.html
+++ b/docs/views/templates/start-with-step-by-step.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %} {% block pageTitle %} Start page with step by step template – GOV.UK Prototype Kit {% endblock %} {% block header %}
+{% extends "layout.html" %} {% block pageTitle %} Start page with step by step template – {{ serviceName }} – GOV.UK Prototype Kit {% endblock %} {% block header %}
 <!-- Blank header with no service name for the start page -->
 {{ govukHeader() }} {% endblock %} {% block pageScripts %}
 <script src="/public/javascripts/step-by-step-nav.js"></script>

--- a/docs/views/templates/start.html
+++ b/docs/views/templates/start.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Start page example
+  Start page template – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block header %}

--- a/docs/views/templates/start.html
+++ b/docs/views/templates/start.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Start page template – GOV.UK Prototype Kit
+  Start page template – {{ serviceName }} – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block header %}

--- a/docs/views/templates/step-by-step-navigation.html
+++ b/docs/views/templates/step-by-step-navigation.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Step by step navigation
+  Step by step navigation template – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block pageScripts %}

--- a/docs/views/templates/step-by-step-navigation.html
+++ b/docs/views/templates/step-by-step-navigation.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Step by step navigation template – GOV.UK Prototype Kit
+  Step by step navigation template – {{ serviceName }} – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block pageScripts %}

--- a/docs/views/templates/task-list.html
+++ b/docs/views/templates/task-list.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Task list
+  Task list template – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block content %}

--- a/docs/views/templates/task-list.html
+++ b/docs/views/templates/task-list.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Task list template – GOV.UK Prototype Kit
+  Task list template – {{ serviceName }} – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block content %}

--- a/docs/views/tutorials-and-examples.html
+++ b/docs/views/tutorials-and-examples.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  GOV.UK Prototype Kit
+  Tutorials and templates – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}
@@ -30,24 +30,24 @@
       <h3 class="govuk-heading-s">Download and install</h3>
       <ul class="govuk-list govuk-list--bullet">
         <li>
-          <a href="/docs/download" data-link="download">Download kit (zip)</a>
+          <a href="/docs/download" data-link="download">Download the Prototype Kit (zip)</a>
         </li>
         <li>
-          <a href="/docs/install/introduction">Simple install guide</a>
+          <a href="/docs/install/introduction">Installation guide for new users</a>
           <ol class="govuk-list govuk-list--number">
             <li>
-              <a href="/docs/install/requirements">Kit requirements</a>
+              <a href="/docs/install/requirements">Prototype Kit requirements</a>
             </li>
             <li>
-              <a href="/docs/install/install-the-kit">Install the kit</a>
+              <a href="/docs/install/install-the-kit">How to install the kit</a>
             </li>
             <li>
-              <a href="/docs/install/run-the-kit">Run the kit</a>
+              <a href="/docs/install/run-the-kit">How to run the kit</a>
             </li>
           </ol>
         </li>
         <li>
-          <a href="/docs/install/developer-install-instructions">Advanced install guide</a>
+          <a href="/docs/install/developer-install-instructions">Installation guide for advanced users</a>
         </li>
       </ul>
       <h3 class="govuk-heading-s">Get started</h3>

--- a/lib/prototype-admin/clear-data-success.html
+++ b/lib/prototype-admin/clear-data-success.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Data cleared - GOV.UK Prototype Kit
+  Data cleared – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block content %}

--- a/lib/prototype-admin/clear-data.html
+++ b/lib/prototype-admin/clear-data.html
@@ -2,7 +2,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Clear data? - GOV.UK Prototype Kit
+  Clear session data – GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}
@@ -19,7 +19,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-        Clear data?
+        Clear session data
       </h1>
       {{ govukWarningText({
         text: "This will clear all of the data entered in this session",

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,6 +7,7 @@ const marked = require('marked')
 const path = require('path')
 const portScanner = require('portscanner')
 const inquirer = require('inquirer')
+const matter = require('gray-matter')
 
 // Local dependencies
 const config = require('../app/config.js')
@@ -171,14 +172,26 @@ exports.matchRoutes = function (req, res, next) {
 
 // Try to match a request to a Markdown file and render it
 exports.matchMdRoutes = function (req, res) {
-  var docsPath = '/../docs/documentation/'
-  if (fs.existsSync(path.join(__dirname, docsPath, req.params[0] + '.md'), 'utf8')) {
-    var doc = fs.readFileSync(path.join(__dirname, docsPath, req.params[0] + '.md'), 'utf8')
-    var html = marked(doc)
-    res.render('documentation_template', { document: html })
+  const docsPath = '/../docs/documentation/'
+  const reqPath = path.join(__dirname, docsPath, req.params[0] + '.md')
+  if (fs.existsSync(reqPath, 'utf8')) {
+    const doc = fs.readFileSync(reqPath, 'utf8')
+    const renderOptions = module.exports.getRenderOptions(doc, docsPath + req.params[0])
+    res.render('documentation_template', renderOptions)
     return true
   }
   return false
+}
+
+exports.getRenderOptions = function (document, docPath) {
+  const parsedFile = matter(document)
+  if (parsedFile.data.title === undefined) {
+    throw new Error(`${docPath} does not have a title in its frontmatter`)
+  }
+
+  const html = marked(parsedFile.content)
+
+  return { document: html, ...parsedFile.data }
 }
 
 // Store data from POST body or GET query in session

--- a/lib/utils.test.js
+++ b/lib/utils.test.js
@@ -46,3 +46,27 @@ describe('checked', () => {
     expect(checked('foo.bar', 'baz')).toBe('checked')
   })
 })
+
+describe('getRenderOptions', () => {
+  it('uses front matter to generate title', () => {
+    const md = '---\n' +
+      'title: Share usage data\n' +
+      '---\n' +
+      '# This is a header'
+
+    const received = utils.getRenderOptions(md)
+
+    expect(received).toHaveProperty('title')
+    expect(received.title).toEqual('Share usage data')
+  })
+
+  it('throws an error if front matter title is not present', () => {
+    const md = '# This is a header'
+
+    const expectedError = new Error('docs/documentation/this-is-a-header.md does not have a title in its frontmatter')
+
+    expect(() => {
+      utils.getRenderOptions(md, 'docs/documentation/this-is-a-header.md')
+    }).toThrow(expectedError)
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "govuk_template_jinja": "^0.24.1",
         "govuk-elements-sass": "^3.1.3",
         "govuk-frontend": "^4.0.0",
+        "gray-matter": "^4.0.3",
         "gulp": "^4.0.0",
         "gulp-nodemon": "^2.5.0",
         "gulp-sass": "^5.0.0",
@@ -1801,7 +1802,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -5189,7 +5189,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -6860,6 +6859,20 @@
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
       "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
     },
     "node_modules/gulp": {
       "version": "4.0.2",
@@ -9982,7 +9995,6 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -13416,6 +13428,29 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/section-matter/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -14002,8 +14037,7 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "node_modules/sshpk": {
       "version": "1.16.1",
@@ -17291,7 +17325,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -19922,8 +19955,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.4.0",
@@ -21242,6 +21274,17 @@
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
       "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+    },
+    "gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "requires": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      }
     },
     "gulp": {
       "version": "4.0.2",
@@ -23544,7 +23587,6 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -26170,6 +26212,25 @@
         }
       }
     },
+    "section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -26680,8 +26741,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "govuk_template_jinja": "^0.24.1",
     "govuk-elements-sass": "^3.1.3",
     "govuk-frontend": "^4.0.0",
+    "gray-matter": "^4.0.3",
     "gulp": "^4.0.0",
     "gulp-nodemon": "^2.5.0",
     "gulp-sass": "^5.0.0",


### PR DESCRIPTION
## What
This implements recommended changes from the draft document on #1085

### getRenderOptions function
We previously generated a lot of our titles using a single, hard-coded name (like "Documentation" or "Install").

This adds a function called `getRenderOptions` which uses [`gray-matter`](https://github.com/jonschlinkert/gray-matter) to check markdown files for frontmatter.

If there is a "title" property in the frontmatter, it uses that as the title. Otherwise, it throws an error. This means that we need to make sure all our documentation markdown has frontmatter, so I've also added a test to check this on all the documentation markdown files.

This function can be used for other frontmatter properties in the future. For instance, I've added `caption` properties to the pages where we want to use them, but haven't yet implemented that in the function.

This shouldn't affect users, since these tests (and the function) target only our documentation site content. One impact is slightly slower completion time if a user runs `npm test`, because we don't yet separate our tests from user tests. We don't document this functionality, so it's likely only advanced users who are writing their own tests would even be aware.

## Outstanding work
I've marked this as ready for review, but there are a few outstanding issues:

* The content changes don't address #855 - we should decide if they need to.
* Inserting captions and heading sizes - I can do a separate PR for this.

## Related issues
Closes #1114

Closes #855 