### PR TITLE
Update to GOV.UK Frontend 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#1328: Update to GOV.UK Frontend 4.1.0](https://github.com/alphagov/govuk-prototype-kit/pull/1328)
 - [#1258: Add GOV.UK Mainstream Guide template](https://github.com/alphagov/govuk-prototype-kit/pull/1258)
 
 ## 12.0.4 (Fix release)

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "govuk_frontend_toolkit": "^7.5.0",
         "govuk_template_jinja": "^0.24.1",
         "govuk-elements-sass": "^3.1.3",
-        "govuk-frontend": "^4.0.1",
+        "govuk-frontend": "^4.1.0",
         "gray-matter": "^4.0.3",
         "gulp": "^4.0.2",
         "gulp-nodemon": "^2.2.1",
@@ -7323,9 +7323,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.1.tgz",
-      "integrity": "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.1.0.tgz",
+      "integrity": "sha512-xBUUarxinGWSccmXPmwa7ovg3xabEQ0+Dcv7pdq9X3F69892OFMqP2g8jvlDUrVsDVdasXLk4Jq4w8dPiaEVqQ==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -21788,9 +21788,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.1.tgz",
-      "integrity": "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.1.0.tgz",
+      "integrity": "sha512-xBUUarxinGWSccmXPmwa7ovg3xabEQ0+Dcv7pdq9X3F69892OFMqP2g8jvlDUrVsDVdasXLk4Jq4w8dPiaEVqQ=="
     },
     "graceful-fs": {
       "version": "4.2.8",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "express-session": "^1.13.0",
     "fancy-log": "^1.3.3",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^4.0.1",
+    "govuk-frontend": "^4.1.0",
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
closes https://github.com/alphagov/govuk-prototype-kit/issues/1323
I can't see anything in the Frontend release notes that we need to update in the kit