### PR TITLE
Set Cypress timeouts for CI only

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,3 +49,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - run: npm run test:integration
+      env:
+        CYPRESS_REQUEST_TIMEOUT: 20000
+        CYPRESS_DEFAULT_COMMAND_TIMEOUT: 40000
+        CYPRESS_PAGE_LOAD_TIMEOUT: 120000
+        CYPRESS_RETRIES: 3

--- a/cypress.json
+++ b/cypress.json
@@ -1,10 +1,6 @@
 {
   "baseUrl": "http://localhost:3000",
   "testFiles": "**/*.cypress.js",
-  "requestTimeout": 20000,
-  "defaultCommandTimeout": 40000,
-  "pageLoadTimeout": 120000,
-  "retries": 3,
   "video": false,
   "chromeWebSecurity": false
 }


### PR DESCRIPTION
We want Cypress to have long timeouts and do lots of retries when running tests on CI, but when running tests locally it is a little annoying. This commit moves the definition of the config 
variables to environment variables in the CI pipeline, rather than in the global configuration file. See Cypress docs [[1]] for details on how this works.

[1]: https://docs.cypress.io/guides/guides/environment-variables#Option-3-CYPRESS_
