### PR TITLE
Stop unit tests from creating release archive more than once

### DIFF
--- a/__tests__/spec/install.js
+++ b/__tests__/spec/install.js
@@ -9,9 +9,9 @@ const utils = require('../util')
 describe('npm install', () => {
   const tmpDir = utils.mkdtempSync()
 
-  it('does not install dev dependencies by default', () => {
+  it('does not install dev dependencies by default', async () => {
     const testDir = path.join(tmpDir, 'install-no-optional')
-    utils.mkPrototypeSync(testDir)
+    await utils.mkPrototype(testDir)
 
     child_process.execSync(
       'npm install',

--- a/__tests__/spec/release-archive.js
+++ b/__tests__/spec/release-archive.js
@@ -10,18 +10,17 @@ describe('release archive', () => {
   var archivePath
   var archiveFiles
 
-  beforeAll(() => {
-    archivePath = utils.mkReleaseArchiveSync()
+  beforeAll(async () => {
+    archivePath = await utils.mkReleaseArchive()
 
     archiveFiles = []
 
-    tar.list({
+    await tar.list({
       file: archivePath,
       onentry: (entry) => {
         const p = entry.path.substring(path.parse(archivePath).name.length + 1)
         if (p) { archiveFiles.push(p) }
-      },
-      sync: true
+      }
     })
   })
 

--- a/__tests__/spec/start.js
+++ b/__tests__/spec/start.js
@@ -12,9 +12,9 @@ describe('npm start', () => {
   const tmpDir = utils.mkdtempSync()
 
   describe('prestart', () => {
-    it('checks whether node modules are installed', () => {
+    it('checks whether node modules are installed', async () => {
       const testDir = path.join(tmpDir, 'check-node-modules-exists')
-      utils.mkPrototypeSync(testDir)
+      await utils.mkPrototype(testDir)
 
       expect(
         child_process.execSync('npm start', { cwd: testDir, encoding: 'utf8' })
@@ -25,7 +25,7 @@ describe('npm start', () => {
   describe('dev server', () => {
     it('suggests running npm install if app crashes', async () => {
       const testDir = path.join(tmpDir, 'onCrash')
-      utils.mkPrototypeSync(testDir)
+      await utils.mkPrototype(testDir)
       fs.symlinkSync(path.join(repoDir, 'node_modules'), path.join(testDir, 'node_modules'), 'dir')
 
       // add a require for an unincluded and uninstalled module

--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -1,13 +1,17 @@
 /* eslint-env jest */
 const child_process = require('child_process') // eslint-disable-line camelcase
-const fs = require('fs')
+const fs = require('fs').promises
 const path = require('path')
 const process = require('process')
+const { promisify } = require('util')
 
 const _ = require('lodash')
 
 const utils = require('../util')
 const fse = require('fs-extra')
+
+const execPromise = promisify(child_process.exec)
+const execFilePromise = promisify(child_process.execFile)
 
 /*
  * Constants
@@ -27,12 +31,12 @@ const bash = process.platform === 'win32' ? 'C:\\Program Files\\Git\\bin\\bash.e
 /**
  * Run update.sh, or one of the functions defined in it.
  *
- * runScriptSync([fnName][, options])
+ * runScript([fnName][, options])
  *
  * Examples:
- * runScriptSync()  // runs `update.sh` in current working directory
- * runScriptSync({ testDir: 'example' })  // runs `update.sh` in directory `example`
- * runScriptSync('extract', { testDir: 'example' })  // runs `source update.sh && extract` in directory `example`
+ * runScript()  // runs `update.sh` in current working directory
+ * runScript({ testDir: 'example' })  // runs `update.sh` in directory `example`
+ * runScript('extract', { testDir: 'example' })  // runs `source update.sh && extract` in directory `example`
  *
  * Returns an object with output of `stdout`, `stderr`, and exit code in `status`.
  *
@@ -43,7 +47,7 @@ const bash = process.platform === 'win32' ? 'C:\\Program Files\\Git\\bin\\bash.e
  * Throws an error if the spawn fails, but does not throw an error if the
  * return status of the script or function is non-zero.
  */
-function runScriptSync (fnName = undefined, options) {
+async function runScript (fnName = undefined, options) {
   if (typeof fnName === 'object') {
     options = fnName
     fnName = undefined
@@ -69,7 +73,21 @@ function runScriptSync (fnName = undefined, options) {
     opts.env.PS4 = '+xtrace '
   }
 
-  const ret = child_process.spawnSync(bash, args, opts)
+  var ret
+  try {
+    ret = await execFilePromise(bash, args, opts)
+    ret.status = 0
+  } catch (err) {
+    if (err.errno !== undefined) {
+      throw err
+    }
+
+    ret = {
+      status: err.code,
+      stdout: err.stdout,
+      stderr: err.stderr
+    }
+  }
 
   if (options.trace) {
     // split the trace lines out from stderr
@@ -83,50 +101,46 @@ function runScriptSync (fnName = undefined, options) {
     ret.trace = trace
   }
 
-  if (ret.error) {
-    throw (ret.error)
-  }
-
   return ret
 }
 
-function runScriptSyncAndExpectSuccess (fnName = undefined, options) {
+async function runScriptAndExpectSuccess (fnName = undefined, options) {
   if (typeof fnName === 'object') {
     options = fnName
     fnName = undefined
   }
 
-  const ret = runScriptSync(fnName, options)
+  const ret = await runScript(fnName, options)
   if (ret.status !== 0) {
     throw new Error(`update.sh in ${path.resolve(options.testDir)} failed with status ${ret.status}:\n${ret.stderr}`)
   }
   return ret
 }
 
-function runScriptSyncAndExpectError (fnName, options) {
+async function runScriptAndExpectError (fnName, options) {
   if (typeof fnName === 'object') {
     options = fnName
     fnName = undefined
   }
 
-  const oldStat = fs.statSync(options.testDir)
+  const oldStat = await fs.stat(options.testDir)
 
-  const ret = runScriptSync(fnName, options)
+  const ret = await runScript(fnName, options)
 
   expect(ret.status).not.toBe(0)
   expect(ret.stderr).toMatch(/ERROR/)
 
   // tests that no files have been added or removed in test directory
-  const newStat = fs.statSync(options.testDir)
+  const newStat = await fs.stat(options.testDir)
   expect(newStat.mtimeMs).toBe(oldStat.mtimeMs)
 
   return ret
 }
 
-function execGitStatusSync (testDir) {
-  return child_process.execSync(
+async function execGitStatus (testDir) {
+  return (await execPromise(
     'git status --porcelain', { cwd: testDir, encoding: 'utf8' }
-  ).split('\n').slice(0, -1)
+  )).stdout.split('\n').slice(0, -1)
 }
 
 describe('update.sh', () => {
@@ -140,104 +154,104 @@ describe('update.sh', () => {
    * Fixture helpers
    */
 
-  function mktestDirSync (testDir) {
-    fs.mkdirSync(testDir)
+  async function mktestDir (testDir) {
+    await fs.mkdir(testDir)
 
-    fs.writeFileSync(path.join(testDir, 'package.json'), '{\n  "name": "govuk-prototype-kit"\n}')
-    fs.writeFileSync(path.join(testDir, 'VERSION.txt'), '0.0.0')
+    await fs.writeFile(path.join(testDir, 'package.json'), '{\n  "name": "govuk-prototype-kit"\n}')
+    await fs.writeFile(path.join(testDir, 'VERSION.txt'), '0.0.0')
 
     return testDir
   }
 
   // Create a test archive fixture
-  function _mktestArchiveSync (archive) {
+  async function _mktestArchive (archive) {
     const archivePath = path.parse(archive)
     const archiveName = archivePath.base
     const archivePrefix = archivePath.name
     const dirToArchive = path.join(fixtureDir, archivePrefix)
 
-    fs.mkdirSync(dirToArchive)
-    fs.writeFileSync(path.join(dirToArchive, 'foo'), '')
-    fs.writeFileSync(path.join(dirToArchive, 'VERSION.txt'), '9999.99.99')
+    await fs.mkdir(dirToArchive)
+    await fs.writeFile(path.join(dirToArchive, 'foo'), '')
+    await fs.writeFile(path.join(dirToArchive, 'VERSION.txt'), '9999.99.99')
 
     if (process.platform === 'win32') {
-      child_process.execSync(`7z a ${archiveName} ${archivePrefix}`, { cwd: fixtureDir })
+      await execPromise(`7z a ${archiveName} ${archivePrefix}`, { cwd: fixtureDir })
     } else {
-      child_process.execSync(`zip -r ${archiveName} ${archivePrefix}`, { cwd: fixtureDir })
+      await execPromise(`zip -r ${archiveName} ${archivePrefix}`, { cwd: fixtureDir })
     }
   }
 
-  function mktestArchiveSync (testDir) {
+  async function mktestArchive (testDir) {
     const archive = path.resolve(fixtureDir, 'govuk-prototype-kit-foo.zip')
 
     try {
-      fs.accessSync(archive)
+      await fs.access(archive)
     } catch (error) {
-      _mktestArchiveSync(archive)
+      await _mktestArchive(archive)
     }
 
     if (testDir) {
       const dest = path.join(testDir, 'update', 'govuk-prototype-kit-foo.zip')
-      fs.mkdirSync(path.dirname(dest), { recursive: true })
-      fs.copyFileSync(archive, path.join(testDir, 'update', 'govuk-prototype-kit-foo.zip'))
+      await fs.mkdir(path.dirname(dest), { recursive: true })
+      await fs.copyFile(archive, path.join(testDir, 'update', 'govuk-prototype-kit-foo.zip'))
       return dest
     } else {
       return archive
     }
   }
 
-  function _mktestPrototypeSync (src) {
+  async function _mktestPrototype (src) {
     // Create a release archive from the HEAD we are running tests in
-    utils.mkPrototypeSync(src)
+    await utils.mkPrototype(src)
 
     // Create a git repo from the new release archive so we can see changes.
-    child_process.execFileSync('git', ['init'], { cwd: src })
-    child_process.execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: src })
-    child_process.execFileSync('git', ['config', 'user.name', 'Jest Tests'], { cwd: src })
+    await execFilePromise('git', ['init'], { cwd: src })
+    await execFilePromise('git', ['config', 'user.email', 'test@example.com'], { cwd: src })
+    await execFilePromise('git', ['config', 'user.name', 'Jest Tests'], { cwd: src })
 
-    child_process.execFileSync('git', ['add', '.'], { cwd: src })
-    child_process.execFileSync('git', ['commit', '-m', 'Initial commit'], { cwd: src })
+    await execFilePromise('git', ['add', '.'], { cwd: src })
+    await execFilePromise('git', ['commit', '-m', 'Initial commit'], { cwd: src })
 
     // let's imagine our prototype has been customised slightly
-    let config = fs.readFileSync(path.join(src, 'app', 'config.js'), 'utf8')
+    let config = await fs.readFile(path.join(src, 'app', 'config.js'), 'utf8')
     config = config.replace('Service name goes here', 'Jest test service')
-    fs.writeFileSync(path.join(src, 'app', 'config.js'), config, 'utf8')
+    await fs.writeFile(path.join(src, 'app', 'config.js'), config, 'utf8')
 
     // and it has been run
-    fs.writeFileSync(path.join(src, 'usage-data-config.json'), '{}')
+    await fs.writeFile(path.join(src, 'usage-data-config.json'), '{}')
 
-    child_process.execFileSync('git', ['commit', '-m', 'Test', '-a'], { cwd: src })
+    await execFilePromise('git', ['commit', '-m', 'Test', '-a'], { cwd: src })
 
     // populate the update folder to speed up tests
-    utils.mkPrototypeSync(path.join(src, 'update'))
+    await utils.mkPrototype(path.join(src, 'update'))
   }
 
-  function mktestPrototypeSync (dest) {
+  async function mktestPrototype (dest) {
     const src = path.resolve(fixtureDir, 'prototype')
     try {
-      fs.accessSync(src)
+      await fs.access(src)
     } catch (error) {
-      _mktestPrototypeSync(src)
+      await _mktestPrototype(src)
     }
 
     if (dest) {
-      child_process.execSync(`cp -r ${src} ${dest}`)
+      await execPromise(`cp -r ${src} ${dest}`)
       return dest
     } else {
       return src
     }
   }
 
-  beforeAll(() => {
+  beforeAll(async () => {
     process.chdir(tmpDir)
     console.log('Running tests in temporary directory', process.cwd())
 
     // setup fixtures
     // - running this now saves time later
     // - ensureDirSync is used to prevent a failure where the fixtureDir already exists from a previous test
-    fse.ensureDirSync(fixtureDir)
-    mktestArchiveSync()
-    mktestPrototypeSync()
+    await fse.ensureDir(fixtureDir)
+    await mktestArchive()
+    await mktestPrototype()
   })
 
   /*
@@ -245,80 +259,80 @@ describe('update.sh', () => {
    */
 
   describe('check', () => {
-    it('exits with error if run in an empty folder', () => {
+    it('exits with error if run in an empty folder', async () => {
       const testDir = 'empty'
-      fs.mkdirSync(testDir)
+      await fs.mkdir(testDir)
 
-      runScriptSyncAndExpectError({ testDir })
+      await runScriptAndExpectError({ testDir })
     })
 
-    it('exits with error if folder does not contain a package.json file', () => {
+    it('exits with error if folder does not contain a package.json file', async () => {
       const testDir = 'no-package-json'
-      fs.mkdirSync(testDir)
-      fs.writeFileSync(path.join(testDir, 'foo'), 'my important data about govuk-prototype-kit')
-      fs.writeFileSync(path.join(testDir, 'bar'), "don't delete my data!")
+      await fs.mkdir(testDir)
+      await fs.writeFile(path.join(testDir, 'foo'), 'my important data about govuk-prototype-kit')
+      await fs.writeFile(path.join(testDir, 'bar'), "don't delete my data!")
 
-      runScriptSyncAndExpectError({ testDir })
+      await runScriptAndExpectError({ testDir })
     })
 
-    it('exits with error if package.json file does not contain string govuk-prototype-kit', () => {
-      const testDir = mktestDirSync('no-govuk-prototype-kit')
-      fs.writeFileSync(path.join(testDir, 'package.json'), '{\n  "name": "test"\n}')
+    it('exits with error if package.json file does not contain string govuk-prototype-kit', async () => {
+      const testDir = await mktestDir('no-govuk-prototype-kit')
+      await fs.writeFile(path.join(testDir, 'package.json'), '{\n  "name": "test"\n}')
 
-      runScriptSyncAndExpectError({ testDir })
+      await runScriptAndExpectError({ testDir })
     })
 
-    it('exits with error if package.json file contains string containing govuk-prototype-kit', () => {
-      const testDir = mktestDirSync('name-contains-govuk-prototype-kit')
-      fs.writeFileSync(path.join(testDir, 'package.json'), '{\n  "name": "govuk-prototype-kit-test"\n}')
+    it('exits with error if package.json file contains string containing govuk-prototype-kit', async () => {
+      const testDir = await mktestDir('name-contains-govuk-prototype-kit')
+      await fs.writeFile(path.join(testDir, 'package.json'), '{\n  "name": "govuk-prototype-kit-test"\n}')
 
-      runScriptSyncAndExpectError({ testDir })
+      await runScriptAndExpectError({ testDir })
     })
   })
 
   describe('prepare', () => {
-    it('removes existing update folder', () => {
+    it('removes existing update folder', async () => {
       const testDir = 'prepare'
-      fs.mkdirSync(path.join(testDir, 'update'), { recursive: true })
-      fs.writeFileSync(path.join(testDir, 'update', 'govuk-prototype-kit-empty.zip'), '')
-      const oldStat = fs.statSync(path.join(testDir, 'update'))
+      await fs.mkdir(path.join(testDir, 'update'), { recursive: true })
+      await fs.writeFile(path.join(testDir, 'update', 'govuk-prototype-kit-empty.zip'), '')
+      const oldStat = await fs.stat(path.join(testDir, 'update'))
 
-      runScriptSyncAndExpectSuccess('prepare', { testDir })
+      await runScriptAndExpectSuccess('prepare', { testDir })
 
-      const newStat = fs.statSync(path.join(testDir, 'update'))
+      const newStat = await fs.stat(path.join(testDir, 'update'))
 
       // tests that update folder _has_ been replaced
       expect(newStat.birthtimeMs).not.toBe(oldStat.birthtimeMs)
-      expect(() => {
-        fs.accessSync(path.join(testDir, 'update', 'govuk-prototype-kit-empty.zip'))
-      }).toThrowError()
+      expect(
+        fs.access(path.join(testDir, 'update', 'govuk-prototype-kit-empty.zip'))
+      ).rejects.toThrow()
     })
 
-    it('does not remove existing update folder if CLEAN=0 is set', () => {
+    it('does not remove existing update folder if CLEAN=0 is set', async () => {
       const testDir = 'prepare-noclean'
-      fs.mkdirSync(path.join(testDir, 'update'), { recursive: true })
-      fs.writeFileSync(path.join(testDir, 'update', 'govuk-prototype-kit-empty.zip'), '')
-      const oldStat = fs.statSync(path.join(testDir, 'update'))
+      await fs.mkdir(path.join(testDir, 'update'), { recursive: true })
+      await fs.writeFile(path.join(testDir, 'update', 'govuk-prototype-kit-empty.zip'), '')
+      const oldStat = await fs.stat(path.join(testDir, 'update'))
 
-      runScriptSyncAndExpectSuccess('prepare', { testDir, env: { CLEAN: '0' } })
+      await runScriptAndExpectSuccess('prepare', { testDir, env: { CLEAN: '0' } })
 
-      const newStat = fs.statSync(path.join(testDir, 'update'))
+      const newStat = await fs.stat(path.join(testDir, 'update'))
 
       // tests that update folder has _not_ been replaced
       expect(newStat.birthtimeMs).toBe(oldStat.birthtimeMs)
-      expect(() => {
-        fs.accessSync(path.join(testDir, 'update', 'govuk-prototype-kit-empty.zip'))
+      expect(async () => {
+        await fs.access(path.join(testDir, 'update', 'govuk-prototype-kit-empty.zip'))
       }).not.toThrowError()
     })
 
-    it('hides the update folder from git', () => {
+    it('hides the update folder from git', async () => {
       const testDir = 'prepare-gitignore'
-      fs.mkdirSync(testDir)
+      await fs.mkdir(testDir)
 
-      runScriptSyncAndExpectSuccess('prepare', { testDir })
+      await runScriptAndExpectSuccess('prepare', { testDir })
 
       expect(
-        fs.readFileSync(path.join(testDir, 'update', '.gitignore'), 'utf8').trim()
+        (await fs.readFile(path.join(testDir, 'update', '.gitignore'), 'utf8')).trim()
       ).toBe('*')
     })
   })
@@ -326,26 +340,26 @@ describe('update.sh', () => {
   describe('fetch', () => {
     it('downloads the latest release of the prototype kit into the update folder', async () => {
       const testDir = 'fetch'
-      fs.mkdirSync(path.join(testDir, 'update'), { recursive: true })
+      await fs.mkdir(path.join(testDir, 'update'), { recursive: true })
 
-      const ret = runScriptSyncAndExpectSuccess('fetch', { testDir, trace: true })
+      const ret = await runScriptAndExpectSuccess('fetch', { testDir, trace: true })
 
       expect(ret.trace).toEqual(expect.arrayContaining([
         expect.stringMatching('curl( -[LJO]*)? https://govuk-prototype-kit.herokuapp.com/docs/download')
       ]))
 
-      expect(fs.readdirSync(path.join(testDir, 'update'))).toEqual([
+      expect(await fs.readdir(path.join(testDir, 'update'))).toEqual([
         expect.stringMatching(/govuk-prototype-kit-\d+\.\d+\.\d+\.zip/)
       ])
     })
   })
 
   describe('extract', () => {
-    it('extracts the release into the update folder', () => {
+    it('extracts the release into the update folder', async () => {
       const testDir = 'extract'
-      mktestArchiveSync(testDir)
+      await mktestArchive(testDir)
 
-      runScriptSyncAndExpectSuccess('extract', { testDir })
+      await runScriptAndExpectSuccess('extract', { testDir })
 
       // note that the extract process should strip 1 leading component from the path,
       // so even though the archive contains:
@@ -354,17 +368,17 @@ describe('update.sh', () => {
       //   - ./foo
       // This is so users don't have to go digging through a complicated
       // directory heirarchy after the script has asked them to manage their config.
-      fs.accessSync(path.join(testDir, 'update', 'foo'))
-      expect(() => {
-        fs.accessSync(path.join(testDir, 'update', 'govuk-prototype-kit-foo', 'foo'))
-      }).toThrow()
+      await fs.access(path.join(testDir, 'update', 'foo'))
+      expect(
+        fs.access(path.join(testDir, 'update', 'govuk-prototype-kit-foo', 'foo'))
+      ).rejects.toThrow()
     })
 
-    it('extracts the file supplied in ARCHIVE_FILE', () => {
+    it('extracts the file supplied in ARCHIVE_FILE', async () => {
       const testDir = 'extractArchiveFile'
-      fs.mkdirSync(path.join(testDir, 'update'), { recursive: true })
+      await fs.mkdir(path.join(testDir, 'update'), { recursive: true })
 
-      const ret = runScriptSyncAndExpectSuccess(
+      const ret = await runScriptAndExpectSuccess(
         'extract',
         { testDir, env: { ARCHIVE_FILE: '../__fixtures__/govuk-prototype-kit-foo.zip' }, trace: true }
       )
@@ -380,82 +394,82 @@ describe('update.sh', () => {
   })
 
   describe('copy', () => {
-    it('updating an existing up-to-date prototype does nothing', () => {
-      const testDir = mktestPrototypeSync('up-to-date')
+    it('updating an existing up-to-date prototype does nothing', async () => {
+      const testDir = await mktestPrototype('up-to-date')
 
-      runScriptSyncAndExpectSuccess('copy', { testDir })
+      await runScriptAndExpectSuccess('copy', { testDir })
 
       // expect that `git status` reports no files added, changed, or removed
-      expect(execGitStatusSync(testDir)).toEqual([])
+      expect(await execGitStatus(testDir)).toEqual([])
     })
 
-    it('does not remove the analytics consent', () => {
-      const testDir = mktestPrototypeSync('usage-data-config')
+    it('does not remove the analytics consent', async () => {
+      const testDir = await mktestPrototype('usage-data-config')
 
-      const oldStat = fs.statSync(path.join(testDir, 'usage-data-config.json'))
+      const oldStat = await fs.stat(path.join(testDir, 'usage-data-config.json'))
 
-      runScriptSyncAndExpectSuccess('copy', { testDir })
+      await runScriptAndExpectSuccess('copy', { testDir })
 
-      const newStat = fs.statSync(path.join(testDir, 'usage-data-config.json'))
+      const newStat = await fs.stat(path.join(testDir, 'usage-data-config.json'))
       expect(newStat.mtimeMs).toBe(oldStat.mtimeMs)
     })
 
-    it('removes files that have been removed from docs, build and lib folders', () => {
-      const testDir = mktestPrototypeSync('remove-dangling-files')
+    it('removes files that have been removed from docs, build and lib folders', async () => {
+      const testDir = await mktestPrototype('remove-dangling-files')
 
       const updateDir = path.join(testDir, 'update')
-      fs.unlinkSync(path.join(updateDir, 'lib', 'build', 'config.json'))
-      fs.unlinkSync(path.join(updateDir, 'lib', 'v6', 'govuk_template_unbranded.html'))
-      fs.rmdirSync(path.join(updateDir, 'lib', 'v6'))
+      await fs.unlink(path.join(updateDir, 'lib', 'build', 'config.json'))
+      await fs.unlink(path.join(updateDir, 'lib', 'v6', 'govuk_template_unbranded.html'))
+      await fs.rmdir(path.join(updateDir, 'lib', 'v6'))
 
-      runScriptSyncAndExpectSuccess('copy', { testDir })
+      await runScriptAndExpectSuccess('copy', { testDir })
 
-      expect(execGitStatusSync(testDir)).toEqual([
+      expect(await execGitStatus(testDir)).toEqual([
         ' D lib/build/config.json',
         ' D lib/v6/govuk_template_unbranded.html'
       ])
     })
 
-    it('removes gulp files and adds build files if the release does not contain gulp', () => {
-      const testDir = mktestPrototypeSync('remove-gulp-files')
+    it('removes gulp files and adds build files if the release does not contain gulp', async () => {
+      const testDir = await mktestPrototype('remove-gulp-files')
 
-      fs.mkdirSync(path.join(testDir, 'gulp'))
-      fs.writeFileSync(path.join(testDir, 'gulp', 'watch.js'), 'foo')
-      fs.writeFileSync(path.join(testDir, 'gulpfile.js'), 'bar')
-      child_process.execSync('git add gulp/watch.js gulpfile.js', { cwd: testDir })
-      child_process.execSync('git rm -r lib/build', { cwd: testDir })
-      child_process.execSync('git commit -q -m "Ensure gulp files exist"', { cwd: testDir })
+      await fs.mkdir(path.join(testDir, 'gulp'))
+      await fs.writeFile(path.join(testDir, 'gulp', 'watch.js'), 'foo')
+      await fs.writeFile(path.join(testDir, 'gulpfile.js'), 'bar')
+      await execPromise('git add gulp/watch.js gulpfile.js', { cwd: testDir })
+      await execPromise('git rm -r lib/build', { cwd: testDir })
+      await execPromise('git commit -q -m "Ensure gulp files exist"', { cwd: testDir })
 
-      runScriptSyncAndExpectSuccess('copy', { testDir })
+      await runScriptAndExpectSuccess('copy', { testDir })
 
-      expect(execGitStatusSync(testDir)).toEqual([
+      expect(await execGitStatus(testDir)).toEqual([
         ' D gulp/watch.js',
         ' D gulpfile.js',
         '?? lib/build/'
       ])
     })
 
-    it('does not change files in apps folder, except for in assets/sass/patterns', () => {
-      const testDir = mktestPrototypeSync('preserve-app-folder')
+    it('does not change files in apps folder, except for in assets/sass/patterns', async () => {
+      const testDir = await mktestPrototype('preserve-app-folder')
 
       const updateDir = path.join(testDir, 'update')
-      fs.mkdirSync(path.join(updateDir, 'app', 'assets', 'sass', 'patterns'))
-      fs.writeFileSync(path.join(updateDir, 'app', 'assets', 'sass', 'patterns', '_task-list.scss'), 'foobar')
-      fs.writeFileSync(path.join(updateDir, 'app', 'routes.js'), 'arglebargle')
+      await fs.mkdir(path.join(updateDir, 'app', 'assets', 'sass', 'patterns'))
+      await fs.writeFile(path.join(updateDir, 'app', 'assets', 'sass', 'patterns', '_task-list.scss'), 'foobar')
+      await fs.writeFile(path.join(updateDir, 'app', 'routes.js'), 'arglebargle')
 
-      runScriptSyncAndExpectSuccess('copy', { testDir })
+      await runScriptAndExpectSuccess('copy', { testDir })
 
-      expect(execGitStatusSync(testDir)).toEqual([
+      expect(await execGitStatus(testDir)).toEqual([
         '?? app/assets/sass/patterns/'
       ])
     })
 
-    it('it outputs errors and logs them to a file', () => {
-      const testDir = mktestDirSync('error-logging')
-      mktestArchiveSync(testDir)
+    it('outputs errors and logs them to a file', async () => {
+      const testDir = await mktestDir('error-logging')
+      await mktestArchive(testDir)
 
-      runScriptSyncAndExpectSuccess('extract', { testDir })
-      const ret = runScriptSync('copy', { testDir })
+      await runScriptAndExpectSuccess('extract', { testDir })
+      const ret = await runScript('copy', { testDir })
 
       // we expect this to fail because the test archive doesn't have a docs folder
       expect(ret.status).toBe(1)
@@ -463,45 +477,45 @@ describe('update.sh', () => {
       expect(ret.stderr).toMatch(/No such file or directory/)
       expect(ret.stderr).toMatch(/ERROR/)
       expect(
-        fs.readFileSync(path.join(testDir, 'update', 'update.log'), 'utf8')
+        await fs.readFile(path.join(testDir, 'update', 'update.log'), 'utf8')
       ).toMatch(/No such file or directory/)
     })
 
-    it('hides the update folder from git', () => {
-      const testDir = mktestPrototypeSync('copy-gitignore')
+    it('hides the update folder from git', async () => {
+      const testDir = await mktestPrototype('copy-gitignore')
 
-      runScriptSyncAndExpectSuccess('copy', { testDir })
+      await runScriptAndExpectSuccess('copy', { testDir })
 
       expect(
-        fs.readFileSync(path.join(testDir, 'update', '.gitignore'), 'utf8').trim()
+        (await fs.readFile(path.join(testDir, 'update', '.gitignore'), 'utf8')).trim()
       ).toBe('*')
     })
   })
 
-  it('can be run as a piped script', () => {
-    const testDir = mktestPrototypeSync('pipe')
+  it('can be run as a piped script', async () => {
+    const testDir = await mktestPrototype('pipe')
 
-    child_process.execSync(`cat '${script}' | bash`, { cwd: testDir, shell: bash, stdio: 'ignore' })
+    execPromise(`cat '${script}' | bash`, { cwd: testDir, shell: bash, stdio: 'ignore' })
   })
 
-  it('hides the update folder from git', () => {
-    const testDir = mktestPrototypeSync('gitignore')
+  it('hides the update folder from git', async () => {
+    const testDir = await mktestPrototype('gitignore')
 
-    runScriptSyncAndExpectSuccess({ testDir })
+    await runScriptAndExpectSuccess({ testDir })
 
-    expect(execGitStatusSync(testDir)).not.toContain('?? update/')
+    expect(await execGitStatus(testDir)).not.toContain('?? update/')
   })
 
-  it('does nothing if check fails', () => {
-    const testDir = mktestPrototypeSync('if-check-fails')
-    child_process.execSync('rm -rf update', { cwd: testDir })
+  it('does nothing if check fails', async () => {
+    const testDir = await mktestPrototype('if-check-fails')
+    await execPromise('rm -rf update', { cwd: testDir })
 
-    fs.writeFileSync(path.join(testDir, 'package.json'), '{\n  "name": "my-very-customised-prototype" \n}')
-    child_process.execSync('git commit -q -m "Customise my prototype" -a', { cwd: testDir })
+    await fs.writeFile(path.join(testDir, 'package.json'), '{\n  "name": "my-very-customised-prototype" \n}')
+    await execPromise('git commit -q -m "Customise my prototype" -a', { cwd: testDir })
 
-    runScriptSyncAndExpectError({ testDir })
+    await runScriptAndExpectError({ testDir })
 
-    expect(execGitStatusSync(testDir)).toEqual([])
+    expect(await execGitStatus(testDir)).toEqual([])
   })
 
   afterAll(() => {

--- a/__tests__/util/globalSetup.js
+++ b/__tests__/util/globalSetup.js
@@ -1,6 +1,9 @@
+const { mkReleaseArchive } = require('./index')
 
 module.exports = async function () {
   process.stdout.write('\nDoing global setup...')
   process.env.KIT_JEST_RUN_ID = process.ppid
+  const releaseArchive = await mkReleaseArchive()
   process.stdout.write('done\n')
+  process.stdout.write(`Test release archive is at '${releaseArchive}'\n`)
 }

--- a/__tests__/util/globalSetup.js
+++ b/__tests__/util/globalSetup.js
@@ -1,0 +1,6 @@
+
+module.exports = async function () {
+  process.stdout.write('\nDoing global setup...')
+  process.env.KIT_JEST_RUN_ID = process.ppid
+  process.stdout.write('done\n')
+}

--- a/__tests__/util/index.js
+++ b/__tests__/util/index.js
@@ -1,8 +1,10 @@
 const child_process = require('child_process') // eslint-disable-line camelcase
+const execPromise = require('util').promisify(child_process.exec)
 const fs = require('fs')
 const os = require('os')
 const path = require('path')
 
+const lockfile = require('proper-lockfile')
 const tar = require('tar')
 
 const repoDir = path.resolve(__dirname, '..', '..')
@@ -19,13 +21,28 @@ function getJestId () {
   return `jest.${process.env.KIT_JEST_RUN_ID || process.ppid}`
 }
 
+function _mkdtempPath () {
+  return path.join(os.tmpdir(), getJestId())
+}
+
 /**
  * Returns the temporary directory path for this Jest test run
  *
  * @returns {string}
  */
+async function mkdtemp () {
+  const tempdir = _mkdtempPath()
+  await fs.promises.mkdir(tempdir, { recursive: true })
+  return tempdir
+}
+
+/**
+ * Synchronous version of `mkdtemp()`.
+ *
+ * @returns {string}
+ */
 function mkdtempSync () {
-  const tempdir = path.join(os.tmpdir(), getJestId())
+  const tempdir = _mkdtempPath()
   fs.mkdirSync(tempdir, { recursive: true })
   return tempdir
 }
@@ -55,6 +72,19 @@ function getWorktreeCommit () {
   return _worktreeCommit
 }
 
+function _mkReleaseArchiveOptions ({ archiveType = 'tar', dir } = {}) {
+  dir = dir || path.join(mkdtempSync(), '__fixtures__')
+  const commitRef = getWorktreeCommit()
+  const releaseName = process.env.KIT_JEST_RUN_ID
+    ? getJestId() : commitRef
+  const name = `govuk-prototype-kit-${releaseName}`
+  const archive = path.format({ dir, name, ext: '.' + archiveType })
+
+  const script = `node scripts/create-release-archive --releaseName ${releaseName} --destDir ${dir} --archiveType ${archiveType} ${commitRef}`
+
+  return { archive, archiveType, commitRef, dir, releaseName, script }
+}
+
 /**
  * Return a path to the release archive for the current git worktree
  *
@@ -67,32 +97,85 @@ function getWorktreeCommit () {
  * @param {string} [options.dir] - The folder to place the archive in, by default is a fixture folder in the temporary directory
  * @returns {string} - The absolute path to the archive
  */
-function mkReleaseArchiveSync ({ archiveType = 'tar', dir } = {}) {
-  dir = dir || path.join(mkdtempSync(), '__fixtures__')
-  const commitRef = getWorktreeCommit()
-  const releaseName = process.env.KIT_JEST_RUN_ID
-    ? getJestId() : commitRef
-  const name = `govuk-prototype-kit-${releaseName}`
-  const archive = path.format({ dir, name, ext: '.' + archiveType })
+async function mkReleaseArchive (options) {
+  options = _mkReleaseArchiveOptions(options)
 
-  fs.mkdirSync(dir, { recursive: true })
+  await fs.promises.mkdir(options.dir, { recursive: true })
 
-  try {
-    fs.accessSync(archive)
-  } catch (err) {
-    child_process.execSync(
-      `node scripts/create-release-archive --releaseName ${releaseName} --destDir ${dir} --archiveType ${archiveType} ${commitRef}`,
-      { cwd: repoDir }
-    )
+  while (!fs.existsSync(options.archive)) {
+    try {
+      const releaseLock = await lockfile.lock(options.archive, { realpath: false, retries: 5 })
+      if (!fs.existsSync(options.archive)) {
+        await execPromise(options.script, { cwd: repoDir })
+      }
+      await releaseLock()
+    } catch (err) {
+      continue
+    }
   }
 
-  return archive
+  return options.archive
+}
+
+/**
+ *
+ * Synchronous version of `mkReleaseArchive()`.
+ *
+ * Note: if you call this function five times in quick succession with the
+ * same arguments, it will happily start running five process to make the same
+ * archive five times. This is usually bad for your computer. If you have
+ * multiple processes that need to get the same release archive (such as in for
+ * the Jest tests), use the async version.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.archiveType=tar] - The type of archive to make, tar or zip
+ * @param {string} [options.dir] - The folder to place the archive in, by default is a fixture folder in the temporary directory
+ * @returns {string} - The absolute path to the archive
+ */
+function mkReleaseArchiveSync (options) {
+  options = _mkReleaseArchiveOptions(options)
+
+  fs.mkdirSync(options.dir, { recursive: true })
+
+  try {
+    fs.accessSync(options.archive)
+  } catch (err) {
+    child_process.execSync(options.script, { cwd: options.repoDir })
+  }
+
+  return options.archive
 }
 
 /**
  * Create a test prototype from the current release archive
  *
  * Creates a prototype at `prototypePath`.
+ *
+ * @param {string} prototypePath
+ * @param {Object} [options]
+ * @param {string} [options.archivePath] - Path to archive to use to create prototype, if not provided uses mkReleaseArchive
+ * @returns {void}
+ */
+async function mkPrototype (prototypePath, { archivePath, overwrite = false } = {}) {
+  if (!overwrite && fs.existsSync(prototypePath)) {
+    const err = new Error(`path already exists '${prototypePath}'`)
+    err.path = prototypePath
+    err.code = 'EEXIST'
+    throw err
+  }
+
+  archivePath = archivePath || await mkReleaseArchive()
+
+  await fs.promises.mkdir(prototypePath, { recursive: true })
+
+  await tar.extract({ cwd: prototypePath, file: archivePath, strip: 1 })
+}
+
+/**
+ * Synchronous version of `mkPrototype()`
+ *
+ * See the note in the docstring for `mkReleaseArchive()` for a warning against
+ * using this function. Prefer the async version where possible.
  *
  * @param {string} prototypePath
  * @param {Object} [options]
@@ -115,7 +198,10 @@ function mkPrototypeSync (prototypePath, { archivePath, overwrite = false } = {}
 }
 
 module.exports = {
+  mkdtemp,
   mkdtempSync,
+  mkReleaseArchive,
   mkReleaseArchiveSync,
+  mkPrototype,
   mkPrototypeSync
 }

--- a/__tests__/util/index.js
+++ b/__tests__/util/index.js
@@ -10,12 +10,22 @@ const repoDir = path.resolve(__dirname, '..', '..')
 var _worktreeCommit
 
 /**
- * Returns the temporary directory path for this jest process
+ * An ID that will be shared between all process in the same Jest test run,
+ * this is useful for sharing fixture files. Normally sharing state across Jest
+ * test files is bad practice, however with our functions to create release
+ * scripts that can take up to half a minute we really do want to share state.
+ */
+function getJestId () {
+  return `jest.${process.env.KIT_JEST_RUN_ID || process.ppid}`
+}
+
+/**
+ * Returns the temporary directory path for this Jest test run
  *
  * @returns {string}
  */
 function mkdtempSync () {
-  const tempdir = path.join(os.tmpdir(), `jest.${process.ppid}.${process.pid}`)
+  const tempdir = path.join(os.tmpdir(), getJestId())
   fs.mkdirSync(tempdir, { recursive: true })
   return tempdir
 }

--- a/__tests__/util/index.js
+++ b/__tests__/util/index.js
@@ -70,7 +70,9 @@ function getWorktreeCommit () {
 function mkReleaseArchiveSync ({ archiveType = 'tar', dir } = {}) {
   dir = dir || path.join(mkdtempSync(), '__fixtures__')
   const commitRef = getWorktreeCommit()
-  const name = `govuk-prototype-kit-${commitRef}`
+  const releaseName = process.env.KIT_JEST_RUN_ID
+    ? getJestId() : commitRef
+  const name = `govuk-prototype-kit-${releaseName}`
   const archive = path.format({ dir, name, ext: '.' + archiveType })
 
   fs.mkdirSync(dir, { recursive: true })
@@ -79,7 +81,7 @@ function mkReleaseArchiveSync ({ archiveType = 'tar', dir } = {}) {
     fs.accessSync(archive)
   } catch (err) {
     child_process.execSync(
-      `node scripts/create-release-archive --releaseName ${commitRef} --destDir ${dir} --archiveType ${archiveType} ${commitRef}`,
+      `node scripts/create-release-archive --releaseName ${releaseName} --destDir ${dir} --archiveType ${archiveType} ${commitRef}`,
       { cwd: repoDir }
     )
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "eslint-plugin-cypress": "^2.12.1",
         "glob": "^7.1.4",
         "jest": "^28.1.1",
+        "proper-lockfile": "^4.1.2",
         "standard": "^14.3.3",
         "start-server-and-test": "^1.14.0",
         "supertest": "^6.2.3",
@@ -9974,6 +9975,17 @@
         "react-is": "^16.8.1"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -10283,6 +10295,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -19773,6 +19794,17 @@
         "react-is": "^16.8.1"
       }
     },
+    "proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -20003,6 +20035,12 @@
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       }
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true
     },
     "reusify": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     }
   },
   "jest": {
+    "globalSetup": "<rootDir>/__tests__/util/globalSetup.js",
     "testPathIgnorePatterns": [
       "__tests__/util/",
       "/node_modules/",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint-plugin-cypress": "^2.12.1",
     "glob": "^7.1.4",
     "jest": "^28.1.1",
+    "proper-lockfile": "^4.1.2",
     "standard": "^14.3.3",
     "start-server-and-test": "^1.14.0",
     "supertest": "^6.2.3",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
       "__tests__/util/",
       "/node_modules/",
       "/tmp/"
-    ]
+    ],
+    "testTimeout": 30000
   }
 }


### PR DESCRIPTION
It turns out that if you start the `create-release-archive` script running five times with the same arguments, it will happily start running five process to make the same archive five times. This is usually bad for your computer. Unfortunately, this is exactly what running Jest on a local machine does; I found that every time I ran the tests my computer would just freeze up (even music would stop playing) as it chewed through creating all the release archives.

This PR tries to stop this from happening, by making all the process use the same release archive. When one of the tests asks for a release archive that doesn't exist, it first acquires a lockfile, which tells any other tests that want the same release archive that they should wait for the first test to finish. Unfortunately, the waiting part is not possible with synchronous Node :scream: So we have to make a load of async versions of our test functions, and rewrite all our tests to be async :sob: