### PR TITLE
Squelch errors from run from release/package scripts when npm start is stopped by a signal

### DIFF
--- a/cypress/scripts/run-as-package.js
+++ b/cypress/scripts/run-as-package.js
@@ -37,7 +37,13 @@ fse.copySync(srcDir, destDir, {
   overwrite: true
 })
 
-child_process.execSync(
-  `node ${path.join('.', 'node_modules', prototypePkg.name, 'start.js')}`,
-  { cwd: testDir, env: { ...process.env, env: 'test' }, stdio: 'inherit' }
-)
+try {
+  child_process.execSync(
+    `node ${path.join('.', 'node_modules', prototypePkg.name, 'start.js')}`,
+    { cwd: testDir, env: { ...process.env, env: 'test' }, stdio: 'inherit' }
+  )
+} catch (error) {
+  if (error.status > 0) {
+    process.exitCode = error.status
+  }
+}

--- a/cypress/scripts/run-from-release.js
+++ b/cypress/scripts/run-from-release.js
@@ -21,7 +21,13 @@ child_process.execSync(
   { cwd: testDir, env: { ...process.env, npm_config_include: '' }, stdio: 'inherit' }
 )
 
-child_process.execSync(
-  'npm start',
-  { cwd: testDir, env: { ...process.env, env: 'test' }, stdio: 'inherit' }
-)
+try {
+  child_process.execSync(
+    'npm start',
+    { cwd: testDir, env: { ...process.env, env: 'test' }, stdio: 'inherit' }
+  )
+} catch (error) {
+  if (error.status > 0) {
+    process.exitCode = error.status
+  }
+}


### PR DESCRIPTION
We don't want the run from release/package scripts to throw if the child process exits with a non-zero status, because then we get unnecessary chaff in our CI logs. Instead just copy the status to our own exit code.