### PR TITLE
Add tests for download

### DIFF
--- a/.github/workflows/test-download.yaml
+++ b/.github/workflows/test-download.yaml
@@ -1,10 +1,9 @@
-name: Tests
+name: Tests (Download)
 
 on:
   push:
     branches:
       - main
-      - support/*
   pull_request:
 
 jobs:
@@ -13,10 +12,11 @@ jobs:
     strategy:
       fail-fast: false  # continue other tests if one test in matrix fails
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [12.x, 14.x, 16.x]
         os: [macos-latest, windows-latest, ubuntu-latest]
 
     name: Test kit on Node v${{ matrix.node-version }} (${{ matrix.os }})
+    continue-on-error: true
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
 
@@ -29,8 +29,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
 
     - name: Use Node v${{ matrix.node-version }}
       uses: actions/setup-node@v3
@@ -46,19 +44,14 @@ jobs:
 
     - run: npm ci
 
-    - run: npx jest --runInBand
-      env:
-        CI: true
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - run: npm run test:integration
+    - run: npm run test:download
       env:
         CYPRESS_REQUEST_TIMEOUT: 20000
         CYPRESS_DEFAULT_COMMAND_TIMEOUT: 40000
         CYPRESS_PAGE_LOAD_TIMEOUT: 150000
         CYPRESS_RETRIES: 3
 
-    - run: npm run test:integration:package
+    - run: npm run test:download:package
       env:
         CYPRESS_REQUEST_TIMEOUT: 20000
         CYPRESS_DEFAULT_COMMAND_TIMEOUT: 40000

--- a/cypress.json
+++ b/cypress.json
@@ -2,5 +2,6 @@
   "baseUrl": "http://localhost:3000",
   "testFiles": "**/*.cypress.js",
   "video": false,
-  "chromeWebSecurity": false
+  "chromeWebSecurity": false,
+  "trashAssetsBeforeRun": true
 }

--- a/cypress/download-tests/1-download-latest-release/download.cypress.js
+++ b/cypress/download-tests/1-download-latest-release/download.cypress.js
@@ -1,0 +1,17 @@
+import { waitForApplication } from '../../integration/utils'
+
+describe('download page', () => {
+  beforeEach(() => {
+    waitForApplication()
+  })
+
+  it('loaded ok', () => {
+    cy.get('main')
+      .find('a').contains('Tutorials and templates')
+      .click()
+
+    cy.get('a[data-link="download"]')
+      .should('contains.text', 'Download the Prototype Kit (zip file)')
+      .download()
+  })
+})

--- a/cypress/integration/utils.js
+++ b/cypress/integration/utils.js
@@ -1,5 +1,3 @@
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
-
 const waitForApplication = async () => {
   cy.task('log', 'Waiting for app to restart and load home page')
   cy.task('waitUntilAppRestarts')
@@ -19,7 +17,6 @@ const deleteFile = (filename) => {
 }
 
 module.exports = {
-  sleep,
   waitForApplication,
   copyFile,
   deleteFile

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -65,6 +65,22 @@ Cypress.Commands.add('waitForResource', (name, options = {}) => {
   )
 })
 
+Cypress.Commands.add(
+  'download',
+  { prevSubject: true },
+  (subject) => {
+    return cy.get(subject)
+      .invoke('attr', 'href')
+      .then((filename) => {
+        cy.url().then((uri) => {
+          const url = new URL(uri)
+          cy.task('log', `Downloading ${url.origin}${filename}`)
+          cy.task('download', { filename: `${url.origin}${filename}` })
+        })
+      })
+  }
+)
+
 // ***********************************************
 // This example commands.js shows you how to
 // create various custom commands and overwrite

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
       "devDependencies": {
         "cypress": "^9.6.0",
         "eslint-plugin-cypress": "^2.12.1",
+        "extract-zip": "^2.0.1",
         "glob": "^7.1.4",
         "jest": "^28.1.1",
         "proper-lockfile": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "test:integration": "KIT_TEST_DIR=tmp/test-prototype start-server-and-test 'node cypress/scripts/run-from-release' 3000 'cypress run'",
     "test:integration:package": "KIT_TEST_DIR=tmp/test-prototype-package start-server-and-test 'node cypress/scripts/run-as-package' 3000 'cypress run'",
     "test:integration:package:open": "KIT_TEST_DIR=tmp/test-prototype-package start-server-and-test 'node cypress/scripts/run-as-package' 3000 'cypress open'",
+    "test:download": "KIT_TEST_DIR=tmp/test-prototype start-server-and-test 'node cypress/scripts/run-from-release' 3000 'cypress run --config integrationFolder=cypress/download-tests'",
+    "test:download:package": "KIT_TEST_DIR=tmp/test-prototype-package start-server-and-test 'node cypress/scripts/run-as-package' 3000 'cypress run --config integrationFolder=cypress/download-tests'",
     "test:smoke": "cypress run --spec \"cypress/integration/0-smoke-tests/*\"",
     "test": "jest && npm run lint"
   },
@@ -53,6 +55,7 @@
   "devDependencies": {
     "cypress": "^9.6.0",
     "eslint-plugin-cypress": "^2.12.1",
+    "extract-zip": "^2.0.1",
     "glob": "^7.1.4",
     "jest": "^28.1.1",
     "proper-lockfile": "^4.1.2",


### PR DESCRIPTION
Tests to download and extract the latest zip file of the prototype kit.
Please note that as cypress has an issue testing a download from an external page, I have created a custom cypress command to retrieve the href of the download and then download the file manually.
Note also that the download test runs in a seperate action.