### PR TITLE
Rename workflows to be consistently named

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: Run linter
+name: Lint
 
 on:
   push:

--- a/.github/workflows/test-heroku.yaml
+++ b/.github/workflows/test-heroku.yaml
@@ -1,4 +1,4 @@
-name: Test kit on Heroku
+name: Tests (Heroku)
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
 jobs:
   test-heroku:
 
-    name: Test
+    name: Test kit on Heroku
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Run tests
+name: Tests
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  run-tests:
+  tests:
 
     strategy:
       fail-fast: false  # continue other tests if one test in matrix fails
@@ -15,7 +15,7 @@ jobs:
         node-version: [12.x, 14.x, 16.x]
         os: [macos-latest, windows-latest, ubuntu-latest]
 
-    name: Node v${{ matrix.node-version }} (${{ matrix.os }})
+    name: Test kit on Node v${{ matrix.node-version }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
 


### PR DESCRIPTION
When trying to keep track of all the checks in the branch protections, it's a lot easier to do if the job name is descriptive, the workflow name is less important.

This PR makes sure that the job names say what the check is doing, and makes the workflow name shorter so it takes up less space in the UI.