### PR TITLE
Change update.sh to pin the version of the kit to upgrade to

### DIFF
--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -345,12 +345,22 @@ describe('update.sh', () => {
       const ret = await runScriptAndExpectSuccess('fetch', { testDir, trace: true })
 
       expect(ret.trace).toEqual(expect.arrayContaining([
-        expect.stringMatching('curl( -[LJO]*)? https://github.com/alphagov/govuk-prototype-kit/releases/download/v12.1.1/govuk-prototype-kit-12.1.1.zip')
+        expect.stringMatching('curl( -[fLJO]*)? https://github.com/alphagov/govuk-prototype-kit/releases/download/v12.1.1/govuk-prototype-kit-12.1.1.zip')
       ]))
 
       expect(await fs.readdir(path.join(testDir, 'update'))).toEqual([
         expect.stringMatching(/govuk-prototype-kit-\d+\.\d+\.\d+\.zip/)
       ])
+    })
+
+    it('raises an error if the version specified does not exist', async () => {
+      const testDir = 'fetchFail'
+      await fs.mkdir(path.join(testDir, 'update'), { recursive: true })
+
+      const ret = await runScriptAndExpectError('fetch', { testDir, env: { VERSION: 'foo' } })
+      expect(ret.stderr).toContain(
+        'ERROR: could not download update'
+      )
     })
   })
 

