### PR TITLE
Fix release archive test

### DIFF
--- a/__tests__/spec/release-archive.js
+++ b/__tests__/spec/release-archive.js
@@ -26,8 +26,7 @@ describe('release archive', () => {
     expect(archiveFiles).toEqual(expect.arrayContaining([
       'app/',
       'lib/',
-      'gulp/',
-      'gulpfile.js',
+      'lib/build/',
       'listen-on-port.js',
       'server.js',
       'Procfile',


### PR DESCRIPTION
This was merged after we had removed gulp, so was looking for the wrong things. Fix it to look for build scripts instead.