### PR TITLE
Fix node_modules folder ignore directive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@ lib/extensions/_extensions.scss
 .start.pid
 .port.tmp
 public
-node_modules/*
+node_modules/
 .tmuxp.*


### PR DESCRIPTION
Remove the trailing `*` from the directory ignores, as it means something slightly different.

While you might think `node_modules/*` and `node_modules/` should mean the same thing thing, the gitignore manual page [[1]] suggests that `node_modules/*` matches the `node_modules` directory, and only the first level of subdirectory. I can't see that this makes a difference for the official git client in practice, although there is a lot of discussion about it on StackOverflow [[2]]. In a recent user support session I did see some unknown third party software treat the two differently - although I wasn't able to reproduce it.

Regardless, its clear that the "more correct" thing to do is have `node_modules/` without a star, and that is also commonly used best practice, (for instance see the gitignore template for Node that GiHub recommends [[3]]), so this commit changes our gitignore file.

[1]: https://git-scm.com/docs/gitignore
[2]: https://stackoverflow.com/questions/8783093/gitignore-syntax-bin-vs-bin-vs-bin-vs-bin
[3]: https://github.com/github/gitignore/blob/8ea9c647018521ab2a9c78d630a2fb6579e16d37/Node.gitignore#L42