### PR TITLE
Remove Node.js unit test files from release archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 .gitattributes export-ignore
 .github export-ignore
 __tests__ export-ignore
+*.test.js export-ignore
 cypress export-ignore
 cypress.json export-ignore
 app.json export-ignore


### PR DESCRIPTION
We have some unit tests which are saved as `.test.js` files next to the implementation being tested. These are currently included in our release archives, but they don't need to be. They won't be of interest to users.

This commit adds an ignore pattern to the gitattributes file, so that in future these files won't be present at all.

--- 

You can test this by downloading the archive for this branch at https://github.com/alphagov/govuk-prototype-kit/tree/ldeb-dont-ship-test-js and inspecting the contents.