--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -345,7 +345,7 @@ describe('update.sh', () => {
       const ret = await runScriptAndExpectSuccess('fetch', { testDir, trace: true })
 
       expect(ret.trace).toEqual(expect.arrayContaining([
-        expect.stringMatching('curl( -[LJO]*)? https://govuk-prototype-kit.herokuapp.com/docs/download')
+        expect.stringMatching('curl( -[LJO]*)? https://github.com/alphagov/govuk-prototype-kit/releases/download/v12.1.1/govuk-prototype-kit-12.1.1.zip')
       ]))
 
       expect(await fs.readdir(path.join(testDir, 'update'))).toEqual([
@@ -359,7 +359,7 @@ describe('update.sh', () => {
       const testDir = 'extract'
       await mktestArchive(testDir)
 
-      await runScriptAndExpectSuccess('extract', { testDir })
+      await runScriptAndExpectSuccess('extract', { testDir, env: { VERSION: 'foo' } })
 
       // note that the extract process should strip 1 leading component from the path,
       // so even though the archive contains:
@@ -465,7 +465,7 @@ describe('update.sh', () => {
       const testDir = await mktestDir('error-logging')
       await mktestArchive(testDir)
 
-      await runScriptAndExpectSuccess('extract', { testDir })
+      await runScriptAndExpectSuccess('extract', { testDir, env: { VERSION: 'foo' } })
       const ret = await runScript('copy', { testDir })
 
       // we expect this to fail because the test archive doesn't have a docs folder

--- a/internal_docs/releasing.md
+++ b/internal_docs/releasing.md
@@ -40,23 +40,25 @@ v8.0.0 // After implementing backwards incompatible changes
 
 7. Run `npm install` to update `package-lock.json`.
 
-8. Commit your changes and open a new pull request on GitHub - copy the relevant Changelog section into the description.
+8. Update `VERSION` in [update.sh](/update.sh#L5).
 
-9. Once someone has merged the pull request, [draft a new release on GitHub](https://github.com/alphagov/govuk-prototype-kit/releases)
+9. Commit your changes and open a new pull request on GitHub - copy the relevant Changelog section into the description.
 
-10. In Tag version and Release title, put v[version number], for example `v7.0.0`.
+10. Once someone has merged the pull request, [draft a new release on GitHub](https://github.com/alphagov/govuk-prototype-kit/releases)
 
-11. In the description, paste the relevant section from the release notes in the Google Doc.
+11. In Tag version and Release title, put v[version number], for example `v7.0.0`.
 
-12. Checkout the *main* branch and pull the latest changes.
+12. In the description, paste the relevant section from the release notes in the Google Doc.
 
-13. Run `node scripts/create-release-archive`, which will generate a ZIP in the root of this project.
+13. Checkout the *main* branch and pull the latest changes.
 
-14. Attach the generated ZIP to the release.
+14. Run `node scripts/create-release-archive`, which will generate a ZIP in the root of this project.
 
-15. Click 'Publish release'.
+15. Attach the generated ZIP to the release.
 
-16. Let the community know about the release
+16. Click 'Publish release'.
+
+17. Let the community know about the release
 
 Write a brief summary with highlights from the release then send it to the following slack channels:
 

--- a/update.sh
+++ b/update.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Set the version of the kit that should be downloaded by default
+VERSION="${VERSION:-12.1.1}"
+
 # Use unofficial bash strict mode
 set -euo pipefail
 
@@ -8,15 +11,18 @@ msg () {
 	1>&2 echo $*
 }
 
+abspath () {
+	# From https://stackoverflow.com/questions/3572030/bash-script-absolute-path-with-os-x
+	[[ "$1" = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
 # Set global vars ARCHIVE_FILE ARCHIVE_ROOT
 get_archive_vars () {
-	# If ARCHIVE_FILE hasn't been set in the env already choose the archive file
-	# in the update folder with the largest version number.
 	if [ -z "${ARCHIVE_FILE:-}" ]; then
-		ARCHIVE_FILE="$(find update -name 'govuk-prototype-kit*.zip' | sort -V | tail -n1)"
+		ARCHIVE_FILE="update/govuk-prototype-kit-${VERSION}.zip"
 	fi
 	if [ ! -z "${ARCHIVE_FILE:-}" ]; then
-		ARCHIVE_FILE="$PWD/$ARCHIVE_FILE"
+		ARCHIVE_FILE="$(abspath $ARCHIVE_FILE)"
 		ARCHIVE_NAME="$(basename "$ARCHIVE_FILE")"
 		ARCHIVE_ROOT="${ARCHIVE_NAME//.zip}"
 	fi
@@ -72,8 +78,8 @@ fetch () {
 	cd update
 
 	if ! ls govuk-prototype-kit*.zip > /dev/null 2>&1; then
-		msg 'Downloading latest version of GOV.UK Prototype Kit...'
-		curl -LJO https://govuk-prototype-kit.herokuapp.com/docs/download
+		msg "Downloading version ${VERSION} of GOV.UK Prototype Kit..."
+		curl -LJO "https://github.com/alphagov/govuk-prototype-kit/releases/download/v${VERSION}/govuk-prototype-kit-v${VERSION}.zip"
 		msg 'Done'
 	fi
 

--- a/update.sh
+++ b/update.sh
@@ -79,7 +79,8 @@ fetch () {
 	cd update
 
 	msg "Downloading version ${VERSION} of GOV.UK Prototype Kit..."
-	curl -LJO "https://github.com/alphagov/govuk-prototype-kit/releases/download/v${VERSION}/${ARCHIVE_NAME}"
+	curl -fLJO "https://github.com/alphagov/govuk-prototype-kit/releases/download/v${VERSION}/${ARCHIVE_NAME}" \
+		|| { msg 'ERROR: could not download update'; exit 1; }
 	msg 'Done'
 
 	cd ..

--- a/update.sh
+++ b/update.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Set the version of the kit that should be downloaded by default
+# Update this when making a new release
 VERSION="${VERSION:-12.1.1}"
 
 # Use unofficial bash strict mode
@@ -77,11 +78,9 @@ fetch () {
 
 	cd update
 
-	if ! ls govuk-prototype-kit*.zip > /dev/null 2>&1; then
-		msg "Downloading version ${VERSION} of GOV.UK Prototype Kit..."
-		curl -LJO "https://github.com/alphagov/govuk-prototype-kit/releases/download/v${VERSION}/govuk-prototype-kit-v${VERSION}.zip"
-		msg 'Done'
-	fi
+	msg "Downloading version ${VERSION} of GOV.UK Prototype Kit..."
+	curl -LJO "https://github.com/alphagov/govuk-prototype-kit/releases/download/v${VERSION}/${ARCHIVE_NAME}"
+	msg 'Done'
 
 	cd ..
 }


### PR DESCRIPTION
We want to make it easier to work with the update script by making it so that the code only has to deal with one target version. See https://github.com/alphagov/govuk-prototype-kit-docs/issues/26 for more details.

This PR changes the update script to target version 12.1.1 (without changing any of the upgrade logic).

