### PR TITLE
Use fs-extra's copy instead of shelling out to cp

### DIFF
--- a/__tests__/spec/update-script.js
+++ b/__tests__/spec/update-script.js
@@ -238,19 +238,20 @@ describe('update.sh', () => {
     await utils.mkPrototype(path.join(src, 'update'))
   }
 
-  async function mktestPrototype (dest, { ref } = {}) {
-    const src = path.resolve(fixtureDir, ref ? `prototype-${ref}` : 'prototype')
+  async function mktestPrototype (destDir, { ref } = {}) {
+    const srcDir = path.resolve(fixtureDir, ref ? `prototype-${ref}` : 'prototype')
     try {
-      await fs.access(src)
+      await fs.access(srcDir)
     } catch (error) {
-      await _mktestPrototype(src, { ref })
+      await _mktestPrototype(srcDir, { ref })
     }
 
-    if (dest) {
-      await execPromise(`cp -r ${src} ${dest}`)
-      return dest
+    if (destDir) {
+      await fs.mkdir(destDir)
+      await fse.copy(srcDir, destDir)
+      return destDir
     } else {
-      return src
+      return srcDir
     }
   }
 


### PR DESCRIPTION
This should shave off a few seconds on tests, especially on Windows.