### PR TITLE
Remove support for ie8 styles

### DIFF
--- a/app/assets/sass/application-ie8.scss
+++ b/app/assets/sass/application-ie8.scss
@@ -1,3 +1,0 @@
-$govuk-is-ie8: true;
-
-@import "application";

--- a/app/assets/sass/unbranded-ie8.scss
+++ b/app/assets/sass/unbranded-ie8.scss
@@ -1,3 +1,0 @@
-$govuk-is-ie8: true;
-
-@import "unbranded";

--- a/lib/_update_scss/index.js
+++ b/lib/_update_scss/index.js
@@ -1,0 +1,5 @@
+const {
+  removeLegacyIE8Sass
+} = require('./update_scss')
+
+removeLegacyIE8Sass()

--- a/lib/_update_scss/update_scss.js
+++ b/lib/_update_scss/update_scss.js
@@ -1,0 +1,35 @@
+const path = require('path')
+const fs = require('fs')
+const { projectDir, packageDir } = require('../path-utils')
+const appSassPath = path.join(projectDir, 'app', 'assets', 'sass')
+const appSassPatternsPath = path.join(appSassPath, 'patterns')
+const libSassPath = path.join(packageDir, 'lib', 'assets', 'sass')
+const libSassPatternsPath = path.join(libSassPath, 'patterns')
+const ie8SassFiles = [
+  'application-ie8.scss',
+  'unbranded-ie8.scss'
+]
+
+function removeLegacyIE8Sass () {
+  ie8SassFiles
+    .forEach(filename => {
+      try {
+        const filePath = path.join(appSassPath, filename)
+        if (fs.existsSync(filePath)) {
+          fs.unlinkSync(path.join(appSassPath, filename))
+        }
+      } catch (err) {
+        console.error(err.message)
+        console.error(err.stack)
+      }
+    })
+}
+
+// These exports are here only for tests
+module.exports = {
+  removeLegacyIE8Sass,
+  appSassPath,
+  libSassPath,
+  appSassPatternsPath,
+  libSassPatternsPath
+}

--- a/lib/_update_scss/update_scss.test.js
+++ b/lib/_update_scss/update_scss.test.js
@@ -1,0 +1,23 @@
+/* eslint-env jest */
+
+const fs = require('fs')
+const path = require('path')
+const updateKit = require('./update_scss')
+const { appSassPath } = require('./update_scss')
+
+describe('scripts/update-kit', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('removeLegacyIE8Sass', () => {
+    it('removes all matching prototype kit sass files from the app sass folder', () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(true)
+      const unlinkSyncSpy = jest.spyOn(fs, 'unlinkSync').mockReturnValue(undefined)
+
+      updateKit.removeLegacyIE8Sass()
+      expect(unlinkSyncSpy).toHaveBeenNthCalledWith(1, path.join(appSassPath, 'application-ie8.scss'))
+      expect(unlinkSyncSpy).toHaveBeenNthCalledWith(2, path.join(appSassPath, 'unbranded-ie8.scss'))
+    })
+  })
+})

--- a/lib/middleware/authentication/authentication.js
+++ b/lib/middleware/authentication/authentication.js
@@ -9,7 +9,6 @@ const { encryptPassword, getNodeEnv } = require('../../utils')
 const allowedPathsWhenUnauthenticated = [
   '/prototype-admin/password',
   '/public/stylesheets/unbranded.css',
-  '/public/stylesheets/unbranded-ie8.css',
   '/extension-assets/govuk-frontend/govuk/all.js']
 
 function authentication () {

--- a/lib/middleware/authentication/authentication.test.js
+++ b/lib/middleware/authentication/authentication.test.js
@@ -177,15 +177,6 @@ describe('authentication', () => {
           assume(res.redirect).not.toHaveBeenCalled()
           expect(next).toHaveBeenCalled()
         })
-        it('should be able to load styles for IE8 password page', () => {
-          authentication()({
-            path: '/public/stylesheets/unbranded-ie8.css',
-            cookies: unauthenticatedCookie
-          }, res, next)
-
-          assume(res.redirect).not.toHaveBeenCalled()
-          expect(next).toHaveBeenCalled()
-        })
       })
 
       describe('when a user is authenticated', () => {

--- a/update.sh
+++ b/update.sh
@@ -172,6 +172,13 @@ copy () {
 	update_gitignore
 }
 
+post () {
+  # execute _update_scss if it exists in the update folder
+  if [ -d "update/lib/_update_scss" ]; then
+    node "update/lib/_update_scss"
+  fi
+}
+
 if [ "$0" == "${BASH_SOURCE:-$0}" ]
 then
 	check
@@ -179,4 +186,5 @@ then
 	fetch
 	extract
 	copy
+	post
 fi


### PR DESCRIPTION
See https://github.com/alphagov/govuk-prototype-kit/issues/1377

Changes:



Create update kit script to perform the removal of the ie8 sass files
Add new post step in update script to execute the update kit script
Remove any references to the ie8 sass files