### PR TITLE
Add GOV.UK Mainstream Guide template page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## New features
+
+- [#1258: Add GOV.UK Mainstream Guide template](https://github.com/alphagov/govuk-prototype-kit/pull/1258)
+
 # 12.0.1 (Fix release)
 
 ## Recommended changes
@@ -16,7 +22,7 @@ If you need help with the Prototype Kit, [contact the GOV.UK Prototype team](htt
 
 # 12.0.0 (Breaking release)
 
-## Breaking changes 
+## Breaking changes
 
 This release ensures the GOV.UK Prototype Kit reflects the latest release of the GOV.UK Frontend, v4.0.0.
 
@@ -30,13 +36,13 @@ Check the [GOV.UK Frontend release notes](https://github.com/alphagov/govuk-fron
 
 This change was added in [#1195: Update the GOV.UK Prototype Kit to use GOV.UK Frontend v4.0.0](https://github.com/alphagov/govuk-prototype-kit/pull/1195).
 
-## New features 
+## New features
 
 ### Preserve query strings when redirecting POSTs to GETs
 
 The GOV.UK Prototype Kit now preserves URL query strings when redirecting POST requests to GET requests.
 
-This means if you have a query like `/link/to/something?query=true&hello=world` on your POST form action, and you submit the form, the URL query string will be present in the redirected URL. 
+This means if you have a query like `/link/to/something?query=true&hello=world` on your POST form action, and you submit the form, the URL query string will be present in the redirected URL.
 
 This feature is useful when you:
 
@@ -62,7 +68,7 @@ If you need help with the Prototype Kit, [contact the GOV.UK Prototype team](htt
 
 We’ve recently experienced 2 security incidents involving common NPM packages used by the Prototype Kit. We’re sorry for the inconvenience this has caused.
 
-We’ve added new measures (a package-lock.json file) to help prevent this in the future. 
+We’ve added new measures (a package-lock.json file) to help prevent this in the future.
 
 To protect your service from any similar threats in future, please upgrade to this new version of the Kit.
 
@@ -85,7 +91,7 @@ You must make the following changes if you’re running Node.js 10 and you updat
 
 You can no longer run the GOV.UK Prototype Kit on Node.js 10.
 
-If you currently run Node.js 10, you'll need to upgrade to a newer version. 
+If you currently run Node.js 10, you'll need to upgrade to a newer version.
 
 We recommend using version 16. You can find more information on the [Prototype Kit requirements page](https://govuk-prototype-kit.herokuapp.com/docs/install/requirements.md).
 

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -9,10 +9,222 @@ $govuk-assets-path: '/govuk/assets/';
 @import "lib/extensions/extensions";
 
 // Patterns that aren't in Frontend
+@import "patterns/contents-list";
+@import "patterns/mainstream-guide";
+@import "patterns/pagination";
+@import "patterns/related-items";
 @import "patterns/step-by-step-header";
 @import "patterns/step-by-step-nav";
 @import "patterns/step-by-step-related";
 @import "patterns/task-list";
-@import "patterns/related-items";
+
 
 // Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you
+
+
+// Mainstream guide example doc
+
+
+// Contents list
+
+
+// .app--contents-list {
+// }
+//
+// .app--contents-list__title {
+//   @include govuk-text-colour;
+//   @include govuk-font($size: 16, $weight: regular, $line-height: 1.5);
+//   margin: 0;
+// }
+//
+// .app--contents-list__list,
+// .app--contents-list__nested-list {
+//   margin: 0;
+//   padding: 0;
+//   list-style-type: none;
+// }
+//
+// .app--contents-list__list-item {
+//   padding-top: govuk-spacing(2);
+//   line-height: 1.3;
+//   list-style-type: none;
+// }
+//
+//
+// .app--contents-list__list,
+// .app--contents-list__nested-list {
+//   @include govuk-text-colour;
+//   @include govuk-font($size: 16);
+//   margin: 0;
+//   padding: 0;
+//   list-style-type: none;
+// }
+//
+// .app--contents-list__list-item--dashed {
+//   $contents-spacing: govuk-spacing(5);
+//   position: relative;
+//   padding-left: $contents-spacing;
+//   padding-right: $contents-spacing;
+//
+//   &:before {
+//     content: "—";
+//     position: absolute;
+//     left: 0;
+//     width: govuk-spacing(4);
+//     overflow: hidden;
+//
+//     .direction-rtl & {
+//       left: auto;
+//       right: 0;
+//     }
+//   }
+// }
+//
+//
+// // Pagination
+//
+// .part-navigation-container {
+//     margin-top: 30px;
+//     margin-bottom: 30px;
+//     padding-bottom: 25px;
+//     border-bottom: 1px
+//     solid #b1b4b6;
+//   }
+//
+// .pagination {
+//   padding: 15px 0 15px 0;
+//   margin-top: 80px;
+//   }
+//
+// .pagination-subtitle-link {
+//   margin-top: -20px;
+// }
+//
+// .pagination-link a, a:visited {
+//   text-decoration: none;
+// }
+//
+//
+//
+//
+// .info-notice {
+//   border-left: 10px solid #b1b4b6;
+//     padding: 1em 0 0.001em 1em;
+//     margin: 2em 0;
+// }
+//
+// .related-navigation {
+// border-top: 2px solid #1d70b8;
+// padding-top: 10px;
+// margin-top: -40px;
+// }
+//
+// .related-links li {
+//   line-height: 1.60;
+// }
+//
+// .contents-list {
+//   padding-top: 50px;
+//   padding-bottom: 10px;
+// }
+//
+// .contents li, ol {
+//   padding: 6px 25px 0px 0px;
+// }
+//
+// .mainstream-guide-content {
+// }
+//
+// // Pagination styling from GOV.UK Mainstream Guide
+//
+// .app--pagination {
+//   display: block;
+//   margin: govuk-spacing(8) 0;
+// }
+//
+// .app--pagination__list {
+//   margin: 0;
+//   padding: 40px 0 0 0;
+// }
+//
+// .app--pagination__item {
+//   font-size: 16;
+//   line-height: 2;
+//   list-style: none;
+//
+//   &:first-child {
+//     margin-bottom: govuk-spacing(4);
+//   }
+// }
+//
+// .app--pagination__link {
+//   display: block;
+//   text-decoration: none;
+//   padding-bottom: govuk-spacing(4);
+//
+//   &:hover,
+//   &:active,
+//   &:visited {
+//     color: $govuk-link-colour;
+//   }
+//
+//   &:hover,
+//   &:active {
+//     background-color: govuk-colour("light-grey");
+//
+//     // Add govuk-link hover decoration to title if no label present
+//     .app--pagination__link-text--decorated {
+//       @include govuk-link-decoration;
+//     }
+//
+//     .app--pagination__link-label,
+//     .app--pagination__link-text--decorated {
+//       @include govuk-link-hover-decoration;
+//     }
+//   }
+//
+//   &:focus {
+//     @include govuk-focused-text;
+//
+//     .app--pagination__link-title {
+//       border-top-color: transparent;
+//     }
+//
+//     .app--pagination__link-icon {
+//       fill: $govuk-text-colour;
+//     }
+//   }
+// }
+//
+// .app--pagination__link-title {
+//   display: block;
+//   border-top: 1px solid $govuk-border-colour;
+//   padding-top: govuk-spacing(3);
+// }
+//
+// .app--pagination__link-divider {
+//   @include govuk-visually-hidden;
+// }
+//
+// .app--pagination__link-text {
+//   font-size: 19px;
+//   font-weight: bold;
+//   margin-left: 20px;
+//   @include govuk-font(19, $weight: bold);
+//   margin-left: govuk-spacing(2);
+// }
+//
+// .app--pagination__link-icon {
+//   @include govuk-font($size: 24, $line-height: (33.75 / 27));
+//   display: inline-block;
+//   margin-bottom: 1px;
+//   height: .482em;
+//   width: .63em;
+//   fill: govuk-colour("dark-grey", $legacy: "grey-1");
+// }
+//
+// .app--pagination__link-label {
+//   display: inline-block;
+//   margin-top: .1em;
+//   margin-left: govuk-spacing(5);
+//   }

--- a/app/assets/sass/patterns/_contents-list.scss
+++ b/app/assets/sass/patterns/_contents-list.scss
@@ -1,0 +1,61 @@
+// Based on https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
+// Note - this code for prototype purposes only. It is not production code.
+
+.app--contents-list {
+  // Always render the contents list above a
+  // back to contents link
+  position: relative;
+  margin: 0 0 govuk-spacing(4) 0;
+  z-index: 1;
+  background: govuk-colour("white");
+  box-shadow: 0 20px 15px -10px govuk-colour("white");
+}
+
+.app--contents-list__title {
+  @include govuk-text-colour;
+  @include govuk-font($size: 16, $weight: regular, $line-height: 1.5);
+  margin: 0;
+}
+
+.app--contents-list__list,
+.app--contents-list__nested-list {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+.app--contents-list__list-item {
+  padding-top: govuk-spacing(2);
+  line-height: 1.3;
+  list-style-type: none;
+}
+
+
+.app--contents-list__list,
+.app--contents-list__nested-list {
+  @include govuk-text-colour;
+  @include govuk-font($size: 16);
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+.app--contents-list__list-item--dashed {
+  $contents-spacing: govuk-spacing(5);
+  position: relative;
+  padding-left: $contents-spacing;
+  padding-right: $contents-spacing;
+
+  &:before {
+    content: "—";
+    position: absolute;
+    left: 0;
+    width: govuk-spacing(4);
+    overflow: hidden;
+
+    .direction-rtl & {
+      left: auto;
+      right: 0;
+    }
+  }
+}

--- a/app/assets/sass/patterns/_mainstream-guide.scss
+++ b/app/assets/sass/patterns/_mainstream-guide.scss
@@ -1,0 +1,15 @@
+.app-mainstream-guide-contents-list {
+    margin-top: 30px;
+    margin-bottom: 30px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid #b1b4b6;
+  
+    @include govuk-media-query($from: tablet) {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+
+.app-mainstream-guide-body{
+    margin-top: 20px;
+}

--- a/app/assets/sass/patterns/_pagination.scss
+++ b/app/assets/sass/patterns/_pagination.scss
@@ -1,0 +1,94 @@
+// Based on https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
+// Note - this code for prototype purposes only. It is not production code.
+
+.app--pagination {
+  display: block;
+  margin: govuk-spacing(8) 0;
+}
+
+.app--pagination__list {
+  margin: 0;
+  padding: 40px 0 0 0;
+}
+
+.app--pagination__item {
+  font-size: 16;
+  line-height: 2;
+  list-style: none;
+
+  &:first-child {
+    margin-bottom: govuk-spacing(4);
+  }
+}
+
+.app--pagination__link {
+  display: block;
+  text-decoration: none;
+  padding-bottom: govuk-spacing(4);
+
+  &:hover,
+  &:active,
+  &:visited {
+    color: $govuk-link-colour;
+  }
+
+  &:hover,
+  &:active {
+    background-color: govuk-colour("light-grey");
+
+    // Add govuk-link hover decoration to title if no label present
+    .app--pagination__link-text--decorated {
+      @include govuk-link-decoration;
+    }
+
+    .app--pagination__link-label,
+    .app--pagination__link-text--decorated {
+      @include govuk-link-hover-decoration;
+    }
+  }
+
+  &:focus {
+    @include govuk-focused-text;
+
+    .app--pagination__link-title {
+      border-top-color: transparent;
+    }
+
+    .app--pagination__link-icon {
+      fill: $govuk-text-colour;
+    }
+  }
+}
+
+.app--pagination__link-title {
+  display: block;
+  border-top: 1px solid $govuk-border-colour;
+  padding-top: govuk-spacing(3);
+}
+
+.app--pagination__link-divider {
+  @include govuk-visually-hidden;
+}
+
+.app--pagination__link-text {
+  font-size: 19px;
+  font-weight: bold;
+  margin-left: 20px;
+  @include govuk-font(19, $weight: bold);
+  margin-left: govuk-spacing(2);
+}
+
+.app--pagination__link-icon {
+  @include govuk-font($size: 24, $line-height: (33.75 / 27));
+  display: inline-block;
+  margin-bottom: 1px;
+  height: .482em;
+  width: .63em;
+  fill: govuk-colour("dark-grey", $legacy: "grey-1");
+}
+
+.app--pagination__link-label {
+  display: inline-block;
+  margin-top: .1em;
+  margin-left: govuk-spacing(5);
+  }

--- a/docs/views/templates/mainstream-guide.html
+++ b/docs/views/templates/mainstream-guide.html
@@ -1,0 +1,158 @@
+
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Mainstream guide example
+{% endblock %}
+
+{% block header %}
+  <!-- Blank header with no service name for this page -->
+  {{ govukHeader() }}
+{% endblock %}
+
+{% block beforeContent %}
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="https://www.gov.uk">Home</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="#">Section</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link">Subsection</a>
+      </li>
+    </ol>
+  </div>
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-xl">
+        Page title
+      </h1>
+
+      <aside class="app-mainstream-guide-contents-list" role="complementary">
+        <nav class="app--contents-list" aria-label="Pages in this guide" role="navigation">
+          <h2 class="app--contents-list__title">
+            Contents
+          </h2>
+          <ol class="app--contents-list__list">
+            <li class="app--contents-list__list-item app--contents-list__list-item--dashed app--contents-list__list-item--active">
+              <a href="#">
+                Page 1
+              </a>
+            </li>
+            <li aria-current="true" class="app--contents-list__list-item app--contents-list__list-item--dashed">
+              Page 2
+            </li>
+            <li class="app--contents-list__list-item app--contents-list__list-item--dashed">
+              <a href="#">
+                Page 3
+              </a>
+            </li>
+          </ol>
+        </nav>
+      </aside>
+
+    </div>
+
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds app-mainstream-guide-body">
+      
+      <h2 class="govuk-heading-m">
+        Page content heading
+      </h2>
+      
+      <p>Content goes here.</p>
+
+      <nav class="app--pagination" role="navigation" aria-label="Pagination">
+        <ul class="app--pagination__list">
+          <li class="app--pagination__item app--pagination__item--previous">
+            <a href="# class="govuk-link app--pagination__link" rel="prev">
+              <span class="app--pagination__link-title">
+                <svg class="app--pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+                  <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+                </svg>
+                <span class="app--pagination__link-text">
+                  Previous
+                </span>
+              </span>
+              <span class="app--pagination__link-divider visually-hidden">:</span>
+              <span class="app--pagination__link-label">
+                Page 1 title
+              </span>
+            </a>
+          </li>
+          <li class="app--pagination__item app--pagination__item--next">
+            <a href="#" class="govuk-link app--pagination__link" rel="next">
+              <span class="app--pagination__link-title">
+                <svg class="app--pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+                  <path d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+                </svg>
+                <span class="app--pagination__link-text">
+                  Next
+                </span>
+              </span>
+              <span class="app--pagination__link-divider visually-hidden">:</span>
+              <span class="app--pagination__link-label">
+                Page 3 title
+              </span>
+            </a>
+          </li>
+        </ul>
+      </nav>
+
+      <p>
+        <a href="#">
+          View a printable version of the whole guide
+        </a>
+      </p>
+
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+
+      <aside class="app-related-items" role="complementary">
+        <h2 class="govuk-heading-m" id="subsection-title">
+          Subsection
+        </h2>
+        <nav role="navigation" aria-labelledby="subsection-title">
+          <ul class="govuk-list govuk-!-font-size-16">
+            <li>
+              <a href="#">
+                Related link
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                Related link
+              </a>
+            </li>
+            <li>
+              <a href="#" class="govuk-!-font-weight-bold">
+                More <span class="govuk-visually-hidden">in Subsection</span>
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </aside>
+
+    </div>
+
+  </main>
+</div>
+
+
+
+
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/docs/views/tutorials-and-examples.html
+++ b/docs/views/tutorials-and-examples.html
@@ -192,6 +192,11 @@
 
       <ul class="govuk-list govuk-list--bullet">
         <li>
+          <a href="/docs/templates/mainstream-guide">
+            Mainstream guide template
+          </a>
+        </li>
+        <li>
           <a href="/docs/templates/start">
             Start page template
           </a>
@@ -212,6 +217,10 @@
         You cannot adjust the design of these pages, but you can use them to help
         you prototype realistic journeys connecting your service with GOV.UK content.
       </p>
+      <p>
+        Check the <a href="https://www.gov.uk/guidance/content-design/planning-content">guidance for mainstream guides</a> on the Content design: planning, writing and managing content manual.
+        </p>
+
       <p>
         Read the <a href="https://design-system.service.gov.uk/patterns/start-pages/">start pages guidance</a> and the <a href="https://design-system.service.gov.uk/patterns/step-by-step-navigation/">step by step navigation guidance</a> to learn how to make these pages live for your service.
       </p>


### PR DESCRIPTION
Closes the [1140 issue](https://github.com/alphagov/govuk-prototype-kit/issues/1140)

- Add GOV.UK Mainstream Guide template to the Prototype Kit 
- Update the Tutorials and templates page to add a link to the GOV.UK Mainstream Guide template, and a link to the 'Content design: planning, writing and managing content' manual
- Update Sass to support: contents list, pagination 

<img width="1130" alt="Screenshot showing mainstream guide template with a heading, page title, contents list and pagination" src="https://user-images.githubusercontent.com/90854/157475605-35c3d4bb-c697-4d25-8a77-520561f25f32.png">
