### PR TITLE
Allow data defaults to be accessed correctly when kit is a package

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
 
     name: Test kit on Node v${{ matrix.node-version }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     defaults:
       run:

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,6 +11,7 @@ const inquirer = require('inquirer')
 
 // Local dependencies
 const config = require('../app/config.js')
+const { projectDir } = require('./path-utils')
 
 // Are we running on Glitch.com?
 const onGlitch = function () {
@@ -253,7 +254,7 @@ var storeData = function (input, data) {
 // Get session default data from file
 let sessionDataDefaults = {}
 
-const sessionDataDefaultsFile = path.join(__dirname, '/../app/data/session-data-defaults.js')
+const sessionDataDefaultsFile = path.join(projectDir, 'app', 'data', 'session-data-defaults.js')
 
 try {
   sessionDataDefaults = require(sessionDataDefaultsFile)


### PR DESCRIPTION
The session-data-defaults should be accessed correctly when the kit is used as a package.