### PR TITLE
Add option to set ARCHIVE_FILE for update script

### DIFF
--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -151,22 +151,24 @@ describe('update.sh', () => {
 
   // Create a test archive fixture
   function _mktestArchiveSync (archive) {
-    const archiveName = path.basename(archive)
-    const dirToArchive = path.join(fixtureDir, 'govuk-prototype-kit-foo')
+    const archivePath = path.parse(archive)
+    const archiveName = archivePath.base
+    const archivePrefix = archivePath.name
+    const dirToArchive = path.join(fixtureDir, archivePrefix)
 
     fs.mkdirSync(dirToArchive)
     fs.writeFileSync(path.join(dirToArchive, 'foo'), '')
     fs.writeFileSync(path.join(dirToArchive, 'VERSION.txt'), '9999.99.99')
 
     if (process.platform === 'win32') {
-      child_process.execSync(`7z a ${archiveName} govuk-prototype-kit-foo`, { cwd: fixtureDir })
+      child_process.execSync(`7z a ${archiveName} ${archivePrefix}`, { cwd: fixtureDir })
     } else {
-      child_process.execSync(`zip -r ${archiveName} govuk-prototype-kit-foo`, { cwd: fixtureDir })
+      child_process.execSync(`zip -r ${archiveName} ${archivePrefix}`, { cwd: fixtureDir })
     }
   }
 
   function mktestArchiveSync (testDir) {
-    const archive = path.resolve(fixtureDir, 'foo.zip')
+    const archive = path.resolve(fixtureDir, 'govuk-prototype-kit-foo.zip')
 
     try {
       fs.accessSync(archive)

--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -74,7 +74,7 @@ function runScriptSync (fnName = undefined, options) {
   if (options.trace) {
     // split the trace lines out from stderr
     let { stderr, trace } = _.groupBy(
-      ret.stderr.split(/(^\++xtrace [^\n]+)\n/m),
+      ret.stderr.split(/(\++xtrace [^\n]+)\n/m),
       (line) => /^\++xtrace [^\n]+/.test(line) ? 'trace' : 'stderr'
     )
     stderr = stderr.join('')

--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -364,6 +364,24 @@ describe('update.sh', () => {
         fs.accessSync(path.join(testDir, 'update', 'govuk-prototype-kit-foo', 'foo'))
       }).toThrow()
     })
+
+    it('extracts the file supplied in ARCHIVE_FILE', () => {
+      const testDir = 'extractArchiveFile'
+      fs.mkdirSync(path.join(testDir, 'update'), { recursive: true })
+
+      const ret = runScriptSyncAndExpectSuccess(
+        'extract',
+        { testDir, env: { ARCHIVE_FILE: '../__fixtures__/govuk-prototype-kit-foo.zip' }, trace: true }
+      )
+
+      expect(ret.trace).not.toEqual(expect.arrayContaining([
+        expect.stringMatching('curl( -[LJO]*)? https://govuk-prototype-kit.herokuapp.com/docs/download')
+      ]))
+
+      expect(ret.trace).toEqual(expect.arrayContaining([
+        expect.stringMatching('unzip .*/__fixtures__/govuk-prototype-kit-foo.zip')
+      ]))
+    })
   })
 
   describe('copy', () => {

--- a/update.sh
+++ b/update.sh
@@ -10,9 +10,16 @@ msg () {
 
 # Set global vars ARCHIVE_FILE ARCHIVE_ROOT
 get_archive_vars () {
-	# choose the archive file in the update folder with the largest version number, use this to update from
-	ARCHIVE_FILE="$(find update -name 'govuk-prototype-kit*.zip' -exec basename '{}' ';' | sort -V | tail -n1)"
-	ARCHIVE_ROOT="${ARCHIVE_FILE//.zip}"
+	# If ARCHIVE_FILE hasn't been set in the env already choose the archive file
+	# in the update folder with the largest version number.
+	if [ -z "${ARCHIVE_FILE:-}" ]; then
+		ARCHIVE_FILE="$(find update -name 'govuk-prototype-kit*.zip' | sort -V | tail -n1)"
+	fi
+	if [ ! -z "${ARCHIVE_FILE:-}" ]; then
+		ARCHIVE_FILE="$PWD/$ARCHIVE_FILE"
+		ARCHIVE_NAME="$(basename "$ARCHIVE_FILE")"
+		ARCHIVE_ROOT="${ARCHIVE_NAME//.zip}"
+	fi
 }
 
 # Hide update folder from git
@@ -55,6 +62,13 @@ prepare () {
 
 # Download the latest Prototype Kit release archive to the update folder
 fetch () {
+	get_archive_vars
+
+	# If archive file already exists do nothing
+	if [ -f "$ARCHIVE_FILE" ]; then
+		return
+	fi
+
 	cd update
 
 	if ! ls govuk-prototype-kit*.zip > /dev/null 2>&1; then

--- a/update.sh
+++ b/update.sh
@@ -10,8 +10,8 @@ msg () {
 
 # Set global vars ARCHIVE_FILE ARCHIVE_ROOT
 get_archive_vars () {
-	# choose the archive file with the largest version number, use this to update from
-	ARCHIVE_FILE="$(find . -name 'govuk-prototype-kit*.zip' -exec basename '{}' ';' | sort -V | tail -n1)"
+	# choose the archive file in the update folder with the largest version number, use this to update from
+	ARCHIVE_FILE="$(find update -name 'govuk-prototype-kit*.zip' -exec basename '{}' ';' | sort -V | tail -n1)"
 	ARCHIVE_ROOT="${ARCHIVE_FILE//.zip}"
 }
 


### PR DESCRIPTION
This is useful for testing, you can point it to a release archive you've made yourself with

```
ARCHIVE_FILE=/path/to/govuk-prototype-kit-f00bar.zip update.sh
```

and it will use that to do the update without you having to create the update folder or copy any files.