### PR TITLE
Add support for tarballs to create-release-archive script

### DIFF
--- a/__tests__/spec/utils.js
+++ b/__tests__/spec/utils.js
@@ -65,9 +65,11 @@ function _mkReleaseArchiveSync ({ archive, prefix }) {
   // Create a stash commit so we can include files modified in the worktree in the archive
   // TODO: this doesn't pick up unstaged files
   const ref = child_process.execSync('git stash create', { cwd: repoDir, encoding: 'utf8' }) || 'HEAD'
+  archive = path.parse(archive)
+  const archiveType = archive.ext.slice(1)
 
   child_process.execSync(
-    `node scripts/create-release-archive --releaseName ${getReleaseVersion()} --destDir ${path.dirname(archive)} ${ref}`,
+    `node scripts/create-release-archive --releaseName ${getReleaseVersion()} --destDir ${archive.dir} --archiveType ${archiveType} ${ref}`,
     { cwd: repoDir }
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "standard": "^14.3.3",
         "start-server-and-test": "^1.14.0",
         "supertest": "^6.2.3",
+        "tar": "^6.1.11",
         "wait-on": "^6.0.1"
       },
       "engines": {
@@ -2730,6 +2731,15 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ci-info": {
@@ -5656,6 +5666,18 @@
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/fs.realpath": {
@@ -8941,6 +8963,31 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
+    "node_modules/minipass": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.3.tgz",
+      "integrity": "sha512-N0BOsdFAlNRfmwMhjAsLVWOk7Ljmeb39iqFlsV1At+jqRhSUP9yeof8FyJu4imaJiSUp8vQebWD/guZwGQC8iA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/mitt": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
@@ -11411,6 +11458,35 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+      "dev": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/tar/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/terminal-link": {
@@ -14321,6 +14397,12 @@
         "readdirp": "~3.6.0"
       }
     },
+    "chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true
+    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -16527,6 +16609,15 @@
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
           "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
         }
+      }
+    },
+    "fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0"
       }
     },
     "fs.realpath": {
@@ -18927,6 +19018,25 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
+    "minipass": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.3.tgz",
+      "integrity": "sha512-N0BOsdFAlNRfmwMhjAsLVWOk7Ljmeb39iqFlsV1At+jqRhSUP9yeof8FyJu4imaJiSUp8vQebWD/guZwGQC8iA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      }
+    },
     "mitt": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
@@ -20798,6 +20908,28 @@
           "requires": {
             "ansi-regex": "^4.1.0"
           }
+        }
+      }
+    },
+    "tar": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+      "dev": true,
+      "requires": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "standard": "^14.3.3",
     "start-server-and-test": "^1.14.0",
     "supertest": "^6.2.3",
+    "tar": "^6.1.11",
     "wait-on": "^6.0.1"
   },
   "standard": {

--- a/scripts/create-release-archive
+++ b/scripts/create-release-archive
@@ -5,6 +5,8 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 
+const tar = require('tar')
+
 const packageJsonScriptsInclude = [
   'start',
   'build',
@@ -39,6 +41,9 @@ function parseArgs (args) {
     } else if (arg === '--releaseName') {
       i++
       argv.releaseName = args[i]
+    } else if (arg === '--archiveType') {
+      i++
+      argv.archiveType = args[i]
     } else {
       argv._.push(arg)
     }
@@ -68,11 +73,12 @@ function cli () {
   const ref = argv.ref || 'HEAD'
   const version = argv.releaseName || getReleaseVersion(argv.ref)
   const newVersion = !argv.releaseName && isNewVersion(version) ? 'new version' : 'version'
+  const archiveType = argv.archiveType || 'zip'
 
   console.log(`Creating release archive for ${newVersion} ${version}`)
 
   const name = `govuk-prototype-kit-${version}`
-  const releaseArchive = `${name}.zip`
+  const releaseArchive = `${name}.${archiveType}`
 
   const repoDir = path.resolve(__dirname, '..')
   const workdir = fs.mkdtempSync(
@@ -89,10 +95,12 @@ function cli () {
   updatePackageJson(path.join(workdir, name, 'package.json'), cleanPackageJson)
 
   // Create the release archive in the project root (or destDir)
-  zipReleaseFiles({
+  archiveReleaseFiles({
     cwd: workdir, file: path.join(argv.dest || repoDir, releaseArchive), prefix: name
   })
 
+  // insert a blank line for niceness
+  console.log()
   console.log(`Saved release archive to ${argv.dest ? argv.dest : ''}${releaseArchive}`)
 
   // Clean up
@@ -160,15 +168,31 @@ function copyReleaseFiles (src, dest, { prefix, ref }) {
   )
 }
 
-function zipReleaseFiles ({ cwd, file, prefix }) {
-  zipCreate(
-    {
-      cwd: cwd,
-      file: file,
-      exclude: path.join(prefix, 'node_modules', '*')
-    },
-    prefix
-  )
+function archiveReleaseFiles ({ cwd, file, prefix }) {
+  const archiveType = path.parse(file).ext.slice(1)
+  if (archiveType === 'zip') {
+    zipCreate(
+      {
+        cwd: cwd,
+        file: file,
+        exclude: path.join(prefix, 'node_modules', '*')
+      },
+      prefix
+    )
+  } else if (archiveType === 'tar') {
+    tar.create(
+      {
+        cwd: cwd,
+        file: file,
+        filter: (p) => !p.startsWith(path.join(prefix, 'node_modules')),
+        portable: true,
+        sync: true
+      },
+      [prefix]
+    )
+  } else {
+    throw new Error(`unrecognized archiveType '${archiveType}'`)
+  }
 }
 
 function zipCreate ({ cwd, file, exclude }, files) {
@@ -194,8 +218,6 @@ function zipCreate ({ cwd, file, exclude }, files) {
     throw [zipProgram, ...zipArgs].join(' \\\n\t') +
      `\n: Failed with status ${ret.status}`
   }
-  // insert a blank line for niceness
-  console.log()
 }
 
 // These exports are here only for tests
@@ -203,7 +225,7 @@ module.exports = {
   cleanPackageJson,
   updatePackageJson,
   getReleaseVersion,
-  zipReleaseFiles
+  archiveReleaseFiles
 }
 
 if (require.main === module) {

--- a/scripts/create-release-archive.test.js
+++ b/scripts/create-release-archive.test.js
@@ -130,7 +130,7 @@ describe('scripts/create-release-archive', () => {
     })
 
     it('zips release files', () => {
-      createReleaseArchive.zipReleaseFiles({ cwd: '/tmp', file: '/test.zip', prefix: 'test' })
+      createReleaseArchive.archiveReleaseFiles({ cwd: '/tmp', file: '/test.zip', prefix: 'test' })
       if (process.platform === 'win32') {
         expect(mockSpawnSync).toBeCalledWith(
           '7z', ['a', '-tzip', '-x!test\\node_modules', '/test.zip', 'test'],


### PR DESCRIPTION
We need to be able to produce tarball release archives for testing the
kit as a package (as npm will not install from a zip archive).