### PR TITLE
Fix tests to work with jest 27s default test runner

### DIFF
--- a/lib/extensions/extensions.test.js
+++ b/lib/extensions/extensions.test.js
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 /* eslint-disable no-prototype-builtins */
-/* global spyOn */
 // NPM dependencies
 const path = require('path')
 const fs = require('fs')
@@ -11,6 +10,7 @@ const extensions = require('./extensions.js')
 
 // Local variables
 const rootPath = path.join(__dirname, '..', '..')
+const pkg = fs.readFileSync('package.json', 'utf8')
 let testScope
 
 // helpers
@@ -24,13 +24,13 @@ describe('extensions', () => {
       },
       fileSystem: {}
     }
-    addFileToMockFileSystem(['package.json'], fs.readFileSync('package.json', 'utf8'))
+    addFileToMockFileSystem(['package.json'], pkg)
     addFileToMockFileSystem(['node_modules', 'govuk-frontend', 'govuk-prototype-kit.config.json'], '{"nunjucksPaths": ["/"],"scripts": ["/govuk/all.js"],"assets": ["/govuk/assets"],"sass": ["/govuk/all.scss"]}')
     setupFakeFilesystem()
     extensions.setExtensionsByType()
   })
   afterEach(() => {
-    jest.clearAllMocks()
+    jest.restoreAllMocks()
     appConfig.baseExtensions = testScope.originalValues.appConfigBaseExtensions
   })
 
@@ -424,7 +424,7 @@ describe('extensions', () => {
       return (filePath).replace(rootPath + path.sep, '').split(path.sec)
     }
 
-    spyOn(fs, 'readFileSync').and.callFake(function (filePath) {
+    jest.spyOn(fs, 'readFileSync').mockImplementation(function (filePath) {
       const trimmedPath = prepFilePath(filePath)
       if (doesFileExitInMockFileSystem(trimmedPath)) {
         return readFileFromMockFileSystem(trimmedPath)
@@ -434,7 +434,7 @@ describe('extensions', () => {
         throw err
       }
     })
-    spyOn(fs, 'existsSync').and.callFake(filePath => doesFileExitInMockFileSystem(prepFilePath(filePath)))
+    jest.spyOn(fs, 'existsSync').mockImplementation(filePath => doesFileExitInMockFileSystem(prepFilePath(filePath)))
   }
 
   const addFileToMockFileSystem = (pathParts, content) => {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
       "__tests__/spec/utils.js",
       "/node_modules/",
       "/tmp/"
-    ],
-    "testRunner": "jest-jasmine2"
+    ]
   }
 }


### PR DESCRIPTION
See Issue: https://github.com/alphagov/govuk-prototype-kit/issues/1154

- Replace test runner jest-jasmine2 with jest-circus
- Replace deprecated ".and.callFake" with ".mockImplementation"