### PR TITLE
Set Integration test default timeouts

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,9 @@
 {
   "baseUrl": "http://localhost:3000",
   "testFiles": "**/*.cypress.js",
+  "requestTimeout": 2000,
+  "defaultCommandTimeout": 40000,
+  "retries": 3,
   "video": false,
   "chromeWebSecurity": false
 }

--- a/cypress.json
+++ b/cypress.json
@@ -3,6 +3,7 @@
   "testFiles": "**/*.cypress.js",
   "requestTimeout": 20000,
   "defaultCommandTimeout": 40000,
+  "pageLoadTimeout": 120000,
   "retries": 3,
   "video": false,
   "chromeWebSecurity": false

--- a/cypress.json
+++ b/cypress.json
@@ -1,7 +1,7 @@
 {
   "baseUrl": "http://localhost:3000",
   "testFiles": "**/*.cypress.js",
-  "requestTimeout": 2000,
+  "requestTimeout": 20000,
   "defaultCommandTimeout": 40000,
   "retries": 3,
   "video": false,

--- a/cypress/integration/1-watch-files/watch-custom-styles.cypress.js
+++ b/cypress/integration/1-watch-files/watch-custom-styles.cypress.js
@@ -29,13 +29,13 @@ describe('watch custom sass files', () => {
       // delete temporary files
       cy.task('deleteFile', { filename: path.join(Cypress.env('projectFolder'), publicStylesheet) })
       cy.task('deleteFile', { filename: customStyleFile })
-      cy.get('.govuk-header', { timeout: 20000 }).should('have.css', 'background-color', BLACK)
+      cy.get('.govuk-header').should('have.css', 'background-color', BLACK)
       cy.task('deleteFile', { filename: backupHeadView })
     })
 
     it('The colour of the header should be changed to green then back to black', () => {
       cy.task('log', 'The colour of the header should be black')
-      cy.get('.govuk-header', { timeout: 20000 }).should('have.css', 'background-color', BLACK)
+      cy.get('.govuk-header').should('have.css', 'background-color', BLACK)
 
       cy.task('log', `Create ${customStyleFile}`)
       cy.task('createFile', {
@@ -54,7 +54,7 @@ describe('watch custom sass files', () => {
       })
 
       cy.task('log', 'The colour of the header should be changed to green')
-      cy.get('.govuk-header', { timeout: 20000 }).should('have.css', 'background-color', GREEN)
+      cy.get('.govuk-header').should('have.css', 'background-color', GREEN)
     })
   })
 })

--- a/cypress/integration/1-watch-files/watch-images.cypress.js
+++ b/cypress/integration/1-watch-files/watch-images.cypress.js
@@ -28,7 +28,7 @@ describe('watch image files', () => {
     cy.task('copyFile', { source, target })
 
     cy.task('log', `Requesting ${publicImage}`)
-    cy.request(`/${publicImage}`, { timeout: 20000, retryOnStatusCodeFailure: true })
+    cy.request(`/${publicImage}`, { retryOnStatusCodeFailure: true })
       .then(response => expect(response.status).to.eq(200))
   })
 })

--- a/cypress/integration/1-watch-files/watch-routes.cypress.js
+++ b/cypress/integration/1-watch-files/watch-routes.cypress.js
@@ -24,7 +24,7 @@ describe('watch route file', () => {
   it(`add and remove ${pageUrl} route`, () => {
     cy.task('log', 'The cypress test page should not be found')
     cy.visit(pageUrl, { failOnStatusCode: false })
-    cy.get('body', { timeout: 20000 })
+    cy.get('body')
       .should('contains.text', `Page not found: ${pagePath}`)
 
     cy.task('log', `Replace ${appRoutes} with Cypress routes`)
@@ -34,7 +34,7 @@ describe('watch route file', () => {
 
     cy.task('log', 'The cypress test page should be displayed')
     cy.visit(pageUrl)
-    cy.get('h1', { timeout: 20000 })
+    cy.get('h1')
       .should('contains.text', 'CYPRESS TEST PAGE')
 
     cy.task('log', `Restore ${appRoutes}`)
@@ -44,7 +44,7 @@ describe('watch route file', () => {
 
     cy.task('log', 'The cypress test page should not be found')
     cy.visit(pageUrl, { failOnStatusCode: false })
-    cy.get('body', { timeout: 20000 })
+    cy.get('body')
       .should('contains.text', `Page not found: ${pagePath}`)
   })
 })

--- a/cypress/integration/1-watch-files/watch-styles.cypress.js
+++ b/cypress/integration/1-watch-files/watch-styles.cypress.js
@@ -30,13 +30,13 @@ describe('watch sass files', () => {
 
       cy.task('deleteFile', { filename: cypressTestStylePattern })
 
-      cy.get('.govuk-header', { timeout: 20000 }).should('have.css', 'background-color', BLACK)
+      cy.get('.govuk-header').should('have.css', 'background-color', BLACK)
       cy.task('deleteFile', { filename: backupAppStylesheet })
     })
 
     it('The colour of the header should be changed to red then back to black', () => {
       cy.task('log', 'The colour of the header should be black')
-      cy.get('.govuk-header', { timeout: 20000 }).should('have.css', 'background-color', BLACK)
+      cy.get('.govuk-header').should('have.css', 'background-color', BLACK)
 
       cy.task('log', `Create ${cypressTestStylePattern}`)
       cy.task('createFile', {
@@ -53,7 +53,7 @@ describe('watch sass files', () => {
       })
 
       cy.task('log', 'The colour of the header should be changed to red')
-      cy.get('.govuk-header', { timeout: 20000 }).should('have.css', 'background-color', RED)
+      cy.get('.govuk-header').should('have.css', 'background-color', RED)
     })
   })
 })

--- a/cypress/integration/1-watch-files/watch-views.cypress.js
+++ b/cypress/integration/1-watch-files/watch-views.cypress.js
@@ -19,7 +19,7 @@ describe('watching start page', () => {
   it('Add and remove the start page', () => {
     cy.task('log', 'The start page should not be found')
     cy.visit(pagePath, { failOnStatusCode: false })
-    cy.get('body', { timeout: 20000 })
+    cy.get('body')
       .should('contains.text', `Page not found: ${pagePath}`)
 
     cy.task('log', `Copy ${templatesView} to ${appView}`)
@@ -27,7 +27,7 @@ describe('watching start page', () => {
 
     cy.task('log', 'The start page should be displayed')
     cy.visit(pagePath)
-    cy.get('h1', { timeout: 20000 })
+    cy.get('h1')
       .should('contains.text', 'Service name goes here')
   })
 })

--- a/cypress/integration/utils.js
+++ b/cypress/integration/utils.js
@@ -4,7 +4,7 @@ const waitForApplication = async () => {
   cy.task('log', 'Waiting for app to restart and load home page')
   cy.task('waitUntilAppRestarts')
   cy.visit('/')
-  cy.get('h1.govuk-heading-xl', { timeout: 20000 })
+  cy.get('h1.govuk-heading-xl')
     .should('contains.text', 'Prototype your service using GOV.UK Prototype Kit')
 }
 


### PR DESCRIPTION
Increase the default timeouts in the integration tests by specifying them in the cypress config file.  This also makes the tests cleaner as the override timeout option can be removed from the cypress commands.