### PR TITLE
Remove redundant content from contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,17 +34,6 @@ Your JavaScript code should pass [linting](docs/linting.md).
 
 For anything else, maintain 2-space, soft-tabs only indentation. No trailing whitespace.
 
-### Versioning
-
-Follow the guidelines on [semver.org](http://semver.org/) for assigning version
-numbers.
-
-Versions should only be changed in a commit of their own, in a pull request of
-their own. This alerts team members to the new version and allows for
-last-minute scrutiny before the new version is released. Also, by raising a
-separate pull request, we avoid version number conflicts between feature
-branches.
-
 ### Commit hygiene
 
 Please see our [Git style guide in the 'How to store source code' page of the GDS Way](https://gds-way.cloudapps.digital/standards/source-code.html#commit-messages), which describes how we prefer Git history and commit messages to read.


### PR DESCRIPTION
Fixes [#1092](https://github.com/alphagov/govuk-prototype-kit/issues/1092).

Removes 'Versioning' section from our ['Contributing' doc](https://github.com/alphagov/govuk-prototype-kit/blob/main/CONTRIBUTING.md).

Contributors should not be doing any versioning. It's something we do ourselves during releases, and our [release doc](https://github.com/alphagov/govuk-prototype-kit/blob/main/internal_docs/releasing.md) already covers it.
