### PR TITLE
Add update script to update package.json for user

### DIFF
--- a/lib/_update/pre.js
+++ b/lib/_update/pre.js
@@ -1,0 +1,5 @@
+const { updatePackageJson } = require('./update-package-json')
+
+;(async function () {
+  await updatePackageJson()
+})()

--- a/lib/_update/update-package-json.js
+++ b/lib/_update/update-package-json.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+const fs = require('fs').promises
+const os = require('os')
+const path = require('path')
+
+const { fetchOriginal, getProjectVersion } = require('./util')
+const { projectDir: prototypeToUpdate } = require('../path-utils')
+
+const updateDir = path.join(prototypeToUpdate, 'update')
+
+async function updatePackageJson () {
+  const userVersion = await getProjectVersion()
+
+  const originalPackageJson = await fetchOriginal(userVersion, 'package.json')
+  const theirPackageJson = await fs.readFile(
+    path.join(prototypeToUpdate, 'package.json'), 'utf8')
+  const ourPackageJson = await fs.readFile(
+    path.join(updateDir, 'package.json'), 'utf8')
+
+  // If the user hasn't changed the file we don't need to prepatch ours, so do nothing
+  if (theirPackageJson === originalPackageJson) {
+    return
+  }
+
+  const merged = await mergePackageJson(
+    JSON.parse(theirPackageJson),
+    JSON.parse(originalPackageJson),
+    JSON.parse(ourPackageJson)
+  )
+
+  const mergedPackageJson = JSON.stringify(merged, null, 2)
+    .replace(/\n/g, os.EOL) + os.EOL
+
+  await fs.writeFile(path.join(updateDir, 'package.json'), mergedPackageJson, 'utf8')
+}
+
+function mergePackageJson (theirs, original, ours) {
+  return {
+    ...ours,
+    dependencies: mergeDeps(
+      theirs.dependencies,
+      original.dependencies,
+      ours.dependencies
+    )
+  }
+}
+
+/*
+ * Merge changes from original to ours into theirs
+ *
+ */
+function mergeDeps (theirs, original, ours) {
+  let merged = { ...theirs, ...ours }
+
+  // If a user has downgraded a package, we respect that...
+  for (const pkg in original) {
+    if (pkg in theirs && theirs[pkg] !== original[pkg]) {
+      merged[pkg] = theirs[pkg]
+    }
+  }
+
+  // ...but we delete packages we have deleted
+  for (const pkg in original) {
+    if (pkg in ours === false) {
+      delete merged[pkg]
+    }
+  }
+
+  // npm sorts the dependencies, so we should too, but the way npm sorts the
+  // dependencies varies from version to version. We want the order of the
+  // merged dependencies to match the order of `ours` as much as possible, so
+  // we sort them twice, once alphabetically, and once to shuffle any items
+  // that are out-of-order compared to `ours`.
+  const ourPackageOrder = Object.fromEntries(
+    [...Object.keys(ours).entries()].map(([i, p]) => [p, i])
+  )
+  const mergedPackageNames = Object.keys(merged)
+    .sort()
+    .sort((a, b) => {
+      if (ourPackageOrder[a] && ourPackageOrder[b]) {
+        return ourPackageOrder[a] - ourPackageOrder[b]
+      } else {
+        return 0
+      }
+    })
+  merged = Object.fromEntries(
+    mergedPackageNames.map(name => [name, merged[name]])
+  )
+
+  return merged
+}
+
+module.exports = {
+  updatePackageJson,
+  // export for tests
+  mergeDeps,
+  mergePackageJson
+}

--- a/lib/_update/update-package-json.js
+++ b/lib/_update/update-package-json.js
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 
 const fs = require('fs').promises
-const os = require('os')
 const path = require('path')
 
-const { fetchOriginal, getProjectVersion } = require('./util')
+const { fetchOriginal, getProjectVersion, normaliseLineEndings } = require('./util')
 const { projectDir: prototypeToUpdate } = require('../path-utils')
 
 const updateDir = path.join(prototypeToUpdate, 'update')
@@ -29,8 +28,8 @@ async function updatePackageJson () {
     JSON.parse(ourPackageJson)
   )
 
