### PR TITLE
Fix update script test for `fetch` when releasing a new version

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -24,3 +24,4 @@ jobs:
     - run: npm test
       env:
         CI: true
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -306,7 +306,7 @@ describe('update.sh', () => {
   })
 
   describe('fetch', () => {
-    it.skip('downloads the latest release of the prototype kit into the update folder', () => {
+    it('downloads the latest release of the prototype kit into the update folder', () => {
       const testDir = 'fetch'
       fs.mkdirSync(path.join(testDir, 'update'), { recursive: true })
 

--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -303,12 +303,16 @@ describe('update.sh', () => {
   describe('fetch', () => {
     it('downloads the latest release of the prototype kit into the update folder', async () => {
       // check what GitHub thinks the latest release archive is
-      var response = await request
+      const req = request
         .get('https://api.github.com/repos/alphagov/govuk-prototype-kit/releases/latest')
         .set('user-agent', 'node-superagent (tests for govuk-prototype-kit)')
 
-      if (response.error) throw response.error
-      const latestRelease = response.body
+      if (process.env.GITHUB_TOKEN) req.set('authorization', `Bearer ${process.env.GITHUB_TOKEN}`)
+
+      const res = await req
+      if (res.error) throw res.error
+
+      const latestRelease = res.body
       const latestReleaseVersion = latestRelease.tag_name.trim().slice(1) // need to drop the prefix 'v'
       const latestReleaseArchiveFilename = `govuk-prototype-kit-${latestReleaseVersion}.zip`
 


### PR DESCRIPTION
Previously we were relying on VERSION.txt for the name of the latest release, however this doesn't work in scenarios where we have changed the version number in preperation but have not yet made the release, as we found recently (see issue #1205).

This PR reinstates the test and fixes it so that it won't fail in future.

Instead we get the latest release version using the GitHub API [[1]].

Closes #1205.

[1]: https://github.com/alphagov/govuk-prototype-kit/issues/1205#issuecomment-995706280

---

I tested this locally by updating `VERSION.txt` and running the tests.