### PR TITLE
Fix update script to work with all v9 versions

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -30,7 +30,7 @@ update_gitignore () {
 
 # Check whether it is safe for the script to run
 check () {
-	if ! grep -q '"govuk-prototype-kit"' package.json 2> /dev/null; then
+	if ! grep -q '"govuk-prototype-kit"\|"express-prototype"' package.json 2> /dev/null; then
 		msg 'ERROR you must run update.sh in a folder containing a GOV.UK Prototype Kit installation'
 		msg 'Exiting'
 		exit 1
@@ -131,6 +131,9 @@ copy () {
 		# specific workaround for old step 9, yuck
 		rm -rvf app/assets/sass/patterns
 		cp -Rv "update/app/assets/sass/patterns" "app/assets/sass/"
+
+		# copy unbranded layout - needed for the password page
+		cp -v "update/app/views/layout_unbranded.html" "app/views/"
 
 		set +x
 


### PR DESCRIPTION
fixes #1286 

Copies layout-unbranded.html - this is needed for the new password page to work and was changed during v9.
Also updated the grep test so it works for v9

Note that Step by step pattern is still broken if updating from v9 - this PR does not fix that