### PR TITLE
Use new Sass API for compiling stylesheets

### DIFF
--- a/lib/build/tasks.js
+++ b/lib/build/tasks.js
@@ -69,10 +69,9 @@ function generateCss (sassPath, cssPath) {
     if (!file.endsWith('.scss')) return
 
     try {
-      const result = sass.renderSync({
-        file: `${sassPath}/${file}`,
+      const result = sass.compile(`${sassPath}/${file}`, {
         quietDeps: true,
-        loadPaths: [__dirname],
+        loadPaths: [path.join(__dirname, '../../')],
         sourceMap: true,
         style: 'expanded'
       })


### PR DESCRIPTION
The `generateCss` build function currently uses the legacy API method `renderSync`, which will be removed in a [future breaking release of Dart Sass](https://sass-lang.com/documentation/js-api/#legacy-api):

> Although this API is deprecated, it will continue to be supported until the release of version 2.0.0 of the sass package.

Not a pressing change then, however I’m suggesting this change over an alternative, which is to remove the current `loadPaths` option – this is not an option in the legacy API, so its presence here is redundant. Let me know if you’d prefer a PR to remove that option instead.

Please note this has been implemented within the latest version of the code in PR: https://github.com/alphagov/govuk-prototype-kit/pull/1503


Have tested, and all tests pass.