### PR TITLE
Try and make the integration tests less flaky

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ usage-data-config.json
 # Prototype Kit ignores - developer tools
 /cypress/downloads
 /cypress/screenshots
-/cypress/support
 /cypress/temp
 /cypress/videos
 /govuk-prototype-kit*.zip

--- a/cypress/fixtures/custom-styles.html
+++ b/cypress/fixtures/custom-styles.html
@@ -1,0 +1,30 @@
+{% extends "layout.html" %}
+
+{% block head %}
+  {{ super() }}
+  <link href="/public/stylesheets/custom-styles.css" rel="stylesheet" type="text/css" />
+{% endblock head %}
+
+{% block pageTitle %}
+  Custom styles – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  <a class="govuk-back-link" href="javascript:window.history.back()">Back</a>
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-xl">
+        Custom styles
+      </h1>
+
+      <p class="app-custom-style">This is a paragraph of text. It has a custom style.</p>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/cypress/fixtures/larry-the-cat.html
+++ b/cypress/fixtures/larry-the-cat.html
@@ -1,0 +1,27 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Larry the cat – {{ serviceName }} – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  <a class="govuk-back-link" href="javascript:window.history.back()">Back</a>
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-xl">
+        Larry the cat
+      </h1>
+
+      <img id="larry" src="/public/images/larry-the-cat.jpg" alt="Larry the cat, Chief Mouser to the Cabinet Office, sitting on a meeting table wearing a Union Jack bowtie.">
+
+      <p>Read more <a href="/url/of/onward/page">about this topic</a>.</p>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/cypress/fixtures/sass/custom-styles.scss
+++ b/cypress/fixtures/sass/custom-styles.scss
@@ -1,0 +1,2 @@
+// Custom styles
+.app-custom-style { background: rgb(0, 255, 0); }

