### PR TITLE
Revert "Allow integration tests to fail on macOS"

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,6 +1,10 @@
 name: Run tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   run-tests:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -42,4 +42,3 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - run: npm run test:integration
-      continue-on-error: ${{ matrix.os == 'macos-latest' }}  # TODO: fix kit so this isn't needed

--- a/.github/workflows/test-heroku.yaml
+++ b/.github/workflows/test-heroku.yaml
@@ -1,6 +1,10 @@
 name: Test kit on Heroku
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   test-heroku:


### PR DESCRIPTION
This reverts commit 6d9f3cbc57e2c5ce00df63f07da16e9c98c08f69.

Let's see if integration tests are still failing on macOS.