### PR TITLE
Bump marked to 4.0.10

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 
 // NPM dependencies
 const { get: getKeypath } = require('lodash')
-const marked = require('marked')
+const { marked } = require('marked')
 const path = require('path')
 const portScanner = require('portscanner')
 const inquirer = require('inquirer')

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "gulp-sass": "^5.0.0",
         "inquirer": "^8.2.0",
         "lodash": "^4.17.21",
-        "marked": "^3.0.8",
+        "marked": "^4.0.10",
         "node-sass": "^6.0.1",
         "notifications-node-client": "^5.1.0",
         "nunjucks": "^3.2.1",
@@ -10473,11 +10473,11 @@
       }
     },
     "node_modules/marked": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
-      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
       "bin": {
-        "marked": "bin/marked"
+        "marked": "bin/marked.js"
       },
       "engines": {
         "node": ">= 12"
@@ -23692,9 +23692,9 @@
       }
     },
     "marked": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
-      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw=="
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw=="
     },
     "matchdep": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "gulp-sass": "^5.0.0",
     "inquirer": "^8.2.0",
     "lodash": "^4.17.21",
-    "marked": "^3.0.8",
+    "marked": "^4.0.10",
     "node-sass": "^6.0.1",
     "notifications-node-client": "^5.1.0",
     "nunjucks": "^3.2.1",


### PR DESCRIPTION
We have a [security advisory for `marked`](https://github.com/alphagov/govuk-prototype-kit/security/dependabot/package-lock.json/marked/open) v3.0.8 that can be resolved by bumping to the latest version.

This involves a breaking change to v4.0.10, however, it appears the only things that have changed are to do with how `marked` is imported or used in a script tag, so simply updating our require statement is enough to keep everything hunky dory.