--- a/cypress/integration/1-watch-files/watch-custom-styles.cypress.js
+++ b/cypress/integration/1-watch-files/watch-custom-styles.cypress.js
@@ -27,6 +27,13 @@ describe('watch custom sass files', () => {
     })
 
     it('The colour of the paragraph should be changed to green', () => {
+      // FIXME: the expected behaviour is that it shouldn't make a difference
+      // whether the stylesheet exists or not, but currently for Browsersync to
+      // update the page properly the stylesheet has to be created first, so we
+      // create an empty one. See issue #1440 for more details.
+      cy.task('log', 'Create an empty custom stylesheet')
+      cy.task('createFile', { filename: customStylesAppPath, data: '// Custom styles\n' })
+
       cy.task('log', 'Create a page to view our custom styles')
       cy.task('copyFile', {
         source: pageFixturePath,

--- a/cypress/integration/1-watch-files/watch-custom-styles.cypress.js
+++ b/cypress/integration/1-watch-files/watch-custom-styles.cypress.js
@@ -2,59 +2,59 @@ const path = require('path')
 
 const { waitForApplication } = require('../utils')
 
-const customStyleFile = path.join(Cypress.env('projectFolder'), 'app', 'assets', 'sass', 'custom.scss')
-const appHeadView = path.join(Cypress.env('projectFolder'), 'app', 'views', 'includes', 'head.html')
-const backupHeadView = path.join(Cypress.env('tempFolder'), 'temp-head.html')
-const publicStylesheet = 'public/stylesheets/custom.css'
+const customStylesFixture = 'custom-styles'
+const customStylesFixtureName = `${customStylesFixture}.scss`
+const customStylesFixturePath = path.join(Cypress.config('fixturesFolder'), 'sass', customStylesFixtureName)
+const customStylesAppPath = path.join(Cypress.env('projectFolder'), 'app', 'assets', 'sass', customStylesFixtureName)
+const customStylesPublicPath = 'public/stylesheets/custom-styles.css'
 
-const GREEN = 'rgb(0, 255, 0)'
-const BLACK = 'rgb(11, 12, 12)'
+const pageFixture = 'custom-styles'
+const pageFixtureName = `${pageFixture}.html`
+const pageFixturePath = path.join(Cypress.config('fixturesFolder'), pageFixtureName)
+const pageAppPath = path.join(Cypress.env('projectFolder'), 'app', 'views', pageFixtureName)
 
 describe('watch custom sass files', () => {
-  describe(`sass file ${customStyleFile} should be created and linked within ${appHeadView} and accessible from the browser as /${publicStylesheet}`, () => {
-    const cssStatement = `
-    .govuk-header { background: ${GREEN}; }
-    `
-
-    before(() => {
+  describe(`sass file ${customStylesFixtureName} should be created and linked within ${pageFixturePath} and accessible from the browser as /${customStylesPublicPath}`, () => {
+    beforeEach(() => {
       waitForApplication()
-      // backup head view
-      cy.task('copyFile', { source: appHeadView, target: backupHeadView })
     })
 
     afterEach(() => {
-      // restore head view
-      cy.task('copyFile', { source: backupHeadView, target: appHeadView })
-
-      // delete temporary files
-      cy.task('deleteFile', { filename: path.join(Cypress.env('projectFolder'), publicStylesheet) })
-      cy.task('deleteFile', { filename: customStyleFile })
-      cy.get('.govuk-header').should('have.css', 'background-color', BLACK)
-      cy.task('deleteFile', { filename: backupHeadView })
+      // delete test files
+      cy.task('deleteFile', { filename: path.join(Cypress.env('projectFolder'), customStylesPublicPath) })
+      cy.task('deleteFile', { filename: customStylesAppPath })
+      cy.task('deleteFile', { filename: pageAppPath })
     })
 
-    it('The colour of the header should be changed to green then back to black', () => {
-      cy.task('log', 'The colour of the header should be black')
-      cy.get('.govuk-header').should('have.css', 'background-color', BLACK)
-
-      cy.task('log', `Create ${customStyleFile}`)
-      cy.task('createFile', {
-        filename: customStyleFile,
-        data: cssStatement
+    it('The colour of the paragraph should be changed to green', () => {
+      cy.task('log', 'Create a page to view our custom styles')
+      cy.task('copyFile', {
+        source: pageFixturePath,
+        target: pageAppPath
       })
 
-      cy.wait(6000)
+      cy.task('log', 'The colour of the paragraph should be black')
+      cy.visit(`/${pageFixture}`)
+      cy.get('p.app-custom-style').should('have.css', 'background-color', 'rgba(0, 0, 0, 0)')
 
-      cy.task('log', `Amend ${appHeadView} to link ${publicStylesheet}`)
-      cy.task('appendFile', {
-        filename: appHeadView,
-        data: `
-  <link href="/${publicStylesheet}" rel="stylesheet" type="text/css" />
-      `
+      cy.task('log', `Create ${customStylesAppPath}`)
+      cy.task('copyFile', {
+        source: customStylesFixturePath,
+        target: customStylesAppPath
       })
 
-      cy.task('log', 'The colour of the header should be changed to green')
-      cy.get('.govuk-header').should('have.css', 'background-color', GREEN)
+      // When we add our stylesheet, we expect Browsersync to detect that and
+      // tell the browser to fetch it, so let's wait for that resource to
+      // become available.
+      cy.task('log', 'Wait for the stylesheet to be loaded')
+      cy.waitForResource(`${customStylesFixture}.css`)
+
+      cy.task('log', 'The colour of the paragraph should be changed to green')
+      cy.get('p.app-custom-style').should('have.css', 'background-color', 'rgb(0, 255, 0)')
+
+      cy.task('log', `Request ${customStylesPublicPath}`)
+      cy.request(`/${customStylesPublicPath}`)
+        .then(response => expect(response.status).to.eq(200))
     })
   })
 })

--- a/cypress/integration/1-watch-files/watch-images.cypress.js
+++ b/cypress/integration/1-watch-files/watch-images.cypress.js
@@ -7,16 +7,22 @@ const cypressImages = path.join(Cypress.config('fixturesFolder'), 'images')
 const appImages = path.join(Cypress.env('projectFolder'), 'app', 'assets', 'images')
 const publicImages = 'public/images'
 
+const pageFixture = 'larry-the-cat'
+const pageFixtureName = `${pageFixture}.html`
+const pageFixturePath = path.join(Cypress.config('fixturesFolder'), pageFixtureName)
+const pageAppPath = path.join(Cypress.env('projectFolder'), 'app', 'views', pageFixtureName)
+
 describe('watch image files', () => {
   before(() => {
     waitForApplication()
   })
 
   afterEach(() => {
-    // delete temporary files
-    cy.task('deleteFile', { filename: path.join(Cypress.env('projectFolder'), publicImages, imageFile) })
-    cy.wait(2000)
+    // delete test files
     cy.task('deleteFile', { filename: path.join(appImages, imageFile) })
+    cy.task('deleteFile', { filename: path.join(Cypress.env('projectFolder'), publicImages, imageFile) })
+    cy.task('deleteFile', { filename: pageAppPath })
+    cy.wait(2000)
   })
 
   it(`image created in ${appImages} should be copied to ${publicImages} and accessible from the browser`, () => {
@@ -24,8 +30,35 @@ describe('watch image files', () => {
     const target = path.join(appImages, imageFile)
     const publicImage = `${publicImages}/${imageFile}`
 
-    cy.task('log', `Copying ${source} to ${target}`)
+    cy.task('log', 'Creating a page to view our image')
+    cy.task('copyFile', { source: pageFixturePath, target: pageAppPath })
+
+    cy.task('log', 'Our page should be missing its image')
+    cy.visit(`/${pageFixture}`)
+    cy.get('img#larry')
+      .should('be.visible')
+      .and(($img) => {
+        // "naturalWidth" and "naturalHeight" are set when the image loads
+        expect($img[0].naturalWidth).to.equal(0)
+      })
+
+    // When we do the copy, we expect the page to reload, so let's set up an
+    // intercept so we can wait for that request
+    cy.intercept(`/${pageFixture}`).as('reloadPage')
+
+    cy.task('log', 'Copying the image to the app folder')
     cy.task('copyFile', { source, target })
+
+    cy.task('log', 'Wait for the page to reload')
+    cy.wait('@reloadPage')
+
+    cy.task('log', 'Our page should now have its image')
+    cy.get('img#larry')
+      .should('be.visible')
+      .and(($img) => {
+        // "naturalWidth" and "naturalHeight" are set when the image loads
+        expect($img[0].naturalWidth).not.to.equal(0)
+      })
 
     cy.task('log', `Requesting ${publicImage}`)
     cy.request(`/${publicImage}`, { retryOnStatusCodeFailure: true })

--- a/cypress/integration/1-watch-files/watch-images.cypress.js
+++ b/cypress/integration/1-watch-files/watch-images.cypress.js
@@ -42,15 +42,18 @@ describe('watch image files', () => {
         expect($img[0].naturalWidth).to.equal(0)
       })
 
-    // When we do the copy, we expect the page to reload, so let's set up an
-    // intercept so we can wait for that request
-    cy.intercept(`/${pageFixture}`).as('reloadPage')
-
     cy.task('log', 'Copying the image to the app folder')
     cy.task('copyFile', { source, target })
 
-    cy.task('log', 'Wait for the page to reload')
-    cy.wait('@reloadPage')
+    cy.task('log', 'Wait for the image to be loaded')
+    cy.waitForResource(imageFile)
+
+    // FIXME: the expected behaviour is that the page should update itself,
+    // however there is a bug in our setup where on Windows the image doesn't
+    // show up without a page reload. When this is fixed, remove this step.
+    // See issue #1440 for other details.
+    cy.task('log', 'Reload the page')
+    cy.reload()
 
     cy.task('log', 'Our page should now have its image')
     cy.get('img#larry')

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -36,7 +36,7 @@ module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
 
-  config.env.projectFolder = process.env.KIT_TEST_DIR || process.cwd()
+  config.env.projectFolder = path.resolve(process.env.KIT_TEST_DIR || process.cwd())
   config.env.tempFolder = path.join(__dirname, '..', 'temp')
 
   const packagePath = path.join(config.env.projectFolder, 'package.json')

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,3 +1,70 @@
+/**
+ * Adds command "cy.waitForResource(name)" that checks performance entries
+ * for resource that ends with the given name.
+ *
+ * @see https://developers.google.com/web/tools/chrome-devtools/network/understanding-resource-timing
+ *
+ * Copied from https://github.com/cypress-io/cypress-example-recipes/blob/434f3b9b62555e53134c160b1f051b0c74a714e2/examples/testing-dom__wait-for-resource/cypress/e2e/spec.cy.js
+ */
+Cypress.Commands.add('waitForResource', (name, options = {}) => {
+  if (Cypress.browser.family === 'firefox') {
+    cy.log('Skip waitForResource in Firefox')
+
+    return
+  }
+
+  cy.log(`Waiting for resource ${name}`)
+
+  const log = false // let's not log inner commands
+  const timeout = options.timeout || Cypress.config('defaultCommandTimeout')
+
+  cy.window({ log }).then(
+    // note that ".then" method has options first, callback second
+    // https://on.cypress.io/then
+    { log, timeout },
+    (win) => {
+      return new Cypress.Promise((resolve, reject) => {
+        let foundResource
+
+        // control how long we should try finding the resource
+        // and if it is still not found. An explicit "reject"
+        // allows us to show nice informative message
+        setTimeout(() => {
+          if (foundResource) {
+            // nothing needs to be done, successfully found the resource
+            return
+          }
+
+          clearInterval(interval)
+          reject(new Error(`Timed out waiting for resource ${name}`))
+        }, timeout)
+
+        const interval = setInterval(() => {
+          foundResource = win.performance
+            .getEntriesByType('resource')
+            .find((item) => item.name.endsWith(name))
+
+          if (!foundResource) {
+            // resource not found, will try again
+            return
+          }
+
+          clearInterval(interval)
+          // because cy.log changes the subject, let's resolve the returned promise
+          // with log + returned actual result
+          resolve(
+            cy.log('✅ success').then(() => {
+              // let's resolve with the found performance object
+              // to allow tests to inspect it
+              return foundResource
+            })
+          )
+        }, 100)
+      })
+    }
+  )
+})
+
 // ***********************************************
 // This example commands.js shows you how to
 // create various custom commands and overwrite

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+// import './commands'
+
+// Alternatively you can use CommonJS syntax:
+require('./commands')

--- a/lib/build/tasks.js
+++ b/lib/build/tasks.js
@@ -78,7 +78,7 @@ function sassExtensions () {
 function generateCss (sassPath, cssPath, options = {}) {
   const { filesToSkip = [], filesToRename = {} } = options
   if (!fs.existsSync(sassPath)) return
-  console.log('compiling CSS...')
+  process.stdout.write('compiling CSS...')
   fs.mkdirSync(cssPath, { recursive: true })
   fs.readdirSync(sassPath)
     .filter(file => ((file.endsWith('.scss') && !filesToSkip.includes(file))))
@@ -99,16 +99,19 @@ function generateCss (sassPath, cssPath, options = {}) {
         console.error(err.stack)
       }
     })
+
+  process.stdout.write('done\n')
 }
 
 function copyAssets (sourcePath, targetPath) {
   if (!fs.existsSync(sourcePath)) return
-  console.log('copying assets...')
+  process.stdout.write('copying assets...')
   const filterFunc = (src) => !src.startsWith(path.join(sourcePath, 'sass'))
 
   // shouldn't have to ensure the directory exists, but copy errors with EEXIST otherwise
   fse.ensureDirSync(targetPath, { recursive: true })
   fse.copySync(sourcePath, targetPath, { filter: filterFunc })
+  process.stdout.write('done\n')
 }
 
 function watchSass (sassPath, generateSassPath, cssPath, options) {


### PR DESCRIPTION
The Cypress tests have been very flaky in CI, especially recently. This PR tries to make them more reliable. By waiting for Browsersync to reload the page after the files in the app folder have been changed, we can be sure of when the change has made it to the public folder.

Note that for the watch images test, Browsersync doesn't put its reloading script on our 404 pages or on images, so this commit has to add a page fixture for displaying the image. For the custom styles test I also decided to take the same approach, as it felt more natural to test (easier to do the cleanup) and more in line with what a user might do.

While doing this, I found that our Browsersync setup isn't behaving exactly we would expect. I don't think these are recent regressions though, so I added workarounds to the test and I will write up tickets to fix these bugs.