### PR TITLE
set site session length to 20hrs for accessibility

### DIFF
--- a/server.js
+++ b/server.js
@@ -164,10 +164,11 @@ app.locals.extensionConfig = extensions.getAppConfig()
 
 // Session uses service name to avoid clashes with other prototypes
 const sessionName = 'govuk-prototype-kit-' + (Buffer.from(config.serviceName, 'utf8')).toString('hex')
+const sessionHours = (promoMode === 'true') ? 20 : 4
 const sessionOptions = {
   secret: sessionName,
   cookie: {
-    maxAge: 1000 * 60 * 60 * 4, // 4 hours
+    maxAge: 1000 * 60 * 60 * sessionHours,
     secure: isSecure
   }
 }


### PR DESCRIPTION
addresses #1122 -set session length to 20 hours for the site to meet WCAG. The session length is left at 4 hours for the kit itself for now, so there's no impact users of the kit. We should investigate that too, but this PR is just for the website.