### PR TITLE
Use Cypress config variable baseUrl instead of hostName

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
+  "baseUrl": "http://localhost:3000",
   "testFiles": "**/*.cypress.js",
   "video": false,
   "chromeWebSecurity": false

--- a/cypress/config.js
+++ b/cypress/config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  hostName: 'http://localhost:3000'
-}

--- a/cypress/integration/1-watch-files/watch-images.cypress.js
+++ b/cypress/integration/1-watch-files/watch-images.cypress.js
@@ -1,5 +1,4 @@
 const { waitForApplication } = require('../utils')
-const { hostName } = require('../../config')
 const imageFile = 'larry-the-cat.jpg'
 const cypressImages = 'cypress/fixtures/images'
 const appImages = 'app/assets/images'
@@ -26,7 +25,7 @@ describe('watch image files', () => {
     cy.task('copyFile', { source, target })
 
     cy.task('log', `Requesting ${publicImage}`)
-    cy.request(`${hostName}/${publicImage}`, { timeout: 20000, retryOnStatusCodeFailure: true })
+    cy.request(`/${publicImage}`, { timeout: 20000, retryOnStatusCodeFailure: true })
       .then(response => expect(response.status).to.eq(200))
   })
 })

--- a/cypress/integration/1-watch-files/watch-views.cypress.js
+++ b/cypress/integration/1-watch-files/watch-views.cypress.js
@@ -1,10 +1,8 @@
-import { hostName } from '../../config'
 import { waitForApplication } from '../utils'
 
 const templatesView = 'docs/views/templates/start.html'
 const appView = 'app/views/start.html'
 const pagePath = '/start'
-const pageUrl = `${hostName}${pagePath}`
 
 describe('watching start page', () => {
   before(() => {
@@ -18,7 +16,7 @@ describe('watching start page', () => {
 
   it('Add and remove the start page', () => {
     cy.task('log', 'The start page should not be found')
-    cy.visit(pageUrl, { failOnStatusCode: false })
+    cy.visit(pagePath, { failOnStatusCode: false })
     cy.get('body', { timeout: 20000 })
       .should('contains.text', `Page not found: ${pagePath}`)
 
@@ -26,7 +24,7 @@ describe('watching start page', () => {
     cy.task('copyFile', { source: templatesView, target: appView })
 
     cy.task('log', 'The start page should be displayed')
-    cy.visit(pageUrl)
+    cy.visit(pagePath)
     cy.get('h1', { timeout: 20000 })
       .should('contains.text', 'Service name goes here')
   })

--- a/cypress/integration/utils.js
+++ b/cypress/integration/utils.js
@@ -1,11 +1,9 @@
-const { hostName } = require('../config')
-
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
 const waitForApplication = async () => {
   cy.task('log', 'Waiting for app to restart and load home page')
   cy.task('waitUntilAppRestarts')
-  cy.visit(hostName)
+  cy.visit('/')
   cy.get('h1.govuk-heading-xl', { timeout: 20000 })
     .should('contains.text', 'Prototype your service using GOV.UK Prototype Kit')
 }

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -16,9 +16,6 @@ const waitOn = require('wait-on')
 const fs = require('fs')
 
 const { sleep } = require('../integration/utils')
-const { hostName } = require('../config')
-
-const waitUntilAppRestarts = async (timeout) => await waitOn({ delay: 2000, resources: [hostName], timeout })
 
 const createFolderForFile = (filepath) => {
   const dir = filepath.substring(0, filepath.lastIndexOf('/'))
@@ -36,6 +33,8 @@ const createFolderForFile = (filepath) => {
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
+
+  const waitUntilAppRestarts = async (timeout) => await waitOn({ delay: 2000, resources: [config.baseUrl], timeout })
 
   on('task', {
     copyFile: async ({ source, target, timeout = 2000 }) => {


### PR DESCRIPTION
Using baseUrl defined in cypress.json lets us easily override it with a command line argument or environment variable:

https://docs.cypress.io/guides/references/configuration

When using `baseUrl`, the server part of the url needs to be omitted from `cy.visit`.