### PR TITLE
Update the GOV.UK Prototype Kit to use GOV.UK Frontend v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,43 @@
 # Unreleased
 
-## Features
+## Breaking changes 
 
-### Preserve query strings
+This release ensures the GOV.UK Prototype Kit reflects the latest release of the GOV.UK Frontend, v4.0.0.
 
-We now preserve URL query strings when redirecting POST requests to GET requests.
+### Update to GOV.UK Frontend v4.0.0
 
-This means if you have a query like `/link/to/something?query=true&hello=world` on your POST form action, and you submit the form, the URL query string will be present in the redirected URL.
+The new release of GOV.UK Frontend contains:
+- an iteration to the accordion component
+- other ‘breaking’ changes you should make to improve your service
 
-This is useful when:
+Check the [GOV.UK Frontend release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v4.0.0) for changes you may need to make to ensure your prototype works.
 
-- You’re using the query string to set flash messages or return paths
-- You want to rely on explicitly what’s in the query string for a specific page, rather than saved data.
+This change was added in [#1195: Update the GOV.UK Prototype Kit to use GOV.UK Frontend v4.0.0](https://github.com/alphagov/govuk-prototype-kit/pull/1195).
 
-Thanks to @edwardhorsford.
+## New features 
 
-- [Pull request #1120: Preserve query string when redirecting POSTs to GETs](https://github.com/alphagov/govuk-prototype-kit/pull/1120)
+### Preserve query strings when redirecting POSTs to GETs
+
+The GOV.UK Prototype Kit now preserves URL query strings when redirecting POST requests to GET requests.
+
+This means if you have a query like `/link/to/something?query=true&hello=world` on your POST form action, and you submit the form, the URL query string will be present in the redirected URL. 
+
+This feature is useful when you:
+
+- use the query string to set flash messages or return paths
+- want to use the values in the query string for a specific page, rather than saved data
+
+Thanks to [@edwardhorsford](https://github.com/edwardhorsford) for contributing this issue and its solution.
+
+This was added in [#1120: Preserve query string when redirecting POSTs to GETs](https://github.com/alphagov/govuk-prototype-kit/pull/1120).
+
 
 ## Fixes
 
-[Pull request #1155: Replace keypather with lodash.get](https://github.com/alphagov/govuk-prototype-kit/pull/1155)
+- [#1155: Replace `keypather` package with `lodash.get`](https://github.com/alphagov/govuk-prototype-kit/pull/1155)
+
+If you need help with the Prototype Kit, [contact the GOV.UK Prototype team](https://design-system.service.gov.uk/get-in-touch/).
+
 
 
 # 11.0.0 (Fix release)

--- a/docs/views/examples/pass-data/vehicle-features.html
+++ b/docs/views/examples/pass-data/vehicle-features.html
@@ -22,9 +22,9 @@
                 Which of these applies to your vehicle?
               </h1>
             </legend>
-            <span id="vehicle-features-hint" class="govuk-hint">
+            <div id="vehicle-features-hint" class="govuk-hint">
               Select all that apply
-            </span>
+            </div>
             <div class="govuk-checkboxes">
               <div class="govuk-checkboxes__item">
                 <input class="govuk-checkboxes__input" id="vehicle-features-heated-seats" name="vehicle-features" type="checkbox" value="Heated seats" {{ checked("vehicle-features", "Heated seats") }}>

--- a/docs/views/templates/start-with-step-by-step.html
+++ b/docs/views/templates/start-with-step-by-step.html
@@ -32,7 +32,7 @@
 
     <a href="#" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8" data-module="govuk-button">
       Start now
-      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
+      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
         <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
       </svg>
     </a>

--- a/docs/views/templates/start.html
+++ b/docs/views/templates/start.html
@@ -45,7 +45,7 @@
 
       <a href="#" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
         Start now
-        <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
+        <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
           <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
         </svg>
       </a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "govuk_frontend_toolkit": "^7.5.0",
         "govuk_template_jinja": "^0.24.1",
         "govuk-elements-sass": "^3.1.3",
-        "govuk-frontend": "^3.14.0",
+        "govuk-frontend": "^4.0.0",
         "gulp": "^4.0.0",
         "gulp-nodemon": "^2.5.0",
         "gulp-sass": "^5.0.0",
@@ -6849,9 +6849,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
-      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.0.tgz",
+      "integrity": "sha512-liaJildULUNSSvEgDm36SQTivqBHiZLdrm+O7bBxnW4Q1g64asi+mJIMzW8QeOqlG4Yn8s0gSklsIyaFOuCisQ==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -21234,9 +21234,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
-      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.0.tgz",
+      "integrity": "sha512-liaJildULUNSSvEgDm36SQTivqBHiZLdrm+O7bBxnW4Q1g64asi+mJIMzW8QeOqlG4Yn8s0gSklsIyaFOuCisQ=="
     },
     "graceful-fs": {
       "version": "4.2.8",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^3.14.0",
+    "govuk-frontend": "^4.0.0",
     "gulp": "^4.0.0",
     "gulp-nodemon": "^2.5.0",
     "gulp-sass": "^5.0.0",


### PR DESCRIPTION
This uses the govuk-frontend v4 pre-release.

I've gone through the CHANGELOG for v4: https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md and there were only a couple of minor things that needed updating.

We can merge this when we have replaced the pre-release with the actual release.

Closes #1063 

## Summary of findings
* The kit doesn't have any accordions. The step by step navigation uses its own styles and scripts to function.
* No use of the `govuk-main-wrapper` mixins
* No use of the `$govuk-border-width-form-element-error` variable
* The kit _does_ have summary lists, but none of them have an empty actions span
* The kit doesn't use `navigationClasses` on the header
* The kit doesn't include conditionally revealed content (other than on the step by step, which handles that itself)
* There are no character counts
* The kit doesn't import individual JavaScript modules
* The kit has no error message spans
* **The kit had some hint spans which have been updated**
* No uses of the Sass `iff` function
* No use of `govuk-tag--inactive`
* No cookie banner
* The kit doesn't import individual Sass files from the `core` or `override` layers
* Footer displays correctly
* **The kit had some SVGs with `role="presentation"` which have now been updated**