### PR TITLE
Drop support for IE8

### DIFF
--- a/app/views/includes/head.html
+++ b/app/views/includes/head.html
@@ -1,5 +1,4 @@
-<!--[if lte IE 8]><link href="/public/stylesheets/application-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
-<!--[if gt IE 8]><!--><link href="/public/stylesheets/application.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
+<link href="/public/stylesheets/application.css" media="all" rel="stylesheet" type="text/css" />
 
 {% for stylesheetUrl in extensionConfig.stylesheets %}
   <link href="{{ stylesheetUrl }}" rel="stylesheet" type="text/css" />

--- a/app/views/layout_unbranded.html
+++ b/app/views/layout_unbranded.html
@@ -5,8 +5,7 @@
 {% endblock %}
 
 {% block head %}
-  <!--[if lte IE 8]><link href="/public/stylesheets/unbranded-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
-  <!--[if gt IE 8]><!--><link href="/public/stylesheets/unbranded.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
+  <link href="/public/stylesheets/unbranded.css" media="all" rel="stylesheet" type="text/css" />
 
   {% for stylesheetUrl in extensionConfig.stylesheets %}
     <link href="{{ stylesheetUrl }}" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
This PR removes the check within the templates to link to the IE8 styles that were removed in a previous PR.