### PR TITLE
Fix bug with release archive script when destDir is a relative path

### DIFF
--- a/scripts/create-release-archive
+++ b/scripts/create-release-archive
@@ -101,7 +101,7 @@ function cli () {
 
   // insert a blank line for niceness
   console.log()
-  console.log(`Saved release archive to ${argv.dest ? argv.dest : ''}${releaseArchive}`)
+  console.log(`Saved release archive to ${path.join(argv.dest ? argv.dest : '', releaseArchive)}`)
 
   // Clean up
   fs.rmdirSync(workdir, { recursive: true })
@@ -174,7 +174,7 @@ function archiveReleaseFiles ({ cwd, file, prefix }) {
     zipCreate(
       {
         cwd: cwd,
-        file: file,
+        file: path.resolve(file),
         exclude: path.join(prefix, 'node_modules', '*')
       },
       prefix

--- a/scripts/create-release-archive.test.js
+++ b/scripts/create-release-archive.test.js
@@ -125,7 +125,7 @@ describe('scripts/create-release-archive', () => {
   })
 
   describe('archiveReleaseFiles', () => {
-    let mockSpawnSync
+    let mockSpawnSync, mockTarCreate
 
     beforeEach(() => {
       mockSpawnSync = jest.spyOn(child_process, 'spawnSync').mockImplementation(() => ({ status: 0 }))
@@ -142,6 +142,21 @@ describe('scripts/create-release-archive', () => {
       } else {
         expect(mockSpawnSync).toBeCalledWith(
           'zip', ['--exclude', 'test/node_modules/*', '-r', '/test.zip', 'test'],
+          expect.objectContaining({ cwd: '/tmp' })
+        )
+      }
+    })
+
+    it('resolves paths correctly for arguments to zip', () => {
+      createReleaseArchive.archiveReleaseFiles({ cwd: '/tmp', file: 'test.zip', prefix: 'test' })
+      if (process.platform === 'win32') {
+        expect(mockSpawnSync).toBeCalledWith(
+          '7z', ['a', '-tzip', '-x!test\\node_modules', path.join(repoDir, 'test.zip'), 'test'],
+          expect.objectContaining({ cwd: '/tmp' })
+        )
+      } else {
+        expect(mockSpawnSync).toBeCalledWith(
+          'zip', ['--exclude', 'test/node_modules/*', '-r', path.join(repoDir, 'test.zip'), 'test'],
           expect.objectContaining({ cwd: '/tmp' })
         )
       }

--- a/scripts/create-release-archive.test.js
+++ b/scripts/create-release-archive.test.js
@@ -133,13 +133,14 @@ describe('scripts/create-release-archive', () => {
     })
 
     it('zips release files by default', () => {
-      createReleaseArchive.archiveReleaseFiles({ cwd: '/tmp', file: '/test.zip', prefix: 'test' })
       if (process.platform === 'win32') {
+        createReleaseArchive.archiveReleaseFiles({ cwd: 'C:\\tmp', file: 'C:\\test.zip', prefix: 'test' })
         expect(mockSpawnSync).toBeCalledWith(
-          '7z', ['a', '-tzip', '-x!test\\node_modules', '/test.zip', 'test'],
-          expect.objectContaining({ cwd: '/tmp' })
+          '7z', ['a', '-tzip', '-x!test\\node_modules', 'C:\\test.zip', 'test'],
+          expect.objectContaining({ cwd: 'C:\\tmp' })
         )
       } else {
+        createReleaseArchive.archiveReleaseFiles({ cwd: '/tmp', file: '/test.zip', prefix: 'test' })
         expect(mockSpawnSync).toBeCalledWith(
           'zip', ['--exclude', 'test/node_modules/*', '-r', '/test.zip', 'test'],
           expect.objectContaining({ cwd: '/tmp' })
@@ -148,13 +149,14 @@ describe('scripts/create-release-archive', () => {
     })
 
     it('resolves paths correctly for arguments to zip', () => {
-      createReleaseArchive.archiveReleaseFiles({ cwd: '/tmp', file: 'test.zip', prefix: 'test' })
       if (process.platform === 'win32') {
+        createReleaseArchive.archiveReleaseFiles({ cwd: 'C:\\tmp', file: 'test.zip', prefix: 'test' })
         expect(mockSpawnSync).toBeCalledWith(
           '7z', ['a', '-tzip', '-x!test\\node_modules', path.join(repoDir, 'test.zip'), 'test'],
-          expect.objectContaining({ cwd: '/tmp' })
+          expect.objectContaining({ cwd: 'C:\\tmp' })
         )
       } else {
+        createReleaseArchive.archiveReleaseFiles({ cwd: '/tmp', file: 'test.zip', prefix: 'test' })
         expect(mockSpawnSync).toBeCalledWith(
           'zip', ['--exclude', 'test/node_modules/*', '-r', path.join(repoDir, 'test.zip'), 'test'],
           expect.objectContaining({ cwd: '/tmp' })


### PR DESCRIPTION
If `--destDir` is a relative path then the create-release-archive script will put the release in the wrong place, or won't be able to create it because the expected directory doesn't exist.

Fix the script so it resolves the file argument to zip/7z.