### PR TITLE
Add content about default session data

### DIFF
--- a/docs/views/examples/pass-data/index.html
+++ b/docs/views/examples/pass-data/index.html
@@ -80,8 +80,16 @@
       <pre class="app-code" tabindex="0"><code>&lt;input type="radio" name="claimant[over-18]" value="yes" {%raw%}{{ checked("['claimant']['over-18']", "yes") }}{%endraw%}&gt;</code></pre>
 
       <h3 class="govuk-heading-s">
-        Setting default data
+        Setting default values
       </h3>
+
+      <p>
+        Default values are pre-filled data in some of your form’s fields. For example, the day’s date on a form that records the date of submission.
+      </p>
+
+      <p>
+        Where possible, you should set default values to make sure your form’s fields are pre-filled. This saves the user from having to enter information unnecessarily.
+      </p>
 
       <p>You can set default values in this file in your prototype folder:
 


### PR DESCRIPTION
Fixes [#1082](https://github.com/alphagov/govuk-prototype-kit/issues/1082).

Updates our ['Pass data from page to page' doc](https://govuk-prototype-kit.herokuapp.com/docs/examples/pass-data) to tell the user why they should use default values.