### PR TITLE
Tell users how to pass data from form inputs

### DIFF
--- a/docs/documentation/make-first-prototype/link-pages-together.md
+++ b/docs/documentation/make-first-prototype/link-pages-together.md
@@ -9,6 +9,10 @@ To take users from one page to another, you can use either:
 - a link (`<a>` tag)
 - a form (`<form>` tag, when the user inputs data)
 
+If you need to pass data, do not use a link with the button class on your form. While the link will look identical to a `<button>` element, it will not pass any data.
+
+To pass data, wrap the button and any form inputs with a `<form>` tag and use a real `<button>` element.
+
 ## Link your start page to question 1
 
 1. Open `start.html` in your `app/views` folder.


### PR DESCRIPTION
Fixes [#1068](https://github.com/alphagov/govuk-prototype-kit/issues/1068).

Updates our ['Link your pages together' tutorial](https://govuk-prototype-kit.herokuapp.com/docs/make-first-prototype/link-pages-together) to tell users:

- links used with button classes do not pass any data
- to use a `<form>` tag and a real `<button>` element if they need to pass data
