### PR TITLE
Don't delete patterns, only copy new ones

### DIFF
--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -390,14 +390,12 @@ describe('update.sh', () => {
       const testDir = mktestPrototypeSync('preserve-app-folder')
 
       const updateDir = path.join(testDir, 'update')
-      fs.unlinkSync(path.join(updateDir, 'app', 'assets', 'sass', 'patterns', '_related-items.scss'))
       fs.writeFileSync(path.join(updateDir, 'app', 'assets', 'sass', 'patterns', '_task-list.scss'), 'foobar')
       fs.writeFileSync(path.join(updateDir, 'app', 'routes.js'), 'arglebargle')
 
       runScriptSyncAndExpectSuccess('copy', { testDir })
 
       expect(execGitStatusSync(testDir)).toEqual([
-        ' D app/assets/sass/patterns/_related-items.scss',
         ' M app/assets/sass/patterns/_task-list.scss'
       ])
     })

--- a/update.sh
+++ b/update.sh
@@ -128,8 +128,7 @@ copy () {
 			-print0 \
 		| xargs -0 -I % cp -v % .
 
-		# specific workaround for old step 9, yuck
-		rm -rvf app/assets/sass/patterns
+		# copy any new patterns
 		cp -Rv "update/app/assets/sass/patterns" "app/assets/sass/"
 
 		# copy unbranded layout - needed for the password page


### PR DESCRIPTION
fixes #1291 

This matches the [previously documented process](https://github.com/alphagov/govuk-prototype-kit/blob/v11.0.0/docs/documentation/updating-the-kit.md)
Users on support are losing their custom patterns
Also improves the comment to be clearer