-  const mergedPackageJson = JSON.stringify(merged, null, 2)
-    .replace(/\n/g, os.EOL) + os.EOL
+  const [mergedPackageJson] = normaliseLineEndings(theirPackageJson,
+    JSON.stringify(merged, null, 2) + '\n')
 
   await fs.writeFile(path.join(updateDir, 'package.json'), mergedPackageJson, 'utf8')
 }

--- a/lib/_update/update-package-json.test.js
+++ b/lib/_update/update-package-json.test.js
@@ -1,0 +1,332 @@
+/* eslint-env jest */
+
+const fs = require('fs').promises
+const path = require('path')
+
+jest.mock('./util')
+const {
+  getProjectVersion: mockGetProjectVersion,
+  fetchOriginal: mockFetchOriginal
+} = require('./util')
+const { projectDir } = require('../path-utils')
+
+const { mergeDeps, mergePackageJson, updatePackageJson } = require('./update-package-json')
+
+describe('updatePackageJson', () => {
+  let mockReadFile, mockWriteFile
+
+  const originalPackageJson = `{
+  "name": "govuk-prototype-kit",
+  "dependencies": {
+    "@govuk-prototype-kit/kit": "^1.0.0"
+  }
+}
+`
+
+  const userPackageJson = `{
+  "name": "govuk-prototype-kit",
+  "dependencies": {
+    "@govuk-prototype-kit/kit": "^1.0.0",
+    "foobar": "^1.0.0"
+  }
+}
+`
+
+  const newPackageJson = `{
+  "name": "govuk-prototype-kit",
+  "dependencies": {
+    "@govuk-prototype-kit/kit": "^2.0.0"
+  }
+}
+`
+
+  const mergedPackageJson = `{
+  "name": "govuk-prototype-kit",
+  "dependencies": {
+    "@govuk-prototype-kit/kit": "^2.0.0",
+    "foobar": "^1.0.0"
+  }
+}
+`
+
+  beforeEach(() => {
+    mockReadFile = jest.spyOn(fs, 'readFile').mockImplementation(() => {})
+    mockWriteFile = jest.spyOn(fs, 'writeFile').mockImplementation(() => {})
+
+    mockGetProjectVersion.mockResolvedValue('99.99.99')
+
+    mockFetchOriginal.mockResolvedValue(originalPackageJson)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('changes package.json in the update folder to reflect changes user has made', async () => {
+    // theirs
+    mockReadFile.mockResolvedValueOnce(userPackageJson)
+    // ours
+    mockReadFile.mockResolvedValueOnce(newPackageJson)
+
+    await updatePackageJson()
+
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      path.join(projectDir, 'update', 'package.json'),
+      mergedPackageJson,
+      'utf8'
+    )
+  })
+
+  it('does nothing if user has not changed package.json', async () => {
+    // theirs
+    mockReadFile.mockResolvedValueOnce(originalPackageJson)
+    // ours
+    mockReadFile.mockResolvedValueOnce(newPackageJson)
+
+    await updatePackageJson()
+
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+})
+
+describe('mergePackageJson', () => {
+  let theirs, original, ours
+
+  beforeEach(() => {
+    original = {
+      version: '1.0.0',
+      dependencies: {}
+    }
+
+    theirs = {
+      version: '1.0.0',
+      dependencies: {}
+    }
+
+    ours = {
+      version: '1.0.0',
+      dependencies: {}
+    }
+  })
+
+  it('does a three way merge of a package.json object', () => {
+    theirs = {
+      version: '1.0.0',
+      dependencies: {
+        bar: '^1.0.0',
+        foo: '^1.0.0'
+      }
+    }
+
+    original = {
+      version: '1.0.0',
+      dependencies: {
+        foo: '^1.0.0'
+      }
+    }
+
+    ours = {
+      version: '2.0.0',
+      dependencies: {
+        foo: '^2.0.0'
+      }
+    }
+
+    expect(mergePackageJson(theirs, original, ours)).toEqual({
+      version: '2.0.0',
+      dependencies: {
+        bar: '^1.0.0',
+        foo: '^2.0.0'
+      }
+    })
+  })
+
+  it('updates the version number', () => {
+    ours = {
+      ...ours,
+      version: '2.0.0'
+    }
+
+    expect(mergePackageJson(theirs, original, ours)).toEqual({
+      version: '2.0.0',
+      dependencies: {}
+    })
+  })
+
+  it('removes properties that we have removed', () => {
+    theirs = {
+      ...theirs,
+      devDependencies: {
+        foobar: '^1.0.0'
+      }
+    }
+
+    original = {
+      ...original,
+      devDependencies: {
+        foobar: '^1.0.0'
+      }
+    }
+
+    expect(mergePackageJson(theirs, original, ours)).toEqual({
+      version: '1.0.0',
+      dependencies: {}
+    })
+  })
+})
+
+describe('mergeDeps', () => {
+  let theirs, original, ours
+
+  beforeEach(() => {
+    theirs = {
+      foo: '^1.0.0'
+    }
+    original = {
+      foo: '^1.0.0'
+    }
+    ours = {
+      foo: '^1.0.0'
+    }
+  })
+
+  it('does a three way merge of a dependencies object', () => {
+    theirs = {
+      bar: '^1.0.0',
+      foo: '^1.0.0'
+    }
+    original = {
+      foo: '^1.0.0'
+    }
+    ours = {
+      foo: '^2.0.0'
+    }
+
+    expect(mergeDeps(theirs, original, ours)).toEqual({
+      bar: '^1.0.0',
+      foo: '^2.0.0'
+    })
+  })
+
+  it('adds packages that we have added', () => {
+    ours = {
+      ...ours,
+      bar: '^1.0.0'
+    }
+
+    expect(mergeDeps(theirs, original, ours)).toEqual({
+      bar: '^1.0.0',
+      foo: '^1.0.0'
+    })
+  })
+
+  it('sorts the packages', () => {
+    ours = {
+      bar: '^1.0.0',
+      ...ours
+    }
+
+    expect(Object.entries(mergeDeps(theirs, original, ours))).toEqual([
+      ['bar', '^1.0.0'],
+      ['foo', '^1.0.0']
+    ])
+  })
+
+  it('sorts the packages in the same order as ours', () => {
+    theirs = {
+      ...theirs,
+      'foo-bar': '^1.0.0',
+      foo_baz: '^1.0.0'
+    }
+    original = {
+      ...original,
+      'foo-bar': '^1.0.0',
+      foo_baz: '^1.0.0'
+    }
+    ours = {
+      ...ours,
+      foo_baz: '^1.0.0',
+      'foo-bar': '^1.0.0'
+    }
+
+    expect(Object.entries(mergeDeps(theirs, original, ours))).toEqual([
+      ['foo', '^1.0.0'],
+      ['foo_baz', '^1.0.0'],
+      ['foo-bar', '^1.0.0']
+    ])
+  })
+
+  it('removes packages that we have removed', () => {
+    theirs = {
+      ...theirs,
+      bar: '^1.0.0'
+    }
+    original = {
+      ...original,
+      bar: '^1.0.0'
+    }
+
+    expect(mergeDeps(theirs, original, ours)).toEqual({
+      foo: '^1.0.0'
+    })
+  })
+
+  it('removes packages that we have removed even if the user has updated them', () => {
+    theirs = {
+      ...theirs,
+      bar: '^2.0.0'
+    }
+    original = {
+      ...original,
+      bar: '^1.0.0'
+    }
+
+    expect(mergeDeps(theirs, original, ours)).toEqual({
+      foo: '^1.0.0'
+    })
+  })
+
+  it('updates packages that we have updated', () => {
+    ours = {
+      ...ours,
+      foo: '^2.0.0'
+    }
+
+    expect(mergeDeps(theirs, original, ours)).toEqual({
+      foo: '^2.0.0'
+    })
+  })
+
+  it('keeps packages the user has added', () => {
+    theirs = {
+      ...theirs,
+      bar: '^1.0.0'
+    }
+
+    expect(mergeDeps(theirs, original, ours)).toEqual({
+      bar: '^1.0.0',
+      foo: '^1.0.0'
+    })
+  })
+
+  it('does not upgrade a package version if the user has downgraded that package', () => {
+    original = {
+      ...original,
+      bar: '^2.0.0'
+    }
+    theirs = {
+      ...theirs,
+      bar: '^1.0.0'
+    }
+    ours = {
+      ...ours,
+      bar: '^3.0.0',
+      foo: '^2.0.0'
+    }
+
+    expect(mergeDeps(theirs, original, ours)).toEqual({
+      bar: '^1.0.0',
+      foo: '^2.0.0'
+    })
+  })
+})

--- a/lib/_update/update-package-json.test.js
+++ b/lib/_update/update-package-json.test.js
@@ -3,7 +3,13 @@
 const fs = require('fs').promises
 const path = require('path')
 
-jest.mock('./util')
+jest.mock('./util', () => {
+  const { normaliseLineEndings } = jest.requireActual('./util')
+  return {
+    ...jest.createMockFromModule('./util'),
+    normaliseLineEndings
+  }
+})
 const {
   getProjectVersion: mockGetProjectVersion,
   fetchOriginal: mockFetchOriginal

--- a/lib/_update/util/index.js
+++ b/lib/_update/util/index.js
@@ -57,5 +57,6 @@ async function patchUserFile (originalVersion, filePath) {
 
 module.exports = {
   getProjectVersion,
+  fetchOriginal,
   patchUserFile
 }

--- a/lib/_update/util/index.js
+++ b/lib/_update/util/index.js
@@ -10,22 +10,28 @@ async function getProjectVersion () {
   return (await fs.readFile(path.join(projectDir, 'VERSION.txt'), 'utf8')).trim()
 }
 
+// Normalise line endings so all strings have the same line endings as control
+function normaliseLineEndings (control, ...targets) {
+  const posixEOL = '\n'
+  const win32EOL = '\r\n'
+  if (control.includes(win32EOL)) {
+    return targets.map((t) => {
+      if (!t.includes(win32EOL)) {
+        return t.replace(new RegExp(posixEOL, 'g'), win32EOL)
+      }
+      return t
+    })
+  }
+  return targets
+}
+
 async function patchUserFile (originalVersion, filePath) {
   const theirs = await fs.readFile(path.resolve(projectDir, filePath), 'utf8')
-  let original = await fetchOriginal(originalVersion, filePath)
-  let ours = await fs.readFile(path.resolve(updateDir, filePath), 'utf8')
+  const originalUnnormalised = await fetchOriginal(originalVersion, filePath)
+  const oursUnnormalised = await fs.readFile(path.resolve(updateDir, filePath), 'utf8')
 
   // Normalise line endings to match their file
-  var eol = '\n'
-  if (theirs.includes('\r\n')) {
-    eol = '\r\n'
-    if (!original.includes(eol)) {
-      original = original.replace(/\n/g, eol)
-    }
-    if (!ours.includes(eol)) {
-      ours = ours.replace(/\n/g, eol)
-    }
-  }
+  const [original, ours] = normaliseLineEndings(theirs, originalUnnormalised, oursUnnormalised)
 
   // It is possible that the file has already been upgraded, in which case there is nothing to do
   if (theirs === ours) {
@@ -58,5 +64,6 @@ async function patchUserFile (originalVersion, filePath) {
 module.exports = {
   getProjectVersion,
   fetchOriginal,
+  normaliseLineEndings,
   patchUserFile
 }

--- a/update.sh
+++ b/update.sh
@@ -105,6 +105,12 @@ extract () {
 	cd ..
 }
 
+pre () {
+	if [ -f 'update/lib/_update/pre.js' ]; then
+		node 'update/lib/_update/pre'
+	fi
+}
+
 # Copy 'core files' from the update folder into the current prototype folder
 copy () {
 	OLD_VERSION="$(cat VERSION.txt)"


### PR DESCRIPTION
We want to simplify the update process for users, so we can make releases more often. One of the currently problems with upgrading is that users lose any packages they have installed personally, and have to reinstall themselves.

This PR adds an update script that compares the users package.json file with the file we would expect them to have, and copies any changes we think they made to add extra packages over to the upgraded package.json. The effect of this is that after running the update script they should not need to re-add any packages they personally installed previously.

---

The code in this PR builds on the outputs of the spike in https://github.com/alphagov/govuk-prototype-kit/issues/1382.