### PR TITLE
 Update link text on pages and templates

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -32,7 +32,7 @@
 
       <ul class="govuk-list govuk-list--bullet">
         <li>
-          <a href="/docs/tutorials-and-examples">Example pages and documentation</a>
+          <a href="/docs/tutorials-and-examples">Tutorials and templates</a>
         </li>
         <li>
           <a href="https://design-system.service.gov.uk">GOV.UK Design System</a>

--- a/docs/documentation/accessibility.md
+++ b/docs/documentation/accessibility.md
@@ -70,7 +70,7 @@ The test was carried out by the GOV.UK Prototype Kit team.
 The GOV.UK Prototype Kit team tested a sample of pages to cover the different content types in the Prototype Kit website. They were:
 
 - [the homepage](/docs)
-- [the tutorials and examples page](/docs/tutorials-and-examples)
+- [the tutorials and templates page](/docs/tutorials-and-examples)
 - [the tutorial pages](/docs/make-first-prototype/start)
 - [the guide pages](/docs/publishing-on-heroku)
 - [the example pages](/docs/examples/pass-data)

--- a/docs/documentation/adding-css-javascript-and-images.md
+++ b/docs/documentation/adding-css-javascript-and-images.md
@@ -21,7 +21,7 @@ To add styles use:
 
 Do not edit the file `/public/styles/application.css` because it’s deleted and rebuilt every time you make a change to your prototype.
 
-The Prototype Kit uses [Sass](https://sass-lang.com/guide), which adds extra features to CSS.
+The [Prototype Kit uses Sass](https://sass-lang.com/guide), which adds extra features to CSS.
 
 ### Using import
 

--- a/docs/documentation/creating-routes.md
+++ b/docs/documentation/creating-routes.md
@@ -47,4 +47,4 @@ Template files are found this way: `/views/` + `template` parameter + `.html`. T
 
 In the same way, the template `/examples/hello_world` would point to the `/examples/hello_world.html` file.
 
-[Read the Express documentation for routes](http://expressjs.com/4x/api.html#app.VERB)
+[Express documentation for routes](http://expressjs.com/4x/api.html#app.VERB)

--- a/docs/documentation/install/developer-install-instructions.md
+++ b/docs/documentation/install/developer-install-instructions.md
@@ -3,7 +3,7 @@ title: Installation guide for advanced users
 ---
 # Installation guide for advanced users
 
-It's built on the [Express](http://expressjs.com/) framework, and uses [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend).
+It's built on the [Express framework](http://expressjs.com/), and uses [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend).
 
 If you already installed a previous version of the Prototype Kit, you can [update the kit](/docs/updating-the-kit) instead.
 
@@ -22,4 +22,4 @@ npm install
 npm start
 ```
 
-Go to [localhost:3000](http://localhost:3000) in your browser.
+[Go to localhost:3000](http://localhost:3000) in your browser.

--- a/docs/documentation/install/install-the-kit.md
+++ b/docs/documentation/install/install-the-kit.md
@@ -75,4 +75,4 @@ npm install
 The install may take about a minute. Whilst installing, it may `WARN` about some items - this is ok. As long as there are no `ERROR`s, you can continue.
 
 
-<a href="run-the-kit.md" class="button">Next (run the kit)</a>
+<a href="run-the-kit.md" class="button">Next (How to run the kit)</a>

--- a/docs/documentation/install/introduction.md
+++ b/docs/documentation/install/introduction.md
@@ -3,15 +3,15 @@ title: Installation guide for new users
 ---
 # Installation guide for new users
 
-This guide will walk you through installing and getting started with the kit. You don’t need any technical knowledge to follow along. If you get stuck, contact us using the [#prototype-kit Slack channel](https://ukgovernmentdigital.slack.com/messages/C0647LW4R/), or if you have a developer on your team, they should be able to help.
+This guide will walk you through installing and getting started with the kit. You don’t need any technical knowledge to follow along. If you get stuck, contact us using the [#prototype-kit channel on cross-government Slack](https://ukgovernmentdigital.slack.com/messages/C0647LW4R/), or if you have a developer on your team, they should be able to help.
 
 Installation takes up to 30 minutes depending on how much you need to install.
 
-If you already installed a previous version of the Prototype Kit, you can [update the kit](/docs/updating-the-kit) instead.
+If you already installed a previous version of the Prototype Kit, you can [update your Prototype Kit](/docs/updating-the-kit) instead.
 
-If you’re comfortable using git and the terminal, you may prefer the [developer friendly instructions](developer-install-instructions).
+If you’re comfortable using git and the terminal, you may prefer the [guide for advanced users](developer-install-instructions).
 
-> This guide is a work in progress. Please help [contribute](https://github.com/alphagov/govuk-prototype-kit/blob/main/CONTRIBUTING.md) to make it even better.
+> This guide is a work in progress. [You can contribute](https://github.com/alphagov/govuk-prototype-kit/blob/main/CONTRIBUTING.md) to make it better.
 
 ## Introduction
 
@@ -21,4 +21,4 @@ The GOV.UK Prototype Kit provides a simple way to make interactive prototypes th
 
 You’ll use a copy of the kit for each different prototype you want to make - they’re self contained. Once installed, the kit uses about 100mb.
 
-<a href="requirements.md" class="button">Next (requirements)</a>
+<a href="requirements.md" class="button">Next (Prototype Kit requirements)</a>

--- a/docs/documentation/install/requirements.md
+++ b/docs/documentation/install/requirements.md
@@ -6,7 +6,7 @@ caption: Installation guide for new users
 
 The GOV.UK Prototype Kit runs on Mac, Windows and Linux. At a minimum you’ll need Node.js (install instructions below) and a web browser.
 
-If you're using an M1 Mac ([certain Macs launched in 2020 and later](https://en.wikipedia.org/wiki/Apple_M1#Products_that_include_the_Apple_M1)), you might experience issues when you run the Prototype Kit. To get support, [contact the Prototype team](/docs/about).
+[If you're using an M1 Mac issued in 2020 or later](https://en.wikipedia.org/wiki/Apple_M1#Products_that_include_the_Apple_M1), you might experience issues when you run the Prototype Kit. To get support, [contact the Prototype team](/docs/about).
 
 ## Software you need
 
@@ -83,4 +83,4 @@ node --version
 
 If it’s installed correctly it should show a number starting with 16.
 
-<a href="install-the-kit.md" class="button">Next (install the kit)</a>
+<a href="install-the-kit.md" class="button">Next (How to install the kit)</a>

--- a/docs/documentation/install/run-the-kit.md
+++ b/docs/documentation/install/run-the-kit.md
@@ -34,7 +34,7 @@ Listening on port 3000 url: http://localhost:3000
 
 ## Check it works
 
-In your web browser, visit <a href="http://localhost:3000" target="_blank">http://localhost:3000 (opens in a new tab)</a>
+In your web browser, <a href="http://localhost:3000" target="_blank">open http://localhost:3000 (opens in a new tab)</a>
 
 You should see the prototype welcome page.
 
@@ -50,7 +50,7 @@ To quit the kit, in the terminal press the `ctrl` and `c` keys together.
 
 The kit is now installed. Congratulations!
 
-The Prototype Kit is updated regularly. We announce new versions of the Prototype Kit in the [#prototype-kit channel on cross-government Slack](https://ukgovernmentdigital.slack.com/messages/prototype-kit/). You should [update to the latest version](/docs/updating-the-kit) to get the latest components, new features and fixes.
+The Prototype Kit is updated regularly. We announce new versions of the Prototype Kit in the [#prototype-kit channel on cross-government Slack](https://ukgovernmentdigital.slack.com/messages/prototype-kit/). You should [update to the latest version of the kit](/docs/updating-the-kit) to get the latest components, new features and fixes.
 
 ## Make your first prototype
 

--- a/docs/documentation/make-first-prototype/branching.md
+++ b/docs/documentation/make-first-prototype/branching.md
@@ -18,7 +18,7 @@ The route takes the answer the user gave to the first question and either sends 
 
 2. Update the content to tell the user why they’re ineligible and what they can do next.
 
-Check it works by visiting http://localhost:3000/ineligible.
+To check it works, [go to http://localhost:3000/ineligible](http://localhost:3000/ineligible).
 
 ## Create a route
 

--- a/docs/documentation/make-first-prototype/create-pages.md
+++ b/docs/documentation/make-first-prototype/create-pages.md
@@ -16,7 +16,7 @@ To copy a file in Atom:
 1. Right-click a file in the folders list on the left and select **Copy**.
 2. Right-click the folder you want to copy the file into and select **Paste**.   
 
-Preview the pages in your prototype by going to ht<span>tp</span>://localhost:3000/NAME-OF-HTML-FILE in your web browser. For example, go to [http://localhost:3000/start](http://localhost:3000/start) to preview `start.html`.
+Preview the pages in your prototype by going to ht<span>tp</span>://localhost:3000/NAME-OF-HTML-FILE in your web browser. For example, [go to http://localhost:3000/start](http://localhost:3000/start) to preview `start.html`.
 
 #### Change the service name
 

--- a/docs/documentation/make-first-prototype/let-user-change-answers.md
+++ b/docs/documentation/make-first-prototype/let-user-change-answers.md
@@ -40,7 +40,7 @@ For each of the `items`, we’ll add a `checked` value, like this:
 ```
 In each case make sure the spelling is exactly the same as the `value`.
 
-Go to [http://localhost:3000/juggling-balls](http://localhost:3000/juggling-balls) and check the journey works by selecting an answer, continuing to the next page, then going back.
+[Go to http://localhost:3000/juggling-balls](http://localhost:3000/juggling-balls) and check the journey works by selecting an answer, continuing to the next page, then going back.
 
 ## Show the user’s answer in question 2
 
@@ -63,6 +63,6 @@ Add `value: data['most-impressive-trick']` like this:
 }) }}
 ```
 
-Go to [http://localhost:3000/juggling-trick](http://localhost:3000/juggling-trick) and check it works by filling in an answer, continuing to the next page, going back, then refreshing your browser.
+[Go to http://localhost:3000/juggling-trick](http://localhost:3000/juggling-trick) and check it works by filling in an answer, continuing to the next page, going back, then refreshing your browser.
 
-[Next (Show different pages depending on user input - branching)](branching)
+[Next (Show different pages depending on user input)](branching)

--- a/docs/documentation/make-first-prototype/link-index-page-start-page.md
+++ b/docs/documentation/make-first-prototype/link-index-page-start-page.md
@@ -4,9 +4,9 @@ caption: Build a basic prototype
 ---
 # Link your index page to your start page
 
-You can route users from your service's index page to your start page. The index page is the page that loads when users visit http://localhost:3000.
+You can route users from your service's index page to your start page. The index page is the page that loads when users [go to http://localhost:3000](http://localhost:3000).
 
 1. Open the `index.html` file in your `app/views` folder.
 2. Add an `<a>` tag that links to `/start`.
 
-You can now find out how to [publish your prototype online](/docs/publishing-on-heroku), so you can share it with your team or do user research.
+You can now find out [how to publish your prototype online](/docs/publishing-on-heroku), so you can share it with your team or do user research.

--- a/docs/documentation/make-first-prototype/link-pages-together.md
+++ b/docs/documentation/make-first-prototype/link-pages-together.md
@@ -15,7 +15,7 @@ To take users from one page to another, you can use either:
 2. Find the `<a>` tag with 'Start now' inside.
 3. Change the value of the `href` attribute from `#` to `/juggling-balls`.
 
-Go to http://localhost:3000/start and select the **Start now** button to check the link works.
+[Go to http://localhost:3000/start](http://localhost:3000/start) and select the **Start now** button to check the link works.
 
 Links normally appear as text with underlines. We make **Start now** look like a button to make it more obvious to users.
 
@@ -25,7 +25,7 @@ Links normally appear as text with underlines. We make **Start now** look like a
 2. Find the line `<form class="form" action="/url/of/next/page" method="post">`.
 3. Change the value of the `action` attribute from `/url/of/next/page` to `/juggling-trick`.
 
-Go to http://localhost:3000/juggling-balls and select **Continue** to check the button works.
+[Go to http://localhost:3000/juggling-balls](http://localhost:3000/juggling-balls) and select **Continue** to check the button works.
 
 This time it's a real HTML button, not a link. Buttons submit form data - the URL is on the form tag, not the button.
 
@@ -35,7 +35,7 @@ This time it's a real HTML button, not a link. Buttons submit form data - the UR
 2. Find the line `<form class="form" action="/url/of/next/page" method="post">`.
 3. Change the value of the `action` attribute from `/url/of/next/page` to `/check-answers`.
 
-Go to http://localhost:3000/juggling-trick and select **Continue** to check the button works.
+[Go to http://localhost:3000/juggling-trick](http://localhost:3000/juggling-trick) and select **Continue** to check the button works.
 
 The 'Check answers' page template links to the ‘Confirmation’ page by default. So you do not need to change the ‘Check answers’ page.
 

--- a/docs/documentation/make-first-prototype/show-users-answers.md
+++ b/docs/documentation/make-first-prototype/show-users-answers.md
@@ -40,7 +40,7 @@ to
 ```
 <span class="govuk-visually-hidden"> your most impressive juggling trick</span>
 ```
-Go to http://localhost:3000/start and answer the questions to check your answers show up correctly.
+[Go to http://localhost:3000/start](http://localhost:3000/start) and answer the questions to check your answers show up correctly.
 
 ## Delete the remaining example answers
 

--- a/docs/documentation/make-first-prototype/start.md
+++ b/docs/documentation/make-first-prototype/start.md
@@ -31,6 +31,6 @@ You'll also need a code editor. You can use any editor, but the instructions in 
 
 If you would like to give feedback about this tutorial, or you’ve got a question, get in touch with the GOV.UK Design System team:
 
-- on the <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/app_redirect?channel=prototype-kit" data-hsupport="slack">#prototype-kit channel on cross-government Slack</a>.
+- on the <a class="govuk-link" href="https://ukgovernmentdigital.slack.com/app_redirect?channel=prototype-kit" data-hsupport="slack">#prototype-kit channel on cross-government Slack</a>
 
 - by email at <a class="govuk-link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" data-hsupport="email">govuk-design-system-support@digital.cabinet-office.gov.uk</a>

--- a/docs/documentation/make-first-prototype/use-components-2.md
+++ b/docs/documentation/make-first-prototype/use-components-2.md
@@ -4,7 +4,7 @@ caption: Build a basic prototype
 ---
 # Add a textarea to question 2
 
-1. Go to the [textarea](https://design-system.service.gov.uk/components/textarea/) page of the Design System.
+1. Go to the [textarea page of the Design System](https://design-system.service.gov.uk/components/textarea/).
 2. Select the **Nunjucks** tab, then **Copy code**.
 3. Open `juggling-trick.html` in your `app/views` folder.
 4. Replace the 2 example `<p>...</p>` paragraphs with the code you copied.

--- a/docs/documentation/make-first-prototype/use-components.md
+++ b/docs/documentation/make-first-prototype/use-components.md
@@ -16,7 +16,7 @@ In the Design System, components have both Nunjucks and HTML example code. Eithe
 
 ## Add radios to question 1
 
-1. Go to the [radios component](https://design-system.service.gov.uk/components/radios/) in the Design System.
+1. Go to the [radios component in the Design System](https://design-system.service.gov.uk/components/radios/).
 2. Select the **Nunjucks** tab under the first example, then **Copy code**.
 3. Open `juggling-balls.html` in your `app/views` folder.
 4. Replace the 2 example `<p>...</p>` paragraphs with the code you copied.

--- a/docs/documentation/publishing-on-heroku-terminal.md
+++ b/docs/documentation/publishing-on-heroku-terminal.md
@@ -3,7 +3,7 @@ title: Publish on the web from the terminal
 ---
 # Publish on the web (Heroku) from the terminal
 
-We recommend using [Heroku](http://www.heroku.com) to get your prototype online. It’s simple and fast to deploy new versions as you work.
+We recommend [using Heroku](http://www.heroku.com) to get your prototype online. It’s simple and fast to deploy new versions as you work.
 
 Once your prototype is on Heroku, other people will be able to access and try your prototype from their own computers or mobile devices.
 
@@ -23,7 +23,7 @@ If you’re new to Heroku, [sign up for a free account](https://signup.heroku.co
 
 ## 3) Install the Heroku toolbelt
 
-Install the [Heroku toolbelt](https://toolbelt.heroku.com/).
+[Install the Heroku toolbelt](https://toolbelt.heroku.com/).
 
 > On Windows, after downloading the toolbelt you'll need to run `heroku login` using the `cmd` app, as it does not work in Git Bash. Once you’ve logged in, you can return to using Git Bash.
 

--- a/docs/documentation/session.md
+++ b/docs/documentation/session.md
@@ -92,10 +92,6 @@ Or in views as:
 {{ data['partner']['last-name'] }}
 ```
 
-You can see a full example here:
+An [example using express-session to store page views for a user](https://github.com/expressjs/session#example)
 
-[https://github.com/expressjs/session#example](https://github.com/expressjs/session#example)
-
-You can read more about Express Session here:
-
-[https://github.com/expressjs/session](https://github.com/expressjs/session)
+Read more about the [Express Session](https://github.com/expressjs/session)

--- a/docs/documentation/setting-up-git.md
+++ b/docs/documentation/setting-up-git.md
@@ -1,7 +1,7 @@
 ---
-title: Set up Git using the Terminal
+title: Set up Git using the terminal
 ---
-# Set up Git using the Terminal
+# Set up Git using the terminal
 
 Git helps track changes in code and lets you undo mistakes or identify bugs. It’s also used to collaborate with other people - so you can share your code with other designers and developers on your team (or with other teams!). Git is a type of version control software.
 

--- a/docs/documentation/setting-up-git.md
+++ b/docs/documentation/setting-up-git.md
@@ -5,15 +5,19 @@ title: Set up Git using the Terminal
 
 Git helps track changes in code and lets you undo mistakes or identify bugs. It’s also used to collaborate with other people - so you can share your code with other designers and developers on your team (or with other teams!). Git is a type of version control software.
 
-This guide will walk you through setting up a git repo (repository) and committing your work so that you can publish your prototype on the web.
+This guide will walk you through setting up a Git repo (repository) and committing your work so that you can publish your prototype on the web.
 
 > You don’t *have* to use Git to use the Prototype Kit, but it will be really useful if you learn some basics.
 
 > Git is not the same as GitHub. Git stores versions of your work, and lets you collaborate more easily with others. GitHub puts it all online with a nice web interface.
 
-You'll need to install Git first. Installation instructions for Mac, Windows, and Linux can be found [here](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git). Once you've done that, read below to get set up.
+You'll need to install Git first. 
 
-## 1) Set up Git
+[Git installation instructions for Mac, Windows, and Linux](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
+
+Once you've done that, read below to get set up.
+
+## 1. Set up Git
 
 Before using Git, it's best to set it up with your name and email address, this helps other people know who worked on what.
 
@@ -27,7 +31,7 @@ For example,  `git config --global user.name "John Smith"`
 
 If you have an account on GitHub, use the *same* email address for both.
 
-## 2) Initialise a Git repo
+## 2. Initialise a Git repo
 
 The first time you want to use Git on your prototype, you need to initialise it.
 
@@ -36,14 +40,14 @@ In your prototype folder:
 git init
 ```
 
-This sets up git to track the files in your prototype folder.
+This sets up Git to track the files in your prototype folder.
 
 The default branch created by the `git init` command is called `master`, which is a [potentially offensive term](https://sfconservancy.org/news/2020/jun/23/gitbranchname/). Rename the current branch to `main` instead:
 ```
 git branch -M main
 ```
 
-## 3) Check the Git status
+## 3. Check the Git status
 
 It’s a good idea to run `git status` frequently. This tells you the current status - for example, if you made changes to files that haven’t been committed.
 
@@ -52,9 +56,9 @@ In your prototype folder:
 git status
 ```
 
-As this is a new git repo, all files in the kit will be listed as having changes.
+As this is a new Git repo, all files in the kit will be listed as having changes.
 
-## 4) Doing your first commit
+## 4. Doing your first commit
 
 There are two stages to committing your changes. The first is to select the specific files with changes you want to commit, called **‘staging’**. The second is to commit all the changes in ‘staging’.
 
@@ -85,16 +89,16 @@ The message you put in the speech marks should be descriptive of the changes you
 
 Read more about writing good commit messages in the [Git style guide in the 'How to store source code' page of the GDS Way](https://gds-way.cloudapps.digital/standards/source-code.html#commit-messages).
 
-## 5) Check Git status again
+## 5. Check Git status again
 
 Run `git status` again and it should say `Nothing to commit` - all the changes you selected have been saved.
 
-## 6) Learning Git
+## 6. Learning Git
 
 We recommend doing a tutorial on Git basics. Once you’ve done that, the best thing is to keep using Git each day (commit at least one change, etc) so it becomes familiar to you. Ask developers on your team to help you until you’re comfortable on your own.
 
-[GitHub tutorial on git](https://try.github.io/levels/1/challenges/1)
+[GitHub tutorial on Git](https://try.github.io/levels/1/challenges/1)
 
-[Advanced git tutorial](http://think-like-a-git.net/)
+[Advanced Git tutorial](http://think-like-a-git.net/)
 
 > Git can be used via the command line or using an app. It’s up to you which you learn. Most developers use the command line, so if you’d like help from them, it’s often better to use that.

--- a/docs/documentation/using-notify.md
+++ b/docs/documentation/using-notify.md
@@ -9,11 +9,9 @@ confirmation email at the end of a journey.
 
 ## Sign up for a GOV.UK Notify account
 
-If you have a government email address you can sign up for an account at
-https://www.gov.uk/notify
+You need an account before you can use GOV.UK Notify to send text messages or emails.
 
-You need an account before you can use GOV.UK Notify to send text
-messages or emails.
+If you have a government email address you can [sign up for a GOV.UK Notify account](https://www.gov.uk/notify)
 
 ## Getting an API key
 
@@ -148,4 +146,4 @@ get consent to use them before doing your research.
 
 ## More things you can do with GOV.UK Notify
 
-The complete documentation for using the GOV.UK Notify API is here: https://docs.notifications.service.gov.uk/node.html
+[Documentation for using the GOV.UK Notify API](https://docs.notifications.service.gov.uk/node.html)

--- a/docs/views/documentation_template.html
+++ b/docs/views/documentation_template.html
@@ -12,7 +12,7 @@
 	      href: "/docs"
 	    },
 	    {
-	      text: "Tutorials and examples",
+	      text: "Tutorials and templates",
 	      href: "/docs/tutorials-and-examples"
 	    }
 	  ]

--- a/docs/views/examples/pass-data/index.html
+++ b/docs/views/examples/pass-data/index.html
@@ -26,7 +26,7 @@
       </p>
 
       <p>
-        <a href="/docs/examples/pass-data/vehicle-registration">You can see an example here.</a>
+        <a href="/docs/examples/pass-data/vehicle-registration">An example of what passing data looks like in a prototype.</a>
       </p>
 
       <p>

--- a/docs/views/examples/pass-data/vehicle-check-answers.html
+++ b/docs/views/examples/pass-data/vehicle-check-answers.html
@@ -66,7 +66,7 @@
 
       <p>
         <a href="/docs/tutorials-and-examples">
-          Return to Prototype Kit examples
+          Return to tutorials and templates
         </a>
       </p>
 

--- a/docs/views/includes/breadcrumb_examples.html
+++ b/docs/views/includes/breadcrumb_examples.html
@@ -4,7 +4,7 @@
       <a class="govuk-breadcrumbs__link" href="/docs">GOV.UK Prototype Kit</a>
     </li>
     <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="/docs/tutorials-and-examples">Tutorials and examples</a>
+      <a class="govuk-breadcrumbs__link" href="/docs/tutorials-and-examples">Tutorials and templates</a>
     </li>
   </ol>
 </div>

--- a/docs/views/index.html
+++ b/docs/views/index.html
@@ -33,7 +33,7 @@ GOV.UK Prototype Kit
     </div>
     <div class="govuk-grid-column-one-third govuk-!-margin-top-6">
 
-      <h2 class="govuk-heading-m"><a href="/docs/tutorials-and-examples" data-htutorials="Tutorials and examples">Tutorials and examples</a></h2>
+      <h2 class="govuk-heading-m"><a href="/docs/tutorials-and-examples" data-htutorials="Tutorials and templates">Tutorials and templates</a></h2>
       <p>
         Tutorials, examples and templates.
       </p>

--- a/docs/views/install.html
+++ b/docs/views/install.html
@@ -28,7 +28,7 @@ Install the Prototype Kit – GOV.UK Prototype Kit
 
       <h2 class="govuk-heading-m">1. Download the kit</h2>
 			<p>
-	      <a href="/docs/download" data-link="download">Download (zip)</a>
+	      <a href="/docs/download" data-link="download">Download the Prototype Kit (zip file)</a>
 			</p>
       <h2 class="govuk-heading-m">2. Install the kit</h2>
 

--- a/docs/views/layout.html
+++ b/docs/views/layout.html
@@ -45,9 +45,9 @@
       },
       {
         href: "/docs/tutorials-and-examples",
-        text: "Tutorials and examples",
+        text: "Tutorials and templates",
         attributes: {
-          "data-tutorials": "Tutorials and examples"
+          "data-tutorials": "Tutorials and templates"
         }
       },
       {

--- a/docs/views/templates/content.html
+++ b/docs/views/templates/content.html
@@ -19,7 +19,7 @@
 
       <p>This is a paragraph of text. It explains in more detail what has happened and wraps across several lines.</p>
 
-      <p>This paragraph has a link to <a href="/url/of/onward/page">find out more about this subject</a>.</p>
+      <p>Read more <a href="/url/of/onward/page">about this topic</a>.</p>
 
     </div>
   </div>

--- a/docs/views/templates/start.html
+++ b/docs/views/templates/start.html
@@ -54,7 +54,7 @@
 
       <p>You can also <a href="#">register by post</a>.</p>
 
-      <p>The online service is also available in <a href="#">Welsh (Cymraeg)</a>.</p>
+      <p>The online service is also <a href="#">available in Welsh (ar gael yn Gymraeg)</a>.</p>
 
       <p>You can’t register for this service if you’re in the UK illegally.</p>
 

--- a/docs/views/tutorials-and-examples.html
+++ b/docs/views/tutorials-and-examples.html
@@ -17,7 +17,7 @@
 
 {% block content %}
 
-  <h1 class="govuk-heading-xl">Tutorials and page templates</h1>
+  <h1 class="govuk-heading-xl">Tutorials and templates</h1>
 
   <div class="govuk-grid-row">
 
@@ -30,7 +30,7 @@
       <h3 class="govuk-heading-s">Download and install</h3>
       <ul class="govuk-list govuk-list--bullet">
         <li>
-          <a href="/docs/download" data-link="download">Download the Prototype Kit (zip)</a>
+          <a href="/docs/download" data-link="download">Download the Prototype Kit (zip file)</a>
         </li>
         <li>
           <a href="/docs/install/introduction">Installation guide for new users</a>
@@ -88,25 +88,25 @@
       <h3 class="govuk-heading-s">Basic usage</h3>
       <ul class="govuk-list govuk-list--bullet">
         <li>
-          <a href="/docs/usage-data">Sending kit usage data</a>
+          <a href="/docs/usage-data">Share usage data</a>
         </li>
         <li>
-          <a href="/docs/adding-css-javascript-and-images">Adding CSS, JavaScript, images and PDFs</a>
+          <a href="/docs/adding-css-javascript-and-images">Add CSS, JavaScript, images and other files</a>
         </li>
         <li>
-          <a href="/docs/github-desktop">Storing your code online with GitHub and GitHub Desktop</a>
+          <a href="/docs/github-desktop">Store your code online with GitHub or GitHub Desktop</a>
         </li>
         <li>
-          <a href="/docs/setting-up-git">Setting up Git using the terminal</a>
+          <a href="/docs/setting-up-git">Set up Git using terminal</a>
         </li>
         <li>
-          <a href="/docs/publishing-on-heroku">Publishing on the web (Heroku)</a>
+          <a href="/docs/publishing-on-heroku">Publish on the web (Heroku)</a>
         </li>
         <li>
-          <a href="/docs/examples/template-data">Passing data into a template</a>
+          <a href="/docs/examples/template-data">Pass data into a page</a>
         </li>
         <li>
-          <a href="/docs/updating-the-kit">Updating to the latest version</a>
+          <a href="/docs/updating-the-kit">Update your Prototype Kit</a>
         </li>
       </ul>
     </div>
@@ -114,19 +114,19 @@
       <h3 class="govuk-heading-s">Advanced usage</h3>
       <ul class="govuk-list govuk-list--bullet">
         <li>
-          <a href="/docs/examples/pass-data">Passing data from page to page</a>
+          <a href="/docs/examples/pass-data">Pass data from page to page</a>
         </li>
         <li>
-          <a href="/docs/creating-routes">Creating routes (server side programming)</a>
+          <a href="/docs/creating-routes">Create routes (server side programming)</a>
         </li>
         <li>
           <a href="/docs/examples/override-service-name">Override the service name on one page</a>
         </li>
         <li>
-          <a href="/docs/session">Storing data in session</a>
+          <a href="/docs/session">Store data in session</a>
         </li>
         <li>
-          <a href="/docs/using-notify">Using GOV.UK Notify</a>
+          <a href="/docs/using-notify">Use GOV.UK Notify to prototype emails and text messages</a>
         </li>
         <li>
           <a href="https://design-system.service.gov.uk/styles/page-template/#changing-template-content">
@@ -134,7 +134,7 @@
           </a>
         </li>
         <li>
-          <a href="/docs/backwards-compatibility">Backwards compatibility</a>
+          <a href="/docs/backwards-compatibility">Use backwards compatibility to upgrade from version 6</a>
         </li>
       </ul>
     </div>
@@ -153,35 +153,35 @@
       <ul class="govuk-list govuk-list--bullet">
         <li>
           <a href="/docs/templates/blank-govuk">
-            Blank
+            GOV.UK page template
           </a> /
           <a href="/docs/templates/blank-unbranded">
-            Blank (non-GOV.UK)
+            Unbranded page template
           </a>
         </li>
         <li>
           <a href="/docs/templates/question">
-            Question page
+            Question page template
           </a>
         </li>
         <li>
           <a href="/docs/templates/content">
-            Content page
+            Content page template
           </a>
         </li>
         <li>
           <a href="/docs/templates/task-list">
-            Task list
+            Task list template
           </a>
         </li>
         <li>
           <a href="/docs/templates/check-answers">
-            Check answers
+            Check your answers template
           </a>
         </li>
         <li>
           <a href="/docs/templates/confirmation">
-            Confirmation
+            Confirmation page template
           </a>
         </li>
       </ul>
@@ -193,17 +193,17 @@
       <ul class="govuk-list govuk-list--bullet">
         <li>
           <a href="/docs/templates/start">
-            Start page
+            Start page template
           </a>
         </li>
         <li>
           <a href="/docs/templates/step-by-step-navigation">
-            Step by step navigation
+            Step by step navigation template
           </a>
         </li>
         <li>
           <a href="/docs/templates/start-with-step-by-step">
-            Start page with Step by step navigation
+            Start page with step by step template
           </a>
         </li>
       </ul>


### PR DESCRIPTION
This updates link text on our documentation pages, as per [our review](https://docs.google.com/spreadsheets/d/1Y-c8e_syvu2hT8jLr0yNKigNAGpf1yU7WJlal3iLSIs/edit?pli=1#gid=1864275821).

Keeping it in draft for now as there's still a few outstanding comments on the above doc.

Closes #1212 