### PR TITLE
Vendor `gulp-nodemon` and remove dependency on `colors`

### DIFF
--- a/gulp/gulp-nodemon.js
+++ b/gulp/gulp-nodemon.js
@@ -1,0 +1,120 @@
+/*
+ * Copied from gulp-nodemon@2.5.0 npm package
+ *
+ * This code is licensed under the MIT License
+ *
+ * Copyright (c) 2010 - present, Remy Sharp, https://remysharp.com <remy@remysharp.com>
+ */
+
+'use strict'
+
+var nodemon
+  , colors  = require('colors')
+  , gulp    = require('gulp')
+  , cp      = require('child_process')
+  , bus     = require('nodemon/lib/utils/bus')
+  , path    = require('path')
+
+module.exports = function (options) {
+  options = options || {};
+
+  // plug nodemon
+  if (options.nodemon && typeof options.nodemon === 'function') {
+    nodemon = options.nodemon
+    delete options.nodemon
+  } else {
+    nodemon = require('nodemon')
+  }
+
+  // Our script
+  var script            = nodemon(options)
+    , originalOn        = script.on
+    , originalListeners = bus.listeners('restart')
+
+  // Allow for injection of tasks on file change
+  if (options.tasks) {
+    // Remove all 'restart' listeners
+    bus.removeAllListeners('restart')
+
+    // Place our listener in first position
+    bus.on('restart', function (files){
+      if (!options.quiet) nodemonLog('running tasks...')
+
+      if (typeof options.tasks === 'function') run(options.tasks(files))
+      else run(options.tasks)
+    })
+
+    // Re-add all other listeners
+    for (var i = 0; i < originalListeners.length; i++) {
+      bus.on('restart', originalListeners[i])
+    }
+  }
+
+  // Capture ^C
+  process.once('SIGINT', function () {
+    script.emit('quit')
+    script.quitEmitted = true
+  })
+  script.on('exit', function () {
+    // Ignore exit event during restart
+    if (script.quitEmitted) {
+      // Properly signal async completion by calling the callback provided by gulp
+      if (typeof options.done === "function") {
+        options.done()
+      }
+
+      process.exit(0)
+    }
+  })
+
+  // Forward log messages and stdin
+  script.on('log', function (log){
+    nodemonLog(log.colour)
+  })
+
+  // Shim 'on' for use with gulp tasks
+  script.on = function (event, tasks){
+    var tasks = Array.prototype.slice.call(arguments)
+      , event = tasks.shift()
+
+    if (event === 'change') {
+      script.changeTasks = tasks
+    } else {
+      for (var i = 0; i < tasks.length; i++) {
+        void function (tasks){
+          if (tasks instanceof Function) {
+            originalOn(event, tasks)
+          } else {
+            originalOn(event, function (){
+              if (Array.isArray(tasks)) {
+                tasks.forEach(function (task){
+                  run(task)
+                })
+              } else run(tasks)
+            })
+          }
+        }(tasks[i])
+      }
+    }
+
+    return script
+  }
+
+  return script
+
+  // Synchronous alternative to gulp.run()
+  function run(tasks) {
+    if (typeof tasks === 'string') tasks = [tasks]
+    if (tasks.length === 0) return
+    if (!(tasks instanceof Array)) throw new Error('Expected task name or array but found: ' + tasks)
+    var gulpPath = path.join(process.cwd(), 'node_modules/.bin/')
+    var gulpCmd = path.join(gulpPath, process.platform === 'win32' ? 'gulp.cmd' : 'gulp')
+    var options = { stdio: [0, 1, 2] }
+    if (process.platform === 'win32') options.shell = true
+    cp.spawnSync(gulpCmd, tasks, options)
+  }
+}
+
+function nodemonLog(message){
+  console.log('[' + new Date().toString().split(' ')[4].gray + '] ' + message)
+}

--- a/gulp/gulp-nodemon.js
+++ b/gulp/gulp-nodemon.js
@@ -1,15 +1,17 @@
 /*
- * Copied from gulp-nodemon@2.5.0 npm package
+ * Copied from gulp-nodemon@2.5.0 npm package.
+ * Modified to remove dependency on `colors`.
  *
- * This code is licensed under the MIT License
+ * The original code and this code are licensed under the MIT License.
  *
  * Copyright (c) 2010 - present, Remy Sharp, https://remysharp.com <remy@remysharp.com>
+ * Copyright (c) 2021 - present, Crown Copyright (Government Digital Service)
  */
 
 'use strict'
 
 var nodemon
-  , colors  = require('colors')
+  , colors  = require('ansi-colors')
   , gulp    = require('gulp')
   , cp      = require('child_process')
   , bus     = require('nodemon/lib/utils/bus')
@@ -116,5 +118,5 @@ module.exports = function (options) {
 }
 
 function nodemonLog(message){
-  console.log('[' + new Date().toString().split(' ')[4].gray + '] ' + message)
+  console.log('[' + colors.gray(new Date().toString().split(' ')[4]) + '] ' + message)
 }

--- a/gulp/nodemon.js
+++ b/gulp/nodemon.js
@@ -10,7 +10,7 @@ const path = require('path')
 const gulp = require('gulp')
 const colour = require('ansi-colors')
 const log = require('fancy-log')
-const nodemon = require('gulp-nodemon')
+const nodemon = require('./gulp-nodemon')
 
 const config = require('./config.json')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "body-parser": "^1.14.1",
         "browser-sync": "^2.11.1",
         "client-sessions": "^0.8.0",
-        "colors": "^1.4.0",
         "cross-spawn": "^7.0.2",
         "del": "^6.0.0",
         "dotenv": "^10.0.0",
@@ -3210,14 +3209,6 @@
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
       "bin": {
         "color-support": "bin.js"
-      }
-    },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "engines": {
-        "node": ">=0.1.90"
       }
     },
     "node_modules/combined-stream": {
@@ -18348,11 +18339,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
-    },
-    "colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "combined-stream": {
       "version": "1.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "body-parser": "^1.14.1",
         "browser-sync": "^2.11.1",
         "client-sessions": "^0.8.0",
+        "colors": "^1.4.0",
         "cross-spawn": "^7.0.2",
         "del": "^6.0.0",
         "dotenv": "^10.0.0",
@@ -26,13 +27,13 @@
         "govuk-elements-sass": "^3.1.3",
         "govuk-frontend": "^4.0.0",
         "gulp": "^4.0.0",
-        "gulp-nodemon": "^2.5.0",
         "gulp-sass": "^5.0.0",
         "gulp-sourcemaps": "^3.0.0",
         "inquirer": "^8.2.0",
         "lodash": "^4.17.21",
         "marked": "^3.0.8",
         "node-sass": "^6.0.1",
+        "nodemon": "^2.0.14",
         "notifications-node-client": "^5.1.0",
         "nunjucks": "^3.2.1",
         "portscanner": "^2.1.1",
@@ -2538,9 +2539,9 @@
       }
     },
     "node_modules/boxen/node_modules/camelcase": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-      "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "engines": {
         "node": ">=10"
       },
@@ -7021,16 +7022,6 @@
       "dependencies": {
         "camelcase": "^3.0.0",
         "object.assign": "^4.1.0"
-      }
-    },
-    "node_modules/gulp-nodemon": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/gulp-nodemon/-/gulp-nodemon-2.5.0.tgz",
-      "integrity": "sha512-vXfaP72xo2C6XOaXrNcLEM3QqDJ1x21S3x97U4YtzN2Rl2kH57++aFkAVxe6BafGRSTxs/xVfE/jNNlCv5Ym2Q==",
-      "dependencies": {
-        "colors": "^1.2.1",
-        "gulp": "^4.0.0",
-        "nodemon": "^2.0.2"
       }
     },
     "node_modules/gulp-sass": {
@@ -17851,9 +17842,9 @@
           }
         },
         "camelcase": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
         },
         "chalk": {
           "version": "4.1.2",
@@ -21378,16 +21369,6 @@
             "object.assign": "^4.1.0"
           }
         }
-      }
-    },
-    "gulp-nodemon": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/gulp-nodemon/-/gulp-nodemon-2.5.0.tgz",
-      "integrity": "sha512-vXfaP72xo2C6XOaXrNcLEM3QqDJ1x21S3x97U4YtzN2Rl2kH57++aFkAVxe6BafGRSTxs/xVfE/jNNlCv5Ym2Q==",
-      "requires": {
-        "colors": "^1.2.1",
-        "gulp": "^4.0.0",
-        "nodemon": "^2.0.2"
       }
     },
     "gulp-sass": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "body-parser": "^1.14.1",
     "browser-sync": "^2.11.1",
     "client-sessions": "^0.8.0",
+    "colors": "^1.4.0",
     "cross-spawn": "^7.0.2",
     "del": "^6.0.0",
     "dotenv": "^10.0.0",
@@ -30,13 +31,13 @@
     "govuk-elements-sass": "^3.1.3",
     "govuk-frontend": "^4.0.0",
     "gulp": "^4.0.0",
-    "gulp-nodemon": "^2.5.0",
     "gulp-sass": "^5.0.0",
     "gulp-sourcemaps": "^3.0.0",
     "inquirer": "^8.2.0",
     "lodash": "^4.17.21",
     "marked": "^3.0.8",
     "node-sass": "^6.0.1",
+    "nodemon": "^2.0.14",
     "notifications-node-client": "^5.1.0",
     "nunjucks": "^3.2.1",
     "portscanner": "^2.1.1",
@@ -53,5 +54,10 @@
   },
   "jest": {
     "testRunner": "jest-jasmine2"
+  },
+  "standard": {
+    "ignore": [
+      "gulp/gulp-nodemon.js"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "body-parser": "^1.14.1",
     "browser-sync": "^2.11.1",
     "client-sessions": "^0.8.0",
-    "colors": "^1.4.0",
     "cross-spawn": "^7.0.2",
     "del": "^6.0.0",
     "dotenv": "^10.0.0",


### PR DESCRIPTION
This PR mitigates against future possible changes to the `colors` package, following the events described in https://www.bleepingcomputer.com/news/security/dev-corrupts-npm-libs-colors-and-faker-breaking-thousands-of-apps/.

We only depend on `colors` in one place, as an indirect dependency of `gulp-nodemon`. gulp-nodemon appears to be no longer maintained, so this PR vendors the code. This comes with an increased security burden, because we can no longer rely on other users of gulp-nodemon to audit this code, or Dependabot security alerts to notify us of any CVEs in the gulp-nodemon code, but I believe that given the small amount of code involved this is a manageable risk.