### PR TITLE
Update link text to match new titles

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -32,7 +32,7 @@
 
       <ul class="govuk-list govuk-list--bullet">
         <li>
-          <a href="/docs/tutorials-and-examples">Example pages and documentation</a>
+          <a href="/docs/tutorials-and-examples">Tutorials and templates</a>
         </li>
         <li>
           <a href="https://design-system.service.gov.uk">GOV.UK Design System</a>

--- a/docs/documentation/accessibility.md
+++ b/docs/documentation/accessibility.md
@@ -70,7 +70,7 @@ The test was carried out by the GOV.UK Prototype Kit team.
 The GOV.UK Prototype Kit team tested a sample of pages to cover the different content types in the Prototype Kit website. They were:
 
 - [the homepage](/docs)
-- [the tutorials and examples page](/docs/tutorials-and-examples)
+- [the tutorials and templates page](/docs/tutorials-and-examples)
 - [the tutorial pages](/docs/make-first-prototype/start)
 - [the guide pages](/docs/publishing-on-heroku)
 - [the example pages](/docs/examples/pass-data)

--- a/docs/views/documentation_template.html
+++ b/docs/views/documentation_template.html
@@ -12,7 +12,7 @@
 	      href: "/docs"
 	    },
 	    {
-	      text: "Tutorials and examples",
+	      text: "Tutorials and templates",
 	      href: "/docs/tutorials-and-examples"
 	    }
 	  ]

--- a/docs/views/includes/breadcrumb_examples.html
+++ b/docs/views/includes/breadcrumb_examples.html
@@ -4,7 +4,7 @@
       <a class="govuk-breadcrumbs__link" href="/docs">GOV.UK Prototype Kit</a>
     </li>
     <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="/docs/tutorials-and-examples">Tutorials and examples</a>
+      <a class="govuk-breadcrumbs__link" href="/docs/tutorials-and-examples">Tutorials and templates</a>
     </li>
   </ol>
 </div>

--- a/docs/views/index.html
+++ b/docs/views/index.html
@@ -33,7 +33,7 @@ GOV.UK Prototype Kit
     </div>
     <div class="govuk-grid-column-one-third govuk-!-margin-top-6">
 
-      <h2 class="govuk-heading-m"><a href="/docs/tutorials-and-examples" data-htutorials="Tutorials and examples">Tutorials and examples</a></h2>
+      <h2 class="govuk-heading-m"><a href="/docs/tutorials-and-examples" data-htutorials="Tutorials and templates">Tutorials and templates</a></h2>
       <p>
         Tutorials, examples and templates.
       </p>

--- a/docs/views/layout.html
+++ b/docs/views/layout.html
@@ -45,9 +45,9 @@
       },
       {
         href: "/docs/tutorials-and-examples",
-        text: "Tutorials and examples",
+        text: "Tutorials and templates",
         attributes: {
-          "data-tutorials": "Tutorials and examples"
+          "data-tutorials": "Tutorials and templates"
         }
       },
       {

--- a/docs/views/tutorials-and-examples.html
+++ b/docs/views/tutorials-and-examples.html
@@ -17,7 +17,7 @@
 
 {% block content %}
 
-  <h1 class="govuk-heading-xl">Tutorials and page templates</h1>
+  <h1 class="govuk-heading-xl">Tutorials and templates</h1>
 
   <div class="govuk-grid-row">
 
@@ -88,25 +88,25 @@
       <h3 class="govuk-heading-s">Basic usage</h3>
       <ul class="govuk-list govuk-list--bullet">
         <li>
-          <a href="/docs/usage-data">Sending kit usage data</a>
+          <a href="/docs/usage-data">Share usage data</a>
         </li>
         <li>
-          <a href="/docs/adding-css-javascript-and-images">Adding CSS, JavaScript, images and PDFs</a>
+          <a href="/docs/adding-css-javascript-and-images">Add CSS, JavaScript, images and other files</a>
         </li>
         <li>
-          <a href="/docs/github-desktop">Storing your code online with GitHub and GitHub Desktop</a>
+          <a href="/docs/github-desktop">Store your code online with GitHub or GitHub Desktop</a>
         </li>
         <li>
-          <a href="/docs/setting-up-git">Setting up Git using the terminal</a>
+          <a href="/docs/setting-up-git">Set up Git using the Terminal</a>
         </li>
         <li>
-          <a href="/docs/publishing-on-heroku">Publishing on the web (Heroku)</a>
+          <a href="/docs/publishing-on-heroku">Publish on the web (Heroku)</a>
         </li>
         <li>
-          <a href="/docs/examples/template-data">Passing data into a template</a>
+          <a href="/docs/examples/template-data">Pass data into a page</a>
         </li>
         <li>
-          <a href="/docs/updating-the-kit">Updating to the latest version</a>
+          <a href="/docs/updating-the-kit">Update your Prototype Kit</a>
         </li>
       </ul>
     </div>
@@ -114,19 +114,19 @@
       <h3 class="govuk-heading-s">Advanced usage</h3>
       <ul class="govuk-list govuk-list--bullet">
         <li>
-          <a href="/docs/examples/pass-data">Passing data from page to page</a>
+          <a href="/docs/examples/pass-data">Pass data from page to page</a>
         </li>
         <li>
-          <a href="/docs/creating-routes">Creating routes (server side programming)</a>
+          <a href="/docs/creating-routes">Create routes (server side programming)</a>
         </li>
         <li>
           <a href="/docs/examples/override-service-name">Override the service name on one page</a>
         </li>
         <li>
-          <a href="/docs/session">Storing data in session</a>
+          <a href="/docs/session">Store data in session</a>
         </li>
         <li>
-          <a href="/docs/using-notify">Using GOV.UK Notify</a>
+          <a href="/docs/using-notify">Use GOV.UK Notify to prototype emails and text messages</a>
         </li>
         <li>
           <a href="https://design-system.service.gov.uk/styles/page-template/#changing-template-content">
@@ -134,7 +134,7 @@
           </a>
         </li>
         <li>
-          <a href="/docs/backwards-compatibility">Backwards compatibility</a>
+          <a href="/docs/backwards-compatibility">Use backwards compatibility to upgrade from version 6</a>
         </li>
       </ul>
     </div>
@@ -153,35 +153,35 @@
       <ul class="govuk-list govuk-list--bullet">
         <li>
           <a href="/docs/templates/blank-govuk">
-            Blank
+            GOV.UK page template
           </a> /
           <a href="/docs/templates/blank-unbranded">
-            Blank (non-GOV.UK)
+            Unbranded page template
           </a>
         </li>
         <li>
           <a href="/docs/templates/question">
-            Question page
+            Question page template
           </a>
         </li>
         <li>
           <a href="/docs/templates/content">
-            Content page
+            Content page template
           </a>
         </li>
         <li>
           <a href="/docs/templates/task-list">
-            Task list
+            Task list template
           </a>
         </li>
         <li>
           <a href="/docs/templates/check-answers">
-            Check answers
+            Check your answers template
           </a>
         </li>
         <li>
           <a href="/docs/templates/confirmation">
-            Confirmation
+            Confirmation page template
           </a>
         </li>
       </ul>
@@ -193,17 +193,17 @@
       <ul class="govuk-list govuk-list--bullet">
         <li>
           <a href="/docs/templates/start">
-            Start page
+            Start page template
           </a>
         </li>
         <li>
           <a href="/docs/templates/step-by-step-navigation">
-            Step by step navigation
+            Step by step navigation template
           </a>
         </li>
         <li>
           <a href="/docs/templates/start-with-step-by-step">
-            Start page with Step by step navigation
+            Start page with step by step template
           </a>
         </li>
       </ul>


### PR DESCRIPTION
**Requires** #1186 

This updates the tutorials and templates page with new link text to match the new titles.

Closes #1091 