### PR TITLE
Update changelog with recent major changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 ### Breaking changes
 
-- [#1432 Remove v6 backwards compatibility support](https://github.com/alphagov/govuk-prototype-kit/pull/1432)
+- [#1394: Remove Internet Explorer 8 support](https://github.com/alphagov/govuk-prototype-kit/issues/1394)
+- [#1432: Remove v6 backwards compatibility support](https://github.com/alphagov/govuk-prototype-kit/pull/1432)
+
+### Other changes
+
+- [#866: Remove docs from the Prototype Kit](https://github.com/alphagov/govuk-prototype-kit/issues/866)
 
 ## 12.1.1 (Fix release)
 


### PR DESCRIPTION
There are a couple of major changes [[1], [2]] that we've made recently that we forgot to add to the changelog, let's fix that.

[1]: https://github.com/alphagov/govuk-prototype-kit/issues/866
[2]: https://github.com/alphagov/govuk-prototype-kit/issues/1394
