### PR TITLE
Update to GOVUK Frontend v4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - [#1394: Remove Internet Explorer 8 support](https://github.com/alphagov/govuk-prototype-kit/issues/1394)
 - [#1432: Remove v6 backwards compatibility support](https://github.com/alphagov/govuk-prototype-kit/pull/1432)
 
+### New Features
+
+- [#1476: Update to GOV.UK Frontend 4.2.0](https://github.com/alphagov/govuk-prototype-kit/pull/1476)
+
 ### Other changes
 
 - [#866: Remove docs from the Prototype Kit](https://github.com/alphagov/govuk-prototype-kit/issues/866)

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -19,6 +19,7 @@
 {% from "govuk/components/input/macro.njk"               import govukInput %}
 {% from "govuk/components/inset-text/macro.njk"          import govukInsetText %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/pagination/macro.njk"          import govukPagination %}
 {% from "govuk/components/panel/macro.njk"               import govukPanel %}
 {% from "govuk/components/phase-banner/macro.njk"        import govukPhaseBanner %}
 {% from "govuk/components/radios/macro.njk"              import govukRadios %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "express-session": "^1.13.0",
         "fancy-log": "^1.3.3",
         "fs-extra": "^10.0.1",
-        "govuk-frontend": "^4.1.0",
+        "govuk-frontend": "^4.2.0",
         "inquirer": "^8.2.0",
         "lodash": "^4.17.21",
         "marked": "^4.0.10",
@@ -5904,9 +5904,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.1.0.tgz",
-      "integrity": "sha512-xBUUarxinGWSccmXPmwa7ovg3xabEQ0+Dcv7pdq9X3F69892OFMqP2g8jvlDUrVsDVdasXLk4Jq4w8dPiaEVqQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.2.0.tgz",
+      "integrity": "sha512-IHbnz5DbnPjuCv4lQvtJGoCNAKAN6byKqmaej8hjd6Y/KTaAuw10npijeqfRJNO4WdDX9a34+n+SC/UmWdjfGQ==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -16727,9 +16727,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.1.0.tgz",
-      "integrity": "sha512-xBUUarxinGWSccmXPmwa7ovg3xabEQ0+Dcv7pdq9X3F69892OFMqP2g8jvlDUrVsDVdasXLk4Jq4w8dPiaEVqQ=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.2.0.tgz",
+      "integrity": "sha512-IHbnz5DbnPjuCv4lQvtJGoCNAKAN6byKqmaej8hjd6Y/KTaAuw10npijeqfRJNO4WdDX9a34+n+SC/UmWdjfGQ=="
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "express-session": "^1.13.0",
     "fancy-log": "^1.3.3",
     "fs-extra": "^10.0.1",
-    "govuk-frontend": "^4.1.0",
+    "govuk-frontend": "^4.2.0",
     "inquirer": "^8.2.0",
     "lodash": "^4.17.21",
     "marked": "^4.0.10",


### PR DESCRIPTION
Closes #1442 

This also adds the new pagination component to `app/views/layout.html`

**I don't think the update process covers this change, we may need to think about that**

[The release notes mention "Replace deprecated govuk-header__link--service-name class in the header"](https://github.com/alphagov/govuk-frontend/releases/tag/v4.2.0) - we have a reference to this in cypress, I'm not sure if it needs updating?