### PR TITLE
Increase CI test timeout

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -13,7 +13,7 @@ jobs:
 
     name: Node v${{ matrix.node-version }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     env:
       npm_config_include: 'optional'


### PR DESCRIPTION
I've been getting a lot of test suite failures recently because of timeouts. Increase limit to 15 minutes.