### PR TITLE
Explain how to update a prototype that's on GitHub

### DIFF
--- a/docs/documentation/updating-the-kit.md
+++ b/docs/documentation/updating-the-kit.md
@@ -57,9 +57,9 @@ It will download a zip file and unzip the latest version of the Prototype Kit in
 
 12. If your prototype is already on GitHub, make sure that users with a local copy will get any file changes you make. To update this kind of prototype:
 
-- [branch off the `main` (or default) branch](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/making-changes-in-a-branch/managing-branches)
-- [pull the latest changes](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/keeping-your-local-repository-in-sync-with-github/syncing-your-branch)
-- once the update completes in your terminal, [commit the files](https://github.com/git-guides/git-commit), [open a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request), and so on
+  - [branch off the `main` (or default) branch](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/making-changes-in-a-branch/managing-branches)
+  - [pull the latest changes](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/keeping-your-local-repository-in-sync-with-github/syncing-your-branch)
+  - once the update completes in your terminal, [commit the files](https://github.com/git-guides/git-commit), [open a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request), and so on
 
 What you do might depend on the process followed by the team working on the prototype.
 

--- a/docs/documentation/updating-the-kit.md
+++ b/docs/documentation/updating-the-kit.md
@@ -55,6 +55,14 @@ It will download a zip file and unzip the latest version of the Prototype Kit in
 
 11. Delete the update folder in Finder or Windows Explorer.
 
+12. If your prototype is already on GitHub, make sure that users with a local copy will get any file changes you make. To update this kind of prototype:
+
+- [branch off the `main` (or default) branch](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/making-changes-in-a-branch/managing-branches)
+- [pull the latest changes](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/keeping-your-local-repository-in-sync-with-github/syncing-your-branch)
+- once the update completes in your terminal, [commit the files](https://github.com/git-guides/git-commit), [open a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request), and so on
+
+What you do might depend on the process followed by the team working on the prototype.
+
 ### If your prototype does not work
 
 If your prototype does not work, compare the new `package.json` file to the `package.json` file in the backup you made in step 3.


### PR DESCRIPTION
Fixes [#1207](https://github.com/alphagov/govuk-prototype-kit/issues/1207).

Updates our ['Update your Prototype Kit' page](https://govuk-prototype-kit.herokuapp.com/docs/updating-the-kit).

We're adding some extra steps following user feedback. They told us they'd updated their prototype, but then they weren't sure they needed to commit and push their changes. So we're adding content to say they need to, to make sure other users with a local copy also get the changes.