### PR TITLE
Fix race condition in fetch test for update script

### DIFF
--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -3,7 +3,8 @@ const child_process = require('child_process') // eslint-disable-line camelcase
 const fs = require('fs')
 const path = require('path')
 const process = require('process')
-const request = require('superagent')
+
+const _ = require('lodash')
 
 const utils = require('./utils')
 
@@ -32,6 +33,12 @@ const bash = process.platform === 'win32' ? 'C:\\Program Files\\Git\\bin\\bash.e
  * runScriptSync({ testDir: 'example' })  // runs `update.sh` in directory `example`
  * runScriptSync('extract', { testDir: 'example' })  // runs `source update.sh && extract` in directory `example`
  *
+ * Returns an object with output of `stdout`, `stderr`, and exit code in `status`.
+ *
+ * If the option `trace` is true, then the return object will also have an
+ * array of strings `trace` which lists the commands called by the scripts (see
+ * the bash man page and the option xtrace).
+ *
  * Throws an error if the spawn fails, but does not throw an error if the
  * return status of the script or function is non-zero.
  */
@@ -44,7 +51,8 @@ function runScriptSync (fnName, options) {
   const opts = {
     ...options,
     cwd: options.testDir,
-    encoding: 'utf8'
+    encoding: 'utf8',
+    env: { LANG: process.env.LANG, PATH: process.env.PATH, ...(options.env || {}) }
   }
 
   let args
@@ -55,7 +63,25 @@ function runScriptSync (fnName, options) {
     args = [script]
   }
 
+  if (options.trace) {
+    args.unshift('-x')
+    opts.env.PS4 = '+xtrace '
+  }
+
   const ret = child_process.spawnSync(bash, args, opts)
+
+  if (options.trace) {
+    // split the trace lines out from stderr
+    let { stderr, trace } = _.groupBy(
+      ret.stderr.split(/(^\++xtrace [^\n]+)\n/m),
+      (line) => /^\++xtrace [^\n]+/.test(line) ? 'trace' : 'stderr'
+    )
+    stderr = stderr.join('')
+    trace = trace.map((line) => line.replace(/^(\++)xtrace /, '$1 '))
+    ret.stderr = stderr
+    ret.trace = trace
+  }
+
   if (ret.error) {
     throw (ret.error)
   }

--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -320,27 +320,18 @@ describe('update.sh', () => {
 
   describe('fetch', () => {
     it('downloads the latest release of the prototype kit into the update folder', async () => {
-      // check what GitHub thinks the latest release archive is
-      const req = request
-        .get('https://api.github.com/repos/alphagov/govuk-prototype-kit/releases/latest')
-        .set('user-agent', 'node-superagent (tests for govuk-prototype-kit)')
-
-      if (process.env.GITHUB_TOKEN) req.set('authorization', `Bearer ${process.env.GITHUB_TOKEN}`)
-
-      const res = await req
-      if (res.error) throw res.error
-
-      const latestRelease = res.body
-      const latestReleaseVersion = latestRelease.tag_name.trim().slice(1) // need to drop the prefix 'v'
-      const latestReleaseArchiveFilename = `govuk-prototype-kit-${latestReleaseVersion}.zip`
-
       const testDir = 'fetch'
       fs.mkdirSync(path.join(testDir, 'update'), { recursive: true })
 
-      runScriptSyncAndExpectSuccess('fetch', { testDir })
+      const ret = runScriptSyncAndExpectSuccess('fetch', { testDir, trace: true })
 
-      fs.accessSync(path.join(testDir, 'update'))
-      fs.accessSync(path.join(testDir, 'update', latestReleaseArchiveFilename))
+      expect(ret.trace).toEqual(expect.arrayContaining([
+        expect.stringMatching('curl( -[LJO]*)? https://govuk-prototype-kit.herokuapp.com/docs/download')
+      ]))
+
+      expect(fs.readdirSync(path.join(testDir, 'update'))).toEqual([
+        expect.stringMatching(/govuk-prototype-kit-\d+\.\d+\.\d+\.zip/)
+      ])
     })
   })
 


### PR DESCRIPTION
There is an unfortunate race condition in the test 'it downloads the latest release of the prototype kit folder', because the update script relies on the prototype kit docs app to direct it to the latest release of the prototype kit, but the tests rely on the GitHub API for the same information. When a release has been made on GitHub but the docs app has not yet finished deployment, the tests will expect a newer version of the kit than the update script will fetch. I couldn't really think of a way around this, and besides I was already unhappy with the fact that the tests were implicitly testing a function of the docs app, so instead this PR loosens the requirements of the test slightly; now we just assert that the script gets the latest release from the prototype kit website.

This fixes #1277.