### PR TITLE
Set granular token permissions for GitHub Actions

### DIFF
--- a/.github/workflows/create-release-tag.yaml
+++ b/.github/workflows/create-release-tag.yaml
@@ -15,6 +15,9 @@ on:
     branches: [main]
     paths: [package.json]
 
+permissions:
+  contents: write
+
 name: Create release tag
 
 jobs:


### PR DESCRIPTION
Following best practise, grant the `GITHUB_TOKEN` only the required permissions. The create release tag needs to be able to:

- create the tag for the version ([POST /repos/{owner}/{repo}/git/refs][1])
- update the latest-release tag ([PATCH /repos/{owner}/{repo}/git/refs/{ref}][2])

According to GitHub's documentation, [write access on 'contents' is what is required to be able to do these two actions][3].

Using this approach also allows us to change the default permissions for workflows to 'Read repository contents' only.

[1]: https://docs.github.com/en/rest/reference/git#create-a-reference
[2]: https://docs.github.com/en/rest/reference/git#update-a-reference
[3]: https://docs.github.com/en/rest/reference/permissions-required-for-github-apps#permission-on-contents