### PR TITLE
Rename generateSass as generateCss

### DIFF
--- a/lib/build/tasks.js
+++ b/lib/build/tasks.js
@@ -30,9 +30,9 @@ const v6PublicPath = path.join(paths.public, 'v6')
 function generateAssets () {
   clean()
   sassExtensions()
-  generateSass(appSassPath, appCssPath)
-  generateSass(docsSassPath, appCssPath)
-  generateSass(v6SassPath, v6CssPath)
+  generateCss(appSassPath, appCssPath)
+  generateCss(docsSassPath, appCssPath)
+  generateCss(v6SassPath, v6CssPath)
   copyAssets(paths.assets, paths.public)
   copyAssets(paths.docsAssets, paths.public)
   copyAssets(paths.v6Assets, v6PublicPath)
@@ -64,7 +64,7 @@ function sassExtensions () {
   fs.writeFileSync(path.join(tempSassPath, '_extensions.scss'), fileContents)
 }
 
-function generateSass (sassPath, cssPath) {
+function generateCss (sassPath, cssPath) {
   if (!fs.existsSync(sassPath)) return
   console.log('compiling CSS...')
   fs.mkdirSync(cssPath, { recursive: true })
@@ -106,7 +106,7 @@ function watchSass (sassPath, cssPath) {
   }).on('all', (event, path) => {
     console.log(`watch ${sassPath}`)
     console.log(event, path)
-    generateSass(sassPath, cssPath)
+    generateCss(sassPath, cssPath)
   })
 }
 


### PR DESCRIPTION
Rename the generateSass function in build tasks as generateCss.