### PR TITLE
Fix npm deprecated config warnings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,5 @@
 audit=false
+loglevel=error
 omit=optional
 optional=false
 script-shell=bash


### PR DESCRIPTION
Fixes #1354.

I just found that for npm@8.7.0 using deprecated config variables will emit some very annoying warnings [1]. However, we use deprecated config variables to make sure users with older node installations don't install the dev dependencies by default.

So with the changes in #1373 for anyone who has installed the latest version of Node 16, or upgraded npm, when they run `npm start` they will see

```
npm WARN config optional Use `--omit=optional` to exclude optional dependencies, or
npm WARN config `--include=optional` to include them.
npm WARN config
npm WARN config     Default value does install optional deps unless otherwise omitted.

> govuk-prototype-kit@12.1.0 start
> node start

compiling CSS...⠂⠂⠂) ⠦ : timing config:load:flatten Completed in 3ms
compiling CSS...⠂⠂⠂) ⠦ : timing config:load:flatten Completed in 3ms
copying assets...⠂⠂) ⠦ : timing config:load:flatten Completed in 3ms
copying assets...
(⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂) ⠦ : timing config:load:flatten Completed in 3ms
GOV.UK Prototype Kit v12.1.0

NOTICE: the kit is for building prototypes, do not use it for production services.

Listening on port 3000   url: http://localhost:3000
(⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂⠂) ⠦ : timing config:load:flatten Completed in 3ms
```

This is very confusing output. This can also make the kit unusable, because the output from `timing config:load:flatten` can interfere with the prompt asking whether you want to allow analytics.

This commit hides the messages by stopping npm from logging warnings to the console. This might not work forever though; future versions of npm may make the using deprecated config variables an error [2].

[1]: https://github.com/npm/cli/releases/tag/v8.7.0
[2]: https://github.com/npm/cli/commit/98377d159f72a5b6073f07235b057984eb09a85c#diff-338e11b7e88bcb8690c3aeb3a50c2939f419236f43ac0ae76ad239b5da13ea8aR509