### PR TITLE
Add route to get update script

### DIFF
--- a/__tests__/spec/sanity-checks.js
+++ b/__tests__/spec/sanity-checks.js
@@ -52,6 +52,18 @@ describe('The Prototype Kit', () => {
     })
   })
 
+  describe('update script', () => {
+    it('should send a well formed response', async () => {
+      const response = await request(app).get('/docs/update.sh')
+      expect(response.statusCode).toBe(200)
+    })
+
+    it('should return plain text file', async () => {
+      const response = await request(app).get('/docs/update.sh')
+      expect(response.type).toBe('text/plain')
+    })
+  })
+
   describe('extensions', () => {
     it('should allow known assets to be loaded from node_modules', (done) => {
       request(app)

--- a/__tests__/spec/sanity-checks.js
+++ b/__tests__/spec/sanity-checks.js
@@ -53,13 +53,19 @@ describe('The Prototype Kit', () => {
   })
 
   describe('update script', () => {
-    it('should send a well formed response', async () => {
+    it('should redirect to GitHub', async () => {
       const response = await request(app).get('/docs/update.sh')
+      expect(response.statusCode).toBe(302)
+      expect(response.get('location')).toBe('https://raw.githubusercontent.com/alphagov/govuk-prototype-kit/main/update.sh')
+    })
+
+    it('should send a well formed response', async () => {
+      const response = await request(app).get('/docs/update.sh').redirects(1)
       expect(response.statusCode).toBe(200)
     })
 
     it('should return plain text file', async () => {
-      const response = await request(app).get('/docs/update.sh')
+      const response = await request(app).get('/docs/update.sh').redirects(1)
       expect(response.type).toBe('text/plain')
     })
   })

--- a/docs/documentation_routes.js
+++ b/docs/documentation_routes.js
@@ -52,9 +52,8 @@ router.get('/download', function (req, res) {
 })
 
 router.get('/update.sh', function (req, res) {
-  res.sendFile(
-    path.resolve(__dirname, '..', 'update.sh'),
-    { headers: { 'content-type': 'text/plain; charset=utf-8' } }
+  res.redirect(
+    'https://raw.githubusercontent.com/alphagov/govuk-prototype-kit/main/update.sh'
   )
 })
 

--- a/docs/documentation_routes.js
+++ b/docs/documentation_routes.js
@@ -51,6 +51,13 @@ router.get('/download', function (req, res) {
   }
 })
 
+router.get('/update.sh', function (req, res) {
+  res.sendFile(
+    path.resolve(__dirname, '..', 'update.sh'),
+    { headers: { 'content-type': 'text/plain; charset=utf-8' } }
+  )
+})
+
 // Examples - examples post here
 router.post('/tutorials-and-examples', function (req, res) {
   res.redirect('tutorials-and-examples')


### PR DESCRIPTION
We want to be able to tell users to run

> curl -L https://govuk-prototype-kit.herokuapp.com/docs/update.sh | bash
