### PR TITLE
Fix template pages that have the wrong h1 size

### DIFF
--- a/docs/views/templates/start.html
+++ b/docs/views/templates/start.html
@@ -29,7 +29,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">
+      <h1 class="govuk-heading-l">
         {% if serviceName %} {{ serviceName }} {% endif %}
       </h1>
 


### PR DESCRIPTION
Fix templates on the Prototype Kit that use `govuk-heading-xl` to `govuk-heading-l`