### PR TITLE
Add caching for Cypress binary

### DIFF
--- a/.github/workflows/test-heroku.yaml
+++ b/.github/workflows/test-heroku.yaml
@@ -12,6 +12,9 @@ jobs:
     name: Test kit on Heroku
     runs-on: ubuntu-latest
 
+    env:
+      CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
+
     steps:
     - uses: actions/checkout@v2
     - name: Use Node v16
@@ -19,5 +22,10 @@ jobs:
       with:
         cache: 'npm'
         node-version: '16'
+    - name: Cache Cypress binary
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/Cypress
+        key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/package.json') }}
     - run: npm ci
     - run: npm run test:heroku


### PR DESCRIPTION
Heroku tests have failed in the past because we haven't been able to
download the binaries for Cypress, use the caches to reduce the chances
of this happening in future.
