### PR TITLE
Update Heroku docs to reflect custom auth process

### DIFF
--- a/docs/documentation/publishing-on-heroku-terminal.md
+++ b/docs/documentation/publishing-on-heroku-terminal.md
@@ -47,15 +47,20 @@ heroku apps:create [name of your app] --region eu
 ```
 Replace `[name of your app]` with your app name from step 4.
 
-## 6) Set a username and password
+## 6) Set a password
 
-Prototypes made with the kit require a username and password when published online. This stops members of the public coming across your prototype by accident.
+Prototypes made with the kit require a password when published online. This stops members of the public coming across your prototype by accident.
 
-### To set username and password:
+To set a password, run:
+
+```
+heroku config:set PASSWORD=password_here
+```
+
+If you get an error about username, run:
 
 ```
 heroku config:set USERNAME=username_here
-heroku config:set PASSWORD=password_here
 ```
 
 ## 7) Deploy your work

--- a/docs/documentation/publishing-on-heroku.md
+++ b/docs/documentation/publishing-on-heroku.md
@@ -43,22 +43,28 @@ You'll need to have [put your code on GitHub](/docs/github-desktop) to use this 
 
 Your prototype will deploy automatically each time you push your code to GitHub (it takes a few minutes each time).
 
-## Set a username and password
+## Set a password
 
-We need to set a username and password or the Prototype Kit won’t run online. They don’t have to be complicated – it’s just to stop people accidentally coming across your prototype online and mistaking it for a real service.
+You need to set a password or the Prototype Kit will not run online. This password does not have to be complicated. It's just to stop people accidentally finding your prototype online and mistaking it for a real service.
 
-1. At the top click the **Settings** tab.
+1. At the top of the Heroku page, click the **Settings** tab.
 
 2. Click **Reveal config vars**.
 
-3. In KEY put the word USERNAME
+3. In KEY, enter the word PASSWORD.
 
-4. In VALUE put a username of your choice, click **Add**.
+4. In VALUE, enter a password of your choice and click **Add**.
 
-That will be saved and you can add another KEY and VALUE.
+5. In the top right of the Heroku page, click **Open app** to see your prototype online.
 
-5. In KEY put the word PASSWORD
+### If you get an error about username
 
-6. In VALUE put a password of your choice, click **Add**.
+1. At the top of the Heroku page, click the **Settings** tab.
 
-7. In the top right, click **Open app** to see your prototype online!
+2. Click **Reveal config vars**.
+
+3. In KEY, enter the word USERNAME.
+
+4. In VALUE, enter a username of your choice and click **Add**.
+
+5. In the top right of the Heroku page, click **Open app** to see your prototype online.


### PR DESCRIPTION
**Do not merge until [#1182](https://github.com/alphagov/govuk-prototype-kit/pull/1182) is released**

This PR updates 2 docs:

- [Publish on the web (Heroku)](https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku)
- [Publish on the web (Heroku) from the terminal](https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku-terminal)

We're removing and relocating content that tells users they need to set a username when publishing the Kit online. In fact, they now only need to set a password. This is because we're introducing a custom authentication process, as browsers no longer always support basic auth.

Some users on old versions may still need the help content about usernames. So we've kept that available under the updated content about passwords.