### PR TITLE
Reduce number of tests running for a pull request

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,6 +1,10 @@
 name: Run tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   run-tests:

--- a/.github/workflows/test-heroku.yaml
+++ b/.github/workflows/test-heroku.yaml
@@ -1,6 +1,10 @@
 name: Test kit on Heroku
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   test-heroku:


### PR DESCRIPTION
Change the GitHub Actions workflows to run only once against a pull request or push, rather than twice for pull requests (which trigger both the pull request event and the push event). This should help speed up the checks, as well as hopefully also reduce the chance of the test servers being overloaded and making our tests flaky again.

---

Note that this means that now pushes to a branch other than main which don't have a pull request will not result in a test, so if you want GitHub to test your changes, you will need to create a (draft) PR.