### PR TITLE
Fix imports of app/config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,14 @@
+/*
+ * Convenience module to make importing users app/config.js file easier,
+ * handling the case where that files does not exist.
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const { appDir } = require('./path-utils')
+const appConfig = path.join(appDir, 'config.js')
+
+const config = fs.existsSync(appConfig) ? require(appConfig) : {}
+
+module.exports = config

--- a/lib/config.test.js
+++ b/lib/config.test.js
@@ -1,0 +1,36 @@
+/* eslint-env jest */
+
+const fs = require('fs')
+const path = require('path')
+
+const { appDir } = require('./path-utils')
+const appConfig = path.join(appDir, 'config.js')
+
+afterEach(() => {
+  jest.restoreAllMocks()
+  jest.resetModules()
+})
+
+it('exports the user app/config.js file', () => {
+  const actualExistsSync = fs.existsSync
+  jest.spyOn(fs, 'existsSync').mockImplementation(
+    path => path === appConfig ? true : actualExistsSync(path)
+  )
+
+  jest.mock(appConfig, () => ({ serviceName: 'My Test Service' }), { virtual: true })
+
+  expect(require('./config')).toStrictEqual({
+    serviceName: 'My Test Service'
+  })
+})
+
+it('exports empty object if user app/config.js does not exist', () => {
+  const actualExistsSync = fs.existsSync
+  jest.spyOn(fs, 'existsSync').mockImplementation(
+    path => path === appConfig ? false : actualExistsSync(path)
+  )
+
+  jest.mock(appConfig, () => { throw new Error('tried to import app/config.js in test') }, { virtual: true })
+
+  expect(require('./config')).toStrictEqual({ })
+})

--- a/lib/extensions/extensions.js
+++ b/lib/extensions/extensions.js
@@ -39,7 +39,7 @@ const fs = require('fs')
 const path = require('path')
 
 // Local dependencies
-const appConfig = require('../../app/config')
+const appConfig = require('../config')
 const { projectDir } = require('../path-utils')
 
 // Generic utilities

--- a/lib/middleware/authentication/authentication.js
+++ b/lib/middleware/authentication/authentication.js
@@ -2,7 +2,7 @@
 const url = require('url')
 
 // Local dependencies
-const config = require('../../../app/config')
+const config = require('../../config')
 const { encryptPassword, getNodeEnv } = require('../../utils')
 
 // Local variables

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -3,3 +3,4 @@
 const path = require('path')
 exports.packageDir = path.resolve(__dirname, '..')
 exports.projectDir = process.cwd()
+exports.appDir = path.join(exports.projectDir, 'app')

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,8 +10,8 @@ const portScanner = require('portscanner')
 const inquirer = require('inquirer')
 
 // Local dependencies
-const config = require('../app/config.js')
-const { projectDir } = require('./path-utils')
+const config = require('./config')
+const { appDir, projectDir } = require('./path-utils')
 
 // Are we running on Glitch.com?
 const onGlitch = function () {
@@ -53,7 +53,7 @@ marked.use({
 // and then add the methods to Nunjucks environment
 exports.addNunjucksFilters = function (env) {
   var coreFilters = require('./core_filters.js')(env)
-  var customFilters = require('../app/filters.js')(env)
+  var customFilters = require(path.join(appDir, 'filters.js'))(env)
   var filters = Object.assign(coreFilters, customFilters)
   Object.keys(filters).forEach(function (filterName) {
     env.addFilter(filterName, filters[filterName])

--- a/listen-on-port.js
+++ b/listen-on-port.js
@@ -1,10 +1,9 @@
-
 // NPM dependencies
 const browserSync = require('browser-sync')
 
 // Local dependencies
 const server = require('./server.js')
-const config = require('./app/config.js')
+const config = require('./lib/config.js')
 const utils = require('./lib/utils.js')
 
 // Set up configuration variables


### PR DESCRIPTION
When using the kit as a package, the file app/config.js may not be present. This commit makes it easier for code in lib to import app/config.js by adding a convenience module lib/config.js, that imports the user's file if it exists, and gives an empty object if it doesn't.

I ran into this issue when working on #1518, I'm raising the change in this separate PR to give people a chance to comment on this detail.