### PR TITLE
Fix the node 12 failing watch javascript integration test with a delay.

### DIFF
--- a/cypress/integration/1-watch-files/watch-javascripts.cypress.js
+++ b/cypress/integration/1-watch-files/watch-javascripts.cypress.js
@@ -33,6 +33,7 @@ describe('watch application.js', () => {
 
     // wait for page to be reloaded by Browsersync
     cy.once('window:load', () => {
+      cy.wait(1000)
       expect(onAlert).to.be.calledWith('Test')
       done()
     })


### PR DESCRIPTION
On node 12 within the CI the integration test watching the javascript file often fails.  I found by adding a one second delay to the test, it passes.