### PR TITLE
Fix generate assets tests failure on macos

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -42,4 +42,3 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - run: npm run test:integration
-      continue-on-error: ${{ matrix.os == 'macos-latest' }}  # TODO: fix kit so this isn't needed

--- a/__tests__/spec/sanity-checks.js
+++ b/__tests__/spec/sanity-checks.js
@@ -26,10 +26,10 @@ describe('The Prototype Kit', () => {
   })
 
   it('should generate assets into the /public folder', () => {
-    assert.doesNotThrow(function () {
-      fs.accessSync(path.resolve(__dirname, '../../public/javascripts/application.js'))
-      fs.accessSync(path.resolve(__dirname, '../../public/images/unbranded.ico'))
-      fs.accessSync(path.resolve(__dirname, '../../public/stylesheets/application.css'))
+    assert.doesNotThrow(async function () {
+      await utils.waitUntilFileExists(path.resolve(__dirname, '../../public/javascripts/application.js'), 5000)
+      await utils.waitUntilFileExists(path.resolve(__dirname, '../../public/images/unbranded.ico'), 5000)
+      await utils.waitUntilFileExists(path.resolve(__dirname, '../../public/stylesheets/application.css'), 5000)
     })
   })
 

--- a/lib/build/tasks.js
+++ b/lib/build/tasks.js
@@ -8,6 +8,8 @@ const sass = require('sass')
 
 const extensions = require('../extensions/extensions')
 
+const utils = require('../utils')
+
 const buildConfig = require('./config.json')
 const { paths } = buildConfig
 
@@ -31,8 +33,9 @@ function generateAssets () {
   copyAssets(paths.v6Assets, v6PublicPath)
 }
 
-function buildWatchAndServe () {
+async function buildWatchAndServe () {
   generateAssets()
+  await utils.waitUntilFileExists(path.join(appCssPath, 'application.css'), 5000)
   watch()
   runNodemon()
 }
@@ -138,6 +141,7 @@ function runNodemon () {
     script: 'listen-on-port.js',
     ignore: [
       'public/*',
+      'cypress/*',
       `${paths.assets}*`,
       'node_modules/*'
     ]

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -224,6 +224,23 @@ exports.getRenderOptions = function (document, docPath) {
   return { document: html, ...parsedFile.data }
 }
 
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+exports.sleep = sleep
+
+async function waitUntilFileExists (filename, timeout) {
+  await sleep(500)
+  const fileExists = fs.existsSync(filename)
+  if (!fileExists) {
+    if (timeout > 0) {
+      return waitUntilFileExists(filename, timeout - 500)
+    } else {
+      throw new Error(`File ${filename} does not exist`)
+    }
+  }
+}
+
+exports.waitUntilFileExists = waitUntilFileExists
+
 // Store data from POST body or GET query in session
 var storeData = function (input, data) {
   for (var i in input) {

--- a/start.js
+++ b/start.js
@@ -5,11 +5,7 @@ const fs = require('fs')
 // Local dependencies
 const { buildWatchAndServe } = require('./lib/build/tasks')
 
-checkFiles()
-createSessionDataDefaults()
-buildAndServe()
-
-async function buildAndServe () {
+async function collectDataUsage () {
 // Local dependencies
   const usageData = require('./lib/usage_data')
 
@@ -31,7 +27,6 @@ async function buildAndServe () {
       usageData.startTracking(usageDataConfig)
     }
   }
-  return buildWatchAndServe()
 }
 
 // Warn if node_modules folder doesn't exist
@@ -66,3 +61,10 @@ function createSessionDataDefaults () {
       .pipe(fs.createWriteStream(sessionDataDefaultsFile))
   }
 }
+
+(async () => {
+  checkFiles()
+  createSessionDataDefaults()
+  await collectDataUsage()
+  await buildWatchAndServe()
+})()


### PR DESCRIPTION
See: https://github.com/alphagov/govuk-prototype-kit/issues/1340

Changes:
- Fix generate assets sanity tests to allow for the generation of /public/assets/application.css
- Only start watching the /public/assets folder when the application.css file has been generated
- Prevent nodemon from watching the /cypress folder
- Clean up start file