### PR TITLE
Add scripts to files to be linted

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "node start",
     "build": "node lib/build/generate-assets",
     "serve": "node listen-on-port",
-    "lint": "standard",
+    "lint": "standard **/*.js scripts/create-release-archive lib/build/dev-server lib/build/generate-assets",
     "rapidtest": "jest --bail",
     "cypress:open": "cypress open",
     "test:heroku": "start-server-and-test 'npx --yes heroku local --port 3000' 3000 test:smoke",


### PR DESCRIPTION
Some of our scripts don't have the `.js` file extension that standard is looking for, so they get missed by `npm run lint`. This commit fixes that by adding the scripts to the default lint command. We'll have to remember to keep this updated when we add new scripts or rename old scripts to remove the file extension.

Unfortunately there isn' a way to configure standard to get the list of files to lint from config, or from a file - I read the source code in `standard-engine` [[1]] to check.

[1]: https://github.com/standard/standard-engine/blob/master/bin/cmd.js