### PR TITLE
Fix authentication on Glitch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Fixes
+
+- [#1303: Fix authentication on Glitch](https://github.com/alphagov/govuk-prototype-kit/pull/1303)
+
 # 12.0.3 (Fix release)
 
 ## Fixes

--- a/app/config.js
+++ b/app/config.js
@@ -25,7 +25,7 @@ module.exports = {
   // Force HTTP to redirect to HTTPS on production
   useHttps: 'true',
 
-  // Enable or disable Browser Sync
+  // Enable or disable Browser Sync (local development only)
   useBrowserSync: 'true'
 
 }

--- a/lib/middleware/authentication/authentication.js
+++ b/lib/middleware/authentication/authentication.js
@@ -3,7 +3,7 @@ const url = require('url')
 
 // Local dependencies
 const config = require('../../../app/config')
-const encryptPassword = require('../../utils').encryptPassword
+const { encryptPassword, getNodeEnv } = require('../../utils')
 
 // Local variables
 const allowedPathsWhenUnauthenticated = [
@@ -45,20 +45,15 @@ module.exports = authentication
 
 function shouldUseAuth () {
   const useAuth = (process.env.USE_AUTH || config.useAuth || 'not set').toLowerCase()
+
   if (useAuth !== 'true') {
     return false
   }
 
-  const isRunningInGlitch = process.env.PROJECT_REMIX_CHAIN !== undefined
-  if (isRunningInGlitch) {
+  if (getNodeEnv() === 'production') {
     return true
   }
 
-  const safeNodeEnv = process.env.NODE_ENV || 'not set'
-  const isRunningInProduction = safeNodeEnv.toLowerCase() === 'production'
-  if (isRunningInProduction) {
-    return true
-  }
   return false
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -125,14 +125,7 @@ exports.findAvailablePort = function (app, callback) {
 
 // Redirect HTTP requests to HTTPS
 exports.forceHttps = function (req, res, next) {
-  var protocol = req.headers['x-forwarded-proto']
-  // Glitch returns a comma separated list for x-forwarded-proto
-  // We need the first to determine if running on https
-  if (protocol) {
-    protocol = protocol.split(',').shift()
-  }
-
-  if (protocol !== 'https') {
+  if (req.protocol !== 'https') {
     console.log('Redirecting request to https')
     // 302 temporary - this is a feature that can be disabled
     return res.redirect(302, 'https://' + req.get('Host') + req.url)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,6 +13,28 @@ const matter = require('gray-matter')
 // Local dependencies
 const config = require('../app/config.js')
 
+// Are we running on Glitch.com?
+const onGlitch = function () {
+  // there isn't an official way to check, but this was recommended
+  // https://support.glitch.com/t/detect-if-app-is-running-on-glitch/3120
+  return Boolean(process.env.PROJECT_REMIX_CHAIN)
+}
+
+exports.onGlitch = onGlitch
+
+// Get a normalised form of NODE_ENV
+//
+// Returns a lower-case string representing the environment the node.js app
+// is running in. Normally this will be one of `production`, `development`,
+// or `test`, although it can be any lower-case string. In most
+// circumstances the value is derived from the environment variable
+// NODE_ENV, defaulting to `development` if that is not set.
+exports.getNodeEnv = function () {
+  const glitchEnv = onGlitch() ? 'production' : false // Glitch doesn't set NODE_ENV, but we want to treat it as production
+  const env = (process.env.NODE_ENV || glitchEnv || 'development').toLowerCase()
+  return env
+}
+
 // Tweak the Markdown renderer
 const defaultMarkedRenderer = marked.defaults.renderer || new marked.Renderer()
 

--- a/lib/utils.test.js
+++ b/lib/utils.test.js
@@ -4,6 +4,65 @@ const nunjucks = require('nunjucks')
 
 const utils = require('./utils.js')
 
+const originalEnvironmentVariables = process.env
+
+describe('onGlitch', () => {
+  beforeEach(() => {
+    process.env = {}
+  })
+
+  afterEach(() => {
+    process.env = originalEnvironmentVariables
+  })
+
+  it('returns false if envvar PROJECT_REMIX_CHAIN is not set', () => {
+    expect(utils.onGlitch()).toBe(false)
+  })
+
+  it('returns true if envvar PROJECT_REMIX_CHAIN is set', () => {
+    process.env.PROJECT_REMIX_CHAIN = '["dead-beef"]'
+    expect(utils.onGlitch()).toBe(true)
+  })
+})
+
+describe('getNodeEnd', () => {
+  beforeEach(() => {
+    process.env = {}
+  })
+
+  afterEach(() => {
+    process.env = originalEnvironmentVariables
+  })
+
+  it('returns the value of NODE_ENV', () => {
+    process.env.NODE_ENV = 'production'
+    expect(utils.getNodeEnv()).toBe('production')
+
+    process.env.NODE_ENV = 'test'
+    expect(utils.getNodeEnv()).toBe('test')
+  })
+
+  it('defaults to development if NODE_ENV is not set or empty', () => {
+    expect(utils.getNodeEnv()).toBe('development')
+
+    process.env.NODE_ENV = ''
+    expect(utils.getNodeEnv()).toBe('development')
+  })
+
+  it('always returns a lower-case string', () => {
+    process.env.NODE_ENV = 'FOOBAR'
+    expect(utils.getNodeEnv()).toBe('foobar')
+  })
+
+  it('returns production if running on Glitch and NODE_ENV not set or empty', () => {
+    process.env.PROJECT_REMIX_CHAIN = '["dead-beef"]'
+    expect(utils.getNodeEnv()).toBe('production')
+
+    process.env.NODE_ENV = ''
+    expect(utils.getNodeEnv()).toBe('production')
+  })
+})
+
 describe('checked', () => {
   var ctx, checked
 

--- a/listen-on-port.js
+++ b/listen-on-port.js
@@ -9,7 +9,7 @@ const utils = require('./lib/utils.js')
 
 // Set up configuration variables
 var useBrowserSync = config.useBrowserSync.toLowerCase()
-var env = (process.env.NODE_ENV || 'development').toLowerCase()
+var env = utils.getNodeEnv()
 
 utils.findAvailablePort(server, function (port) {
   console.log('Listening on port ' + port + '   url: http://localhost:' + port)

--- a/server.js
+++ b/server.js
@@ -49,8 +49,7 @@ if (useV6) {
 
 // Set up configuration variables
 var releaseVersion = packageJson.version
-var glitchEnv = (process.env.PROJECT_REMIX_CHAIN) ? 'production' : false // glitch.com
-var env = (process.env.NODE_ENV || glitchEnv || 'development').toLowerCase()
+var env = utils.getNodeEnv()
 var useAutoStoreData = process.env.USE_AUTO_STORE_DATA || config.useAutoStoreData
 var useCookieSessionStore = process.env.USE_COOKIE_SESSION_STORE || config.useCookieSessionStore
 var useHttps = process.env.USE_HTTPS || config.useHttps


### PR DESCRIPTION
Fixes #1302.

[Browsersync](browsersync.io) and [Glitch](glitch.com) don't work well together. Currently when on Glitch, Browsersync runs, and for reasons I don't understand this stops the authentication working (you can never log in).

As a fix/workaround, this PR changes `listen-on-port.js` to not use Browsersync if the prototype is running on Glitch. I think this shouldn't be a problem for users, because using Browsersync with Glitch doesn't make much sense (it won't work, and Glitch auto-relaods for you anyway).

With this PR I've tried to follow the maxim of 'leave the code better than you found it', so the way I've approached the fix is to take the logic of determining whether we're running on Glitch, and whether we're running on production, and make a function in utils, with tests, that can be used in all the places we were previously checking environment variables in various different ways.

I also removed some Glitch related code that wasn't needed, as ExpressJS does the same thing for us, and added a comment to `config.js` making it clear that Browsersync won't run if your prototype is published (whether with Heroku or Glitch).