### PR TITLE
Fix message about colour when the app crashes

### DIFF
--- a/__tests__/spec/start.js
+++ b/__tests__/spec/start.js
@@ -1,9 +1,12 @@
 /* eslint-env jest */
 
 const child_process = require('child_process') // eslint-disable-line camelcase
+const fs = require('fs')
 const path = require('path')
 
 const utils = require('./utils')
+
+const repoDir = path.resolve(__dirname, '..', '..')
 
 describe('npm start', () => {
   const tmpDir = utils.mkdtempSync()
@@ -16,6 +19,30 @@ describe('npm start', () => {
       expect(
         child_process.execSync('npm start', { cwd: testDir, encoding: 'utf8' })
       ).toMatch(/ERROR: Node module folder missing. Try running `npm install`\n$/)
+    })
+  })
+
+  describe('dev server', () => {
+    it('suggests running npm install if app crashes', async () => {
+      const testDir = path.join(tmpDir, 'onCrash')
+      utils.mkPrototypeSync(testDir)
+      fs.symlinkSync(path.join(repoDir, 'node_modules'), path.join(testDir, 'node_modules'), 'dir')
+
+      // add a require for an unincluded and uninstalled module
+      // this should always fail
+      fs.writeFileSync(
+        path.join(testDir, 'listen-on-port.js'),
+        "const foobar = require('foobar')\n"
+      )
+
+      const app = child_process.spawnSync(
+        'node lib/build/dev-server',
+        { cwd: testDir, encoding: 'utf8', shell: true, timeout: 2500 }
+      )
+
+      expect(app).toEqual(expect.objectContaining({
+        stdout: expect.stringContaining('[nodemon] For missing modules try running `npm install`')
+      }))
     })
   })
 })

--- a/lib/build/dev-server.js
+++ b/lib/build/dev-server.js
@@ -1,0 +1,3 @@
+const { devServer } = require('./tasks')
+
+devServer()

--- a/lib/build/tasks.js
+++ b/lib/build/tasks.js
@@ -1,9 +1,11 @@
+const fs = require('fs')
+const path = require('path')
+
+const chokidar = require('chokidar')
 const colour = require('nodemon/lib/utils/colour')
 const del = require('del')
-const fs = require('fs')
 const fse = require('fs-extra')
-const path = require('path')
-const chokidar = require('chokidar')
+const nodemon = require('nodemon')
 const sass = require('sass')
 
 const extensions = require('../extensions/extensions')
@@ -124,8 +126,6 @@ function watch () {
 }
 
 function runNodemon () {
-  const nodemon = require('nodemon')
-
   // Warn about npm install on crash
   const onCrash = () => {
     console.log(colour.cyan('[nodemon] For missing modules try running `npm install`'))

--- a/lib/build/tasks.js
+++ b/lib/build/tasks.js
@@ -33,11 +33,15 @@ function generateAssets () {
   copyAssets(paths.v6Assets, v6PublicPath)
 }
 
+function devServer () {
+  watch()
+  return runNodemon()
+}
+
 async function buildWatchAndServe () {
   generateAssets()
   await utils.waitUntilFileExists(path.join(appCssPath, 'application.css'), 5000)
-  watch()
-  runNodemon()
+  devServer()
 }
 
 function clean () {
@@ -136,7 +140,7 @@ function runNodemon () {
     process.exit(0)
   }
 
-  nodemon({
+  return nodemon({
     watch: ['.env', '**/*.js', '**/*.json'],
     script: 'listen-on-port.js',
     ignore: [
@@ -152,5 +156,6 @@ function runNodemon () {
 
 module.exports = {
   buildWatchAndServe,
+  devServer,
   generateAssets
 }

--- a/lib/build/tasks.js
+++ b/lib/build/tasks.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const path = require('path')
 
 const chokidar = require('chokidar')
-const colour = require('nodemon/lib/utils/colour')
+const colour = require('ansi-colors')
 const del = require('del')
 const fse = require('fs-extra')
 const nodemon = require('nodemon')


### PR DESCRIPTION
Fixes #1355.

Currently when the app crashes for whatever reason, in the terminal a message about `colour.cyan(...) is not a function` appears, when what should be appearing is a message suggesting that the user run `npm install` to make sure all modules are present.

This PR also adds a test to ensure this regression doesn't happen again. Writing the tests was a real odyssey, although you wouldn't know it from the code I committed in the end... ask me about it sometime!