### PR TITLE
Update alt-text / captions for images

### DIFF
--- a/docs/assets/sass/docs.scss
+++ b/docs/assets/sass/docs.scss
@@ -9,6 +9,16 @@ img{
   max-width: 100%;
 }
 
+// remove user agent stylesheet indent from figures / captions
+figure {
+  // Needed for WebKit, Blink
+  margin-inline-start: inherit;
+  margin-inline-end: inherit;
+  // Needed for Internet Explorer
+  margin-left: inherit;
+  margin-right: inherit;
+}
+
 // adjust code block font-size to 19px
 .hljs {
   font-size: 19px;

--- a/docs/documentation/backwards-compatibility.md
+++ b/docs/documentation/backwards-compatibility.md
@@ -27,7 +27,8 @@ If any pages or routes exist in both apps, the one in version 7 will win.
 
 1. Find and replace all instances of **/public/** to **/public/v6/** in your code.
 In Atom, press **cmd shift F**. It looks like this:
-![Screenshot of Atom find and replace](/public/images/docs/backwards-compatibility-atom.png)
+
+![Screenshot of section of the Atom user interface with: a text field that contains '/public/'; a button labelled 'find all'; a text field containing '/public/v6'; and a button labelled 'replace all'.](/public/images/docs/backwards-compatibility-atom.png)
 
 1. [Download the latest Prototype Kit](/docs/download) and unzip it.
 

--- a/docs/documentation/github-desktop.md
+++ b/docs/documentation/github-desktop.md
@@ -30,7 +30,7 @@ Some concepts:
 
 A screenshot of GitHub Desktop at this point:
 
-![](/public/images/docs/github-desktop-add-local-repository.png)
+![Screenshot of the GitHub Desktop app. There is a separate pop-up box with the heading 'Add local repository'. In this box there is a text input labelled 'local path'. A button labelled 'choose'. A link titled 'Create a repository'. A button labelled 'Cancel'. And a button labelled 'Add repository'.](/public/images/docs/github-desktop-add-local-repository.png)
 
 3. In the warning, click the **create a repository** link.
 

--- a/docs/documentation/install/run-the-kit.md
+++ b/docs/documentation/install/run-the-kit.md
@@ -36,9 +36,12 @@ Listening on port 3000 url: http://localhost:3000
 
 In your web browser, <a href="http://localhost:3000" target="_blank">open http://localhost:3000 (opens in a new tab)</a>
 
-You should see the prototype welcome page.
+<figure>
 
-![Screenshot of the Prototype Kit homepage](/public/images/docs/prototype-kit-homepage.png)
+![The heading is GOV.UK Prototype Kit.](/public/images/docs/prototype-kit-homepage.png)
+
+<figcaption class="govuk-body">Screenshot of what your prototype homepage should look like.</figcaption>
+</figure>
 
 ## Quitting the kit
 

--- a/docs/documentation/make-first-prototype/start.md
+++ b/docs/documentation/make-first-prototype/start.md
@@ -13,7 +13,12 @@ It will take about an hour to finish this tutorial, after you install the Protot
 
 Our prototype will look a bit like this:
 
-![Overview of pages linked together](/public/images/docs/tutorial-overview.png)
+<figure>
+
+![The first page has the title 'Start page' with the button 'Start now'. This is linked to a second page with the title 'Question 1' and a 'Continue' button. This forks to 2 different pages. 1 is titled 'Ineligible'. 2 is titled Question 2. Question 2 is linked to a page titled 'Check answers'. This links to page 6, titled 'Complete'.](/public/images/docs/tutorial-overview.png)
+
+<figcaption class="govuk-body">Diagram of 6 pages connected together.</figcaption>
+</figure>
 
 ## Before you start
 

--- a/docs/documentation/make-first-prototype/use-components-2.md
+++ b/docs/documentation/make-first-prototype/use-components-2.md
@@ -32,6 +32,11 @@ Your component code should now look like this:
 
 Your page should now look like this:
 
-![Screenshot of the question page with a textarea](/public/images/docs/tutorial-textarea.png)
+<figure>
+
+![](/public/images/docs/tutorial-textarea.png)
+
+<figcaption class="govuk-body">Screenshot of how your prototype should look.</figcaption>
+</figure>
 
 [Next (Show the user’s answers on your ‘Check answers’ page)](show-users-answers)

--- a/docs/documentation/make-first-prototype/use-components-2.md
+++ b/docs/documentation/make-first-prototype/use-components-2.md
@@ -34,7 +34,7 @@ Your page should now look like this:
 
 <figure>
 
-![](/public/images/docs/tutorial-textarea.png)
+![Web page with the heading "What is your most impressive juggling trick", a textarea and continue button](/public/images/docs/tutorial-textarea.png)
 
 <figcaption class="govuk-body">Screenshot of how your prototype should look.</figcaption>
 </figure>

--- a/docs/documentation/make-first-prototype/use-components.md
+++ b/docs/documentation/make-first-prototype/use-components.md
@@ -73,7 +73,7 @@ Your page should now look like this:
 
 <figure>
 
-![](/public/images/docs/tutorial-radios.png)
+![Web page with the heading "How many balls can you juggle?", 3 radios and a continue button](/public/images/docs/tutorial-radios.png)
 
 <figcaption class="govuk-body">Screenshot of how your prototype should look.</figcaption>
 </figure>

--- a/docs/documentation/make-first-prototype/use-components.md
+++ b/docs/documentation/make-first-prototype/use-components.md
@@ -71,6 +71,11 @@ Your component code should now look like this:
 
 Your page should now look like this:
 
-![Screenshot of the question page with radios](/public/images/docs/tutorial-radios.png)
+<figure>
+
+![](/public/images/docs/tutorial-radios.png)
+
+<figcaption class="govuk-body">Screenshot of how your prototype should look.</figcaption>
+</figure>
 
 [Next (add a textarea to question 2)](use-components-2)

--- a/docs/documentation/publishing-on-heroku.md
+++ b/docs/documentation/publishing-on-heroku.md
@@ -13,7 +13,7 @@ You'll need to have [put your code on GitHub](/docs/github-desktop) to use this 
 
 2. In the top right click **New** then **Create new app**.
 
-![Screenshot of Heroku Create New App page](/public/images/docs/heroku-create-app.png)
+![Screenshot of a Heroku dashboard page that is titled 'Create a new app'. There are 2 input fields on the page. A text input labelled 'App name'. And a drop-down labelled 'Choose a region'. There is a button labelled 'Add to pipeline' and another button labelled 'Create app'.](/public/images/docs/heroku-create-app.png)
 
 3. Enter a name for your prototype app. App names in Heroku have to be unique across all the users of Heroku. It can be helpful to add your name or organisation to the start of the name to make it unique. For example joelanman-juggling-prototype.
 
@@ -25,7 +25,7 @@ You'll need to have [put your code on GitHub](/docs/github-desktop) to use this 
 
 1. For **Deployment method** choose **GitHub**. ‘Deploy’ means publish.
 
-![Screenshot of section of page headed Deployment method](/public/images/docs/heroku-deploy.png)
+![Screenshot of a section on the Heroku page that has the heading 'Deployment method'. It lists 3 links, left to right: 1. Heroku Git. 2. GitHub. 3. Container Registry.](/public/images/docs/heroku-deploy.png)
 
 2. Scroll down and click **Connect to GitHub**.
 


### PR DESCRIPTION
Closes #1232.

---

Note that this PR adds `<figcaption>` elements to some images, as semantic captions. See page 'How to run the kit' for an example. We apply an additional CSS reset to remove margins from `<figure>` elements that are usually applied by browser stylesheets.