### PR TITLE
Allow running the kit either as a project or as an npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ public
 node_modules/
 .tmuxp.*
 .idea
+/cypress-test
 /cypress/videos
 /cypress/screenshots
 /cypress/downloads

--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -6,6 +6,7 @@ const process = require('process')
 const request = require('superagent')
 
 const utils = require('./utils')
+const fse = require('fs-extra')
 
 /*
  * Constants
@@ -203,8 +204,10 @@ describe('update.sh', () => {
     process.chdir(tmpDir)
     console.log('Running tests in temporary directory', process.cwd())
 
-    // setup fixtures - running this now saves time later
-    fs.mkdirSync(fixtureDir)
+    // setup fixtures
+    // - running this now saves time later
+    // - ensureDirSync is used to prevent a failure where the fixtureDir already exists from a previous test
+    fse.ensureDirSync(fixtureDir)
     mktestArchiveSync()
     mktestPrototypeSync()
   })

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -6,7 +6,7 @@ $govuk-new-link-styles: true;
 $govuk-assets-path: '/govuk/assets/';
 
 // Import GOV.UK Frontend and any extension styles if extensions have been configured
-@import ".generated-assets/sass/extensions";
+@import ".tmp/sass/extensions";
 
 // Patterns that aren't in Frontend
 @import "patterns/contents-list";

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -6,7 +6,7 @@ $govuk-new-link-styles: true;
 $govuk-assets-path: '/govuk/assets/';
 
 // Import GOV.UK Frontend and any extension styles if extensions have been configured
-@import "../../../.generated-assets/sass/extensions";
+@import ".generated-assets/sass/extensions";
 
 // Patterns that aren't in Frontend
 @import "patterns/contents-list";

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -6,7 +6,7 @@ $govuk-new-link-styles: true;
 $govuk-assets-path: '/govuk/assets/';
 
 // Import GOV.UK Frontend and any extension styles if extensions have been configured
-@import "lib/extensions/extensions";
+@import "../../../.generated-assets/sass/extensions";
 
 // Patterns that aren't in Frontend
 @import "patterns/contents-list";

--- a/cypress/integration/1-watch-files/watch-views.cypress.js
+++ b/cypress/integration/1-watch-files/watch-views.cypress.js
@@ -2,7 +2,7 @@ const path = require('path')
 
 const { waitForApplication } = require('../utils')
 
-const templatesView = path.join(Cypress.env('projectFolder'), 'docs', 'views', 'templates', 'start.html')
+const templatesView = path.join(Cypress.env('packageFolder') || Cypress.env('projectFolder'), 'docs', 'views', 'templates', 'start.html')
 const appView = path.join(Cypress.env('projectFolder'), 'app', 'views', 'start.html')
 const pagePath = '/start'
 

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -39,10 +39,19 @@ module.exports = (on, config) => {
   config.env.projectFolder = process.env.KIT_TEST_DIR || process.cwd()
   config.env.tempFolder = path.join(__dirname, '..', 'temp')
 
+  const packagePath = path.join(config.env.projectFolder, 'package.json')
+  const packageContent = fs.readFileSync(packagePath, 'utf8')
+  const packageObject = JSON.parse(packageContent)
+  const dependencies = packageObject.dependencies || {}
+
+  if ('govuk-prototype-kit' in dependencies) {
+    config.env.packageFolder = path.join(config.env.projectFolder, 'node_modules', 'govuk-prototype-kit')
+  }
+
   const waitUntilAppRestarts = async (timeout) => await waitOn({ delay: 2000, resources: [config.baseUrl], timeout })
 
   on('task', {
-    copyFile: async ({ source, target, timeout = 2000 }) => {
+    copyFile: async ({ source, target }) => {
       try {
         createFolderForFile(target)
         fs.copyFileSync(source, target)

--- a/cypress/scripts/run-as-package.js
+++ b/cypress/scripts/run-as-package.js
@@ -1,0 +1,26 @@
+const child_process = require('child_process') // eslint-disable-line camelcase
+const fs = require('fs')
+const path = require('path')
+
+const utils = require('../../__tests__/spec/utils')
+
+const testDir = path.resolve(process.env.KIT_TEST_DIR || 'cypress/temp/test-project')
+const releaseArchive = utils.mkReleaseArchiveSync({ archiveType: 'tar', dir: path.resolve('cypress', 'temp') })
+
+fs.mkdirSync(testDir, { recursive: true })
+
+process.chdir(testDir)
+console.log(`running tests in ${testDir}`)
+
+fs.writeFileSync(path.join(testDir, 'package.json'), '{ "name": "test-prototype" }')
+fs.writeFileSync(path.join(testDir, 'usage-data-config.json'), '{ "collectUsageData": false }')
+
+child_process.execSync(
+  `npm install ${releaseArchive} govuk-frontend`,
+  { cwd: testDir, env: { ...process.env, npm_config_include: '' }, stdio: 'inherit' }
+)
+
+child_process.execSync(
+  'node node_modules/govuk-prototype-kit/start.js',
+  { cwd: testDir, env: { ...process.env, env: 'test' }, stdio: 'inherit' }
+)

--- a/cypress/scripts/run-as-package.js
+++ b/cypress/scripts/run-as-package.js
@@ -1,7 +1,9 @@
 const child_process = require('child_process') // eslint-disable-line camelcase
 const fs = require('fs')
+const fse = require('fs-extra')
 const path = require('path')
 
+const prototypePkg = require('../../package.json')
 const utils = require('../../__tests__/spec/utils')
 
 const testDir = path.resolve(process.env.KIT_TEST_DIR || 'cypress/temp/test-project')
@@ -20,7 +22,19 @@ child_process.execSync(
   { cwd: testDir, env: { ...process.env, npm_config_include: '' }, stdio: 'inherit' }
 )
 
+// Copy the files in the installed releaseArchive app folder into an app folder in the project
+const srcDir = path.join('.', 'node_modules', prototypePkg.name, 'app')
+const destDir = path.join('.', 'app')
+
+fs.mkdirSync(destDir, {
+  recursive: true
+})
+
+fse.copySync(srcDir, destDir, {
+  overwrite: true
+})
+
 child_process.execSync(
-  'node node_modules/govuk-prototype-kit/start.js',
+  `node ${path.join('.', 'node_modules', prototypePkg.name, 'start.js')}`,
   { cwd: testDir, env: { ...process.env, env: 'test' }, stdio: 'inherit' }
 )

--- a/lib/build/check-files.js
+++ b/lib/build/check-files.js
@@ -1,20 +1,21 @@
 const fs = require('fs')
 const path = require('path')
 
-const repoDir = path.resolve(__dirname, '..', '..')
+const packageDir = path.resolve(__dirname, '..', '..')
+const projectDir = process.cwd()
 
 exports.checkFiles = function () {
   // Warn if node_modules folder doesn't exist
-  const nodeModulesExists = fs.existsSync(path.join(repoDir, '/node_modules'))
+  const nodeModulesExists = fs.existsSync(path.join(projectDir, '/node_modules'))
   if (!nodeModulesExists) {
     console.log('ERROR: Node module folder missing. Try running `npm install`')
     process.exit(0)
   }
 
   // Create template .env file if it doesn't exist
-  const envExists = fs.existsSync(path.join(repoDir, '/.env'))
+  const envExists = fs.existsSync(path.join(projectDir, '/.env'))
   if (!envExists) {
-    fs.createReadStream(path.join(repoDir, '/lib/template.env'))
-      .pipe(fs.createWriteStream(path.join(repoDir, '/.env')))
+    fs.createReadStream(path.join(packageDir, '/lib/template.env'))
+      .pipe(fs.createWriteStream(path.join(projectDir, '/.env')))
   }
 }

--- a/lib/build/check-files.js
+++ b/lib/build/check-files.js
@@ -1,6 +1,8 @@
 const fs = require('fs')
 const path = require('path')
 
+// Warning: Do not require external dependencies in this file.
+
 const packageDir = path.resolve(__dirname, '..', '..')
 const projectDir = process.cwd()
 

--- a/lib/build/tasks.js
+++ b/lib/build/tasks.js
@@ -56,7 +56,10 @@ function sassExtensions () {
   fileContents += extensions.getFileSystemPaths('sass')
     .map(filePath => `@import "${filePath.split(path.sep).join('/')}";`)
     .join('\n')
-  fs.writeFileSync(path.join('lib', 'extensions', '_extensions.scss'), fileContents)
+  const extensionsDir = path.join('.generated-assets', 'sass')
+  fse.ensureDirSync(extensionsDir, { recursive: true })
+  fs.writeFileSync(path.join(extensionsDir, '.gitignore'), '*')
+  fs.writeFileSync(path.join(extensionsDir, '_extensions.scss'), fileContents)
 }
 
 function generateSass (sassPath, cssPath) {
@@ -142,7 +145,7 @@ function runNodemon () {
 
   return nodemon({
     watch: ['.env', '**/*.js', '**/*.json'],
-    script: 'listen-on-port.js',
+    script: path.join(__dirname, '..', '..', 'listen-on-port.js'),
     ignore: [
       'public/*',
       'cypress/*',

--- a/lib/build/tasks.js
+++ b/lib/build/tasks.js
@@ -144,7 +144,7 @@ function runNodemon () {
   }
 
   return nodemon({
-    watch: ['.env', '**/*.js', '**/*.json'],
+    watch: ['./.env', './**/*.js', './**/*.json'],
     script: path.join(__dirname, '..', '..', 'listen-on-port.js'),
     ignore: [
       'public/*',

--- a/lib/build/tasks.js
+++ b/lib/build/tasks.js
@@ -13,11 +13,14 @@ const extensions = require('../extensions/extensions')
 const utils = require('../utils')
 
 const buildConfig = require('./config.json')
+const { projectDir, packageDir } = require('../utils')
 const { paths } = buildConfig
 
 const appSassPath = path.join(paths.assets, 'sass')
 const docsSassPath = path.join(paths.docsAssets, 'sass')
 const v6SassPath = path.join(paths.v6Assets, 'sass')
+const tempPath = path.join(projectDir, '.tmp')
+const tempSassPath = path.join(tempPath, 'sass')
 
 const appCssPath = path.join(paths.public, 'stylesheets')
 const v6CssPath = path.join(paths.public, 'v6', 'stylesheets')
@@ -56,10 +59,9 @@ function sassExtensions () {
   fileContents += extensions.getFileSystemPaths('sass')
     .map(filePath => `@import "${filePath.split(path.sep).join('/')}";`)
     .join('\n')
-  const extensionsDir = path.join('.generated-assets', 'sass')
-  fse.ensureDirSync(extensionsDir, { recursive: true })
-  fs.writeFileSync(path.join(extensionsDir, '.gitignore'), '*')
-  fs.writeFileSync(path.join(extensionsDir, '_extensions.scss'), fileContents)
+  fse.ensureDirSync(tempSassPath, { recursive: true })
+  fs.writeFileSync(path.join(tempPath, '.gitignore'), '*')
+  fs.writeFileSync(path.join(tempSassPath, '_extensions.scss'), fileContents)
 }
 
 function generateSass (sassPath, cssPath) {
@@ -144,8 +146,12 @@ function runNodemon () {
   }
 
   return nodemon({
-    watch: ['./.env', './**/*.js', './**/*.json'],
-    script: path.join(__dirname, '..', '..', 'listen-on-port.js'),
+    watch: [
+      path.join(projectDir, '.env'),
+      path.join(projectDir, '**', '*.js'),
+      path.join(projectDir, '**', '*.json')
+    ],
+    script: path.join(packageDir, 'listen-on-port.js'),
     ignore: [
       'public/*',
       'cypress/*',

--- a/lib/extensions/extensions.js
+++ b/lib/extensions/extensions.js
@@ -40,6 +40,7 @@ const path = require('path')
 
 // Local dependencies
 const appConfig = require('../../app/config')
+const { projectDir } = require('../utils')
 
 // Generic utilities
 const removeDuplicates = arr => [...new Set(arr)]
@@ -50,16 +51,15 @@ const objectMap = (object, mapFn) => Object.keys(object).reduce((result, key) =>
 }, {})
 
 // File utilities
-const getPathFromProjectRoot = (...all) => {
-  return path.resolve.apply(null, ['.'].concat(all))
-}
+const getPathFromProjectRoot = (...all) => path.join(...[projectDir].concat(all))
+const pathToPackageConfigFile = packageName => getPathFromProjectRoot('node_modules', packageName, 'govuk-prototype-kit.config.json')
 
 const readJsonFile = (filePath) => {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'))
 }
-const getPackageConfig = (configFilePath) => {
-  if (fs.existsSync(configFilePath)) {
-    return readJsonFile(configFilePath)
+const getPackageConfig = packageName => {
+  if (fs.existsSync(pathToPackageConfigFile(packageName))) {
+    return readJsonFile(pathToPackageConfigFile(packageName))
   } else {
     return {}
   }
@@ -82,8 +82,8 @@ const getBaseExtensions = () => appConfig.baseExtensions || ['govuk-frontend']
 // Get all npm dependencies
 // Get baseExtensions in the order defined in `baseExtensions` in config.js
 // Then place baseExtensions before npm dependencies (and remove duplicates)
-const getPackageNamesInOrder = (packageJsonPath) => {
-  const dependencies = readJsonFile(packageJsonPath).dependencies || {}
+const getPackageNamesInOrder = () => {
+  const dependencies = readJsonFile(getPathFromProjectRoot('package.json')).dependencies || {}
   const allNpmDependenciesInAlphabeticalOrder = Object.keys(dependencies).sort()
   const installedBaseExtensions = getBaseExtensions()
     .filter(packageName => allNpmDependenciesInAlphabeticalOrder.includes(packageName))
@@ -109,10 +109,9 @@ const getPackageNamesInOrder = (packageJsonPath) => {
 //      { packageName: 'govuk-frontend', item: '/all.scss' }
 //    ]}
 const getExtensionsByType = () => {
-  const packageNamesInOrder = getPackageNamesInOrder(path.join('.', 'package.json'))
-  return packageNamesInOrder
+  return getPackageNamesInOrder()
     .reduce((accum, packageName) => Object.assign({}, accum, objectMap(
-      getPackageConfig(path.join('.', 'node_modules', packageName, 'govuk-prototype-kit.config.json')),
+      getPackageConfig(packageName),
       (listOfItemsForType, type) => (accum[type] || [])
         .concat([].concat(listOfItemsForType).map(item => ({
           packageName,

--- a/lib/extensions/extensions.js
+++ b/lib/extensions/extensions.js
@@ -51,16 +51,15 @@ const objectMap = (object, mapFn) => Object.keys(object).reduce((result, key) =>
 
 // File utilities
 const getPathFromProjectRoot = (...all) => {
-  return path.join.apply(null, [__dirname, '..', '..'].concat(all))
+  return path.resolve.apply(null, ['.'].concat(all))
 }
-const pathToPackageConfigFile = packageName => getPathFromProjectRoot('node_modules', packageName, 'govuk-prototype-kit.config.json')
 
 const readJsonFile = (filePath) => {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'))
 }
-const getPackageConfig = packageName => {
-  if (fs.existsSync(pathToPackageConfigFile(packageName))) {
-    return readJsonFile(pathToPackageConfigFile(packageName))
+const getPackageConfig = (configFilePath) => {
+  if (fs.existsSync(configFilePath)) {
+    return readJsonFile(configFilePath)
   } else {
     return {}
   }
@@ -83,8 +82,8 @@ const getBaseExtensions = () => appConfig.baseExtensions || ['govuk-frontend']
 // Get all npm dependencies
 // Get baseExtensions in the order defined in `baseExtensions` in config.js
 // Then place baseExtensions before npm dependencies (and remove duplicates)
-const getPackageNamesInOrder = () => {
-  const dependencies = readJsonFile(getPathFromProjectRoot('package.json')).dependencies || {}
+const getPackageNamesInOrder = (packageJsonPath) => {
+  const dependencies = readJsonFile(packageJsonPath).dependencies || {}
   const allNpmDependenciesInAlphabeticalOrder = Object.keys(dependencies).sort()
   const installedBaseExtensions = getBaseExtensions()
     .filter(packageName => allNpmDependenciesInAlphabeticalOrder.includes(packageName))
@@ -110,9 +109,10 @@ const getPackageNamesInOrder = () => {
 //      { packageName: 'govuk-frontend', item: '/all.scss' }
 //    ]}
 const getExtensionsByType = () => {
-  return getPackageNamesInOrder()
+  const packageNamesInOrder = getPackageNamesInOrder(path.join('.', 'package.json'))
+  return packageNamesInOrder
     .reduce((accum, packageName) => Object.assign({}, accum, objectMap(
-      getPackageConfig(packageName),
+      getPackageConfig(path.join('.', 'node_modules', packageName, 'govuk-prototype-kit.config.json')),
       (listOfItemsForType, type) => (accum[type] || [])
         .concat([].concat(listOfItemsForType).map(item => ({
           packageName,

--- a/lib/usage_data.js
+++ b/lib/usage_data.js
@@ -10,12 +10,14 @@ const { v4: uuidv4 } = require('uuid')
 
 // Local dependencies
 const packageJson = require('../package.json')
+const { projectDir } = require('./utils')
+const usageDataFilePath = path.join(projectDir, 'usage-data-config.json')
 
 exports.getUsageDataConfig = function () {
   // Try to read config file to see if usage data is opted in
   let usageDataConfig = {}
   try {
-    usageDataConfig = require(path.resolve('usage-data-config.json'))
+    usageDataConfig = require(usageDataFilePath)
   } catch (e) {
     // do nothing - we will make a config
   }
@@ -25,7 +27,7 @@ exports.getUsageDataConfig = function () {
 exports.setUsageDataConfig = function (usageDataConfig) {
   const usageDataConfigJSON = JSON.stringify(usageDataConfig, null, '  ')
   try {
-    fs.writeFileSync('./usage-data-config.json', usageDataConfigJSON)
+    fs.writeFileSync(usageDataFilePath, usageDataConfigJSON)
     return true
   } catch (error) {
     console.error(error)

--- a/lib/usage_data.js
+++ b/lib/usage_data.js
@@ -15,7 +15,7 @@ exports.getUsageDataConfig = function () {
   // Try to read config file to see if usage data is opted in
   let usageDataConfig = {}
   try {
-    usageDataConfig = require(path.join(__dirname, '../usage-data-config.json'))
+    usageDataConfig = require(path.resolve('usage-data-config.json'))
   } catch (e) {
     // do nothing - we will make a config
   }
@@ -25,7 +25,7 @@ exports.getUsageDataConfig = function () {
 exports.setUsageDataConfig = function (usageDataConfig) {
   const usageDataConfigJSON = JSON.stringify(usageDataConfig, null, '  ')
   try {
-    fs.writeFileSync(path.join(__dirname, '../usage-data-config.json'), usageDataConfigJSON)
+    fs.writeFileSync('./usage-data-config.json', usageDataConfigJSON)
     return true
   } catch (error) {
     console.error(error)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,6 +10,10 @@ const portScanner = require('portscanner')
 const inquirer = require('inquirer')
 const matter = require('gray-matter')
 
+// Directory locations
+exports.packageDir = path.resolve(__dirname, '..')
+exports.projectDir = process.cwd()
+
 // Local dependencies
 const config = require('../app/config.js')
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "cypress:open": "cypress open",
     "test:heroku": "start-server-and-test 'npx --yes heroku local --port 3000' 3000 test:smoke",
     "test:integration": "KIT_TEST_DIR=tmp/test-prototype start-server-and-test 'node cypress/scripts/run-from-release' 3000 'cypress run'",
+    "test:integration:package": "KIT_TEST_DIR=tmp/test-prototype-package start-server-and-test 'node cypress/scripts/run-as-package' 3000 'cypress run'",
     "test:smoke": "cypress run --spec \"cypress/integration/0-smoke-tests/*\"",
     "test": "jest && npm run lint"
   },

--- a/server.js
+++ b/server.js
@@ -118,8 +118,8 @@ middleware.forEach(func => app.use(func))
 
 // Set up App
 var appViews = extensions.getAppViews([
-  path.join(__dirname, '/app/views/'),
-  path.join(__dirname, '/lib/')
+  path.join('.', '/app/views/'),
+  path.join('.', '/lib/')
 ])
 
 var nunjucksConfig = {
@@ -143,7 +143,7 @@ utils.addNunjucksFilters(nunjucksAppEnv)
 app.set('view engine', 'html')
 
 // Middleware to serve static assets
-app.use('/public', express.static(path.join(__dirname, '/public')))
+app.use('/public', express.static(path.join('.', '/public')))
 
 // Serve govuk-frontend in from node_modules (so not to break pre-extensions prototype kits)
 app.use('/node_modules/govuk-frontend', express.static(path.join(__dirname, '/node_modules/govuk-frontend')))

--- a/server.js
+++ b/server.js
@@ -27,6 +27,7 @@ const packageJson = require('./package.json')
 const routes = require(`${process.cwd()}/app/routes.js`)
 const utils = require('./lib/utils.js')
 const extensions = require('./lib/extensions/extensions.js')
+const { projectDir } = require('./lib/utils')
 
 // Variables for v6 backwards compatibility
 // Set false by default, then turn on if we find /app/v6/routes.js
@@ -118,8 +119,8 @@ middleware.forEach(func => app.use(func))
 
 // Set up App
 var appViews = extensions.getAppViews([
-  path.join('.', '/app/views/'),
-  path.join('.', '/lib/')
+  path.join(projectDir, '/app/views/'),
+  path.join(projectDir, '/lib/')
 ])
 
 var nunjucksConfig = {
@@ -143,7 +144,7 @@ utils.addNunjucksFilters(nunjucksAppEnv)
 app.set('view engine', 'html')
 
 // Middleware to serve static assets
-app.use('/public', express.static(path.join('.', '/public')))
+app.use('/public', express.static(path.join(projectDir, '/public')))
 
 // Serve govuk-frontend in from node_modules (so not to break pre-extensions prototype kits)
 app.use('/node_modules/govuk-frontend', express.static(path.join(__dirname, '/node_modules/govuk-frontend')))

--- a/server.js
+++ b/server.js
@@ -24,7 +24,7 @@ const config = require('./app/config.js')
 const documentationRoutes = require('./docs/documentation_routes.js')
 const prototypeAdminRoutes = require('./lib/prototype-admin-routes.js')
 const packageJson = require('./package.json')
-const routes = require('./app/routes.js')
+const routes = require(`${process.cwd()}/app/routes.js`)
 const utils = require('./lib/utils.js')
 const extensions = require('./lib/extensions/extensions.js')
 

--- a/start.js
+++ b/start.js
@@ -6,11 +6,9 @@ const fs = require('fs')
 const checkFiles = require('./lib/build/check-files').checkFiles
 checkFiles()
 
-// External dependencies
-const fse = require('fs-extra')
-
 // Local dependencies
 const { buildWatchAndServe } = require('./lib/build/tasks')
+const { projectDir } = require('./lib/utils')
 
 async function collectDataUsage () {
 // Local dependencies
@@ -38,16 +36,14 @@ async function collectDataUsage () {
 
 function createSessionDataDefaults () {
 // Create template session data defaults file if it doesn't exist
-  const dataDirectory = path.join('.', '/app/data')
+  const dataDirectory = path.join(projectDir, '/app/data')
   const sessionDataDefaultsFile = path.join(dataDirectory, '/session-data-defaults.js')
   const sessionDataDefaultsFileExists = fs.existsSync(sessionDataDefaultsFile)
 
   if (!sessionDataDefaultsFileExists) {
     console.log('Creating session data defaults file')
     if (!fs.existsSync(dataDirectory)) {
-      fs.mkdirSync(dataDirectory, {
-        recursive: true
-      })
+      fs.mkdirSync(dataDirectory)
     }
 
     fs.createReadStream(path.join(__dirname, '/lib/template.session-data-defaults.js'))
@@ -55,23 +51,7 @@ function createSessionDataDefaults () {
   }
 }
 
-function ensureAppExits () {
-  const srcDir = path.join(__dirname, 'app')
-  const destDir = path.join('.', 'app')
-
-  if (!fs.existsSync(destDir)) {
-    fs.mkdirSync(destDir, {
-      recursive: true
-    })
-
-    fse.copySync(srcDir, destDir, {
-      overwrite: true
-    })
-  }
-}
-
 (async () => {
-  ensureAppExits()
   createSessionDataDefaults()
   await collectDataUsage()
   await buildWatchAndServe()

--- a/start.js
+++ b/start.js
@@ -1,11 +1,13 @@
 // Core dependencies
 const path = require('path')
 const fs = require('fs')
-const fse = require('fs-extra')
 
 // Check for node_modules before running
 const checkFiles = require('./lib/build/check-files').checkFiles
 checkFiles()
+
+// External dependencies
+const fse = require('fs-extra')
 
 // Local dependencies
 const { buildWatchAndServe } = require('./lib/build/tasks')

--- a/start.js
+++ b/start.js
@@ -1,6 +1,7 @@
 // Core dependencies
 const path = require('path')
 const fs = require('fs')
+const fse = require('fs-extra')
 
 // Check for node_modules before running
 const checkFiles = require('./lib/build/check-files').checkFiles
@@ -35,14 +36,16 @@ async function collectDataUsage () {
 
 function createSessionDataDefaults () {
 // Create template session data defaults file if it doesn't exist
-  const dataDirectory = path.join(__dirname, '/app/data')
+  const dataDirectory = path.join('.', '/app/data')
   const sessionDataDefaultsFile = path.join(dataDirectory, '/session-data-defaults.js')
   const sessionDataDefaultsFileExists = fs.existsSync(sessionDataDefaultsFile)
 
   if (!sessionDataDefaultsFileExists) {
     console.log('Creating session data defaults file')
     if (!fs.existsSync(dataDirectory)) {
-      fs.mkdirSync(dataDirectory)
+      fs.mkdirSync(dataDirectory, {
+        recursive: true
+      })
     }
 
     fs.createReadStream(path.join(__dirname, '/lib/template.session-data-defaults.js'))
@@ -50,7 +53,23 @@ function createSessionDataDefaults () {
   }
 }
 
+function ensureAppExits () {
+  const srcDir = path.join(__dirname, 'app')
+  const destDir = path.join('.', 'app')
+
+  if (!fs.existsSync(destDir)) {
+    fs.mkdirSync(destDir, {
+      recursive: true
+    })
+
+    fse.copySync(srcDir, destDir, {
+      overwrite: true
+    })
+  }
+}
+
 (async () => {
+  ensureAppExits()
   createSessionDataDefaults()
   await collectDataUsage()
   await buildWatchAndServe()


### PR DESCRIPTION
See Issue: https://github.com/alphagov/govuk-prototype-kit/issues/1335

- Allow the kit to be installed as a package
- Integration tests now run against a release archive
- A script has been added to allow Integration tests to simulate running the kit as a package dependency