### PR TITLE
Allow updating test prototype in tmp folder

### DIFF
--- a/__tests__/spec/release-archive.js
+++ b/__tests__/spec/release-archive.js
@@ -1,7 +1,8 @@
 /* eslint-env jest */
 
-const childProcess = require('child_process')
 const path = require('path')
+
+const tar = require('tar')
 
 const utils = require('../util')
 
@@ -12,14 +13,16 @@ describe('release archive', () => {
   beforeAll(() => {
     archivePath = utils.mkReleaseArchiveSync()
 
-    console.log(`test release archive saved to ${archivePath}`)
+    archiveFiles = []
 
-    archiveFiles = childProcess.execSync(`zipinfo -1 ${archivePath}`, { encoding: 'utf8' })
-      .trim().split('\n').map(
-        p => p.substring(path.parse(archivePath).name.length + 1)
-      ).filter(
-        p => p
-      )
+    tar.list({
+      file: archivePath,
+      onentry: (entry) => {
+        const p = entry.path.substring(path.parse(archivePath).name.length + 1)
+        if (p) { archiveFiles.push(p) }
+      },
+      sync: true
+    })
   })
 
   it('contains the prototype kit files', () => {

--- a/__tests__/spec/release-archive.js
+++ b/__tests__/spec/release-archive.js
@@ -50,9 +50,8 @@ describe('release archive', () => {
     expect(archiveFiles).not.toContain('cypress/')
     expect(archiveFiles).not.toContain('cypress.json')
 
-    expect(archiveFiles).not.toContainEqual(
-      expect.stringMatching(/.*\.test\.js$/)
-    )
+    expect(archiveFiles.filter(p => /.*\.test\.js$/.test(p)))
+      .toEqual([])
   })
 
   it('does not contain internal files', () => {

--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -188,9 +188,6 @@ describe('update.sh', () => {
 
   function _mktestPrototypeSync (src) {
     // Create a release archive from the HEAD we are running tests in
-    const archivePath = utils.mkReleaseArchiveSync()
-    const releaseDir = path.parse(archivePath).name
-
     utils.mkPrototypeSync(src)
 
     // Create a git repo from the new release archive so we can see changes.
@@ -212,9 +209,7 @@ describe('update.sh', () => {
     child_process.execFileSync('git', ['commit', '-m', 'Test', '-a'], { cwd: src })
 
     // populate the update folder to speed up tests
-    child_process.execSync(`unzip -q ${archivePath}`, { cwd: src })
-    child_process.execSync(`mv ${releaseDir} update`, { cwd: src })
-    fs.copyFileSync(archivePath, path.join(src, 'update', path.basename(archivePath)))
+    utils.mkPrototypeSync(path.join(src, 'update'))
   }
 
   function mktestPrototypeSync (dest) {

--- a/__tests__/util/index.js
+++ b/__tests__/util/index.js
@@ -87,8 +87,8 @@ function mkReleaseArchiveSync ({ archiveType = 'tar', dir } = {}) {
  * @param {string} [options.archivePath] - Path to archive to use to create prototype, if not provided uses mkReleaseArchiveSync
  * @returns {void}
  */
-function mkPrototypeSync (prototypePath, { archivePath } = {}) {
-  if (fs.existsSync(prototypePath)) {
+function mkPrototypeSync (prototypePath, { archivePath, overwrite = false } = {}) {
+  if (!overwrite && fs.existsSync(prototypePath)) {
     const err = new Error(`path already exists '${prototypePath}'`)
     err.path = prototypePath
     err.code = 'EEXIST'

--- a/__tests__/util/index.js
+++ b/__tests__/util/index.js
@@ -3,6 +3,8 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 
+const tar = require('tar')
+
 const repoDir = path.resolve(__dirname, '..', '..')
 
 var _worktreeCommit
@@ -51,11 +53,11 @@ function getWorktreeCommit () {
  * not untracked changes.
  *
  * @param {Object} [options]
- * @param {string} [options.archiveType=zip] - The type of archive to make, tar or zip
+ * @param {string} [options.archiveType=tar] - The type of archive to make, tar or zip
  * @param {string} [options.dir] - The folder to place the archive in, by default is a fixture folder in the temporary directory
  * @returns {string} - The absolute path to the archive
  */
-function mkReleaseArchiveSync ({ archiveType = 'zip', dir } = {}) {
+function mkReleaseArchiveSync ({ archiveType = 'tar', dir } = {}) {
   dir = dir || path.join(mkdtempSync(), '__fixtures__')
   const commitRef = getWorktreeCommit()
   const name = `govuk-prototype-kit-${commitRef}`
@@ -94,15 +96,10 @@ function mkPrototypeSync (prototypePath, { archivePath } = {}) {
   }
 
   archivePath = archivePath || mkReleaseArchiveSync()
-  const releaseDir = path.parse(archivePath).name
 
-  const parentDir = path.dirname(prototypePath)
-  const name = path.basename(prototypePath)
+  fs.mkdirSync(prototypePath, { recursive: true })
 
-  fs.mkdirSync(parentDir, { recursive: true })
-
-  child_process.execSync(`unzip -q ${archivePath}`, { cwd: parentDir })
-  child_process.execSync(`mv ${releaseDir} ${name}`, { cwd: parentDir })
+  tar.extract({ cwd: prototypePath, file: archivePath, strip: 1, sync: true })
 }
 
 module.exports = {

--- a/cypress/scripts/run-from-release.js
+++ b/cypress/scripts/run-from-release.js
@@ -9,15 +9,7 @@ const testDir = path.resolve(process.env.KIT_TEST_DIR || 'tmp/test-prototype')
 console.log('getting release archive...')
 const releaseArchive = utils.mkReleaseArchiveSync({ dir: path.resolve('tmp') })
 console.log(`using test release archive ${path.relative('', releaseArchive)}`)
-
-try {
-  utils.mkPrototypeSync(testDir, { archivePath: releaseArchive })
-} catch (error) {
-  /* assume it is okay if prototype exists already */
-  if (error.code !== 'EEXIST') {
-    throw error
-  }
-}
+utils.mkPrototypeSync(testDir, { archivePath: releaseArchive, overwrite: true })
 
 console.log(`running tests in ${path.relative('', testDir)}`)
 process.chdir(testDir)

--- a/scripts/create-release-archive
+++ b/scripts/create-release-archive
@@ -184,7 +184,7 @@ function archiveReleaseFiles ({ cwd, file, prefix }) {
       {
         cwd: cwd,
         file: file,
-        filter: (p) => !p.startsWith(path.join(prefix, 'node_modules')),
+        filter: (p) => !p.startsWith(path.posix.join(prefix, 'node_modules')),
         portable: true,
         sync: true
       },


### PR DESCRIPTION
The run-from-release script used to silently ignore a newer release archive if there was already a test prototype in the directory; which in hindsight isn't very helpful. Instead we let `mkPrototypeSync` overwrite existing files. There's still a chance that I might get my test prototype in a weird state, but there's a better chance now that it will actually run the code I just wrote.

This PR also switches the tests to use tar for creating test release archives, partly in a bid to make the tests slightly faster, and also to allow the overwrite behaviour without having to use the 'dangerous' overwrite option for `unzip`.