### PR TITLE
Add cypress download tests v13

### DIFF
--- a/.github/workflows/test-download.yaml
+++ b/.github/workflows/test-download.yaml
@@ -15,7 +15,7 @@ jobs:
         node-version: [16.x]
         os: [ubuntu-latest]
 
-    name: Test kit on Node v${{ matrix.node-version }} (${{ matrix.os }})
+    name: Test downloading kit from website
     continue-on-error: true
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25

--- a/.github/workflows/test-download.yaml
+++ b/.github/workflows/test-download.yaml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         cache: 'npm'
-        node-version: '16'
+        node-version: ${{ matrix.node-version }}
 
     - name: Cache Cypress binary
       uses: actions/cache@v3

--- a/.github/workflows/test-download.yaml
+++ b/.github/workflows/test-download.yaml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false  # continue other tests if one test in matrix fails
       matrix:
-        node-version: [12.x, 14.x, 16.x]
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        node-version: [16.x]
+        os: [ubuntu-latest]
 
     name: Test kit on Node v${{ matrix.node-version }} (${{ matrix.os }})
     continue-on-error: true
@@ -34,7 +34,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         cache: 'npm'
-        node-version: ${{ matrix.node-version }}
+        node-version: '16'
 
     - name: Cache Cypress binary
       uses: actions/cache@v3

--- a/.github/workflows/test-download.yaml
+++ b/.github/workflows/test-download.yaml
@@ -1,0 +1,52 @@
+name: Tests (Download)
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  tests:
+
+    strategy:
+      fail-fast: false  # continue other tests if one test in matrix fails
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+        os: [macos-latest, windows-latest, ubuntu-latest]
+
+    name: Test kit on Node v${{ matrix.node-version }} (${{ matrix.os }})
+    continue-on-error: true
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node v${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        cache: 'npm'
+        node-version: ${{ matrix.node-version }}
+
+    - name: Cache Cypress binary
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/Cypress
+        key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/package.json') }}
+
+    - run: npm ci
+
+    - run: npm run test:acceptance:download
+      env:
+        CYPRESS_REQUEST_TIMEOUT: 20000
+        CYPRESS_DEFAULT_COMMAND_TIMEOUT: 40000
+        CYPRESS_PAGE_LOAD_TIMEOUT: 150000
+        CYPRESS_RETRIES: 3

--- a/cypress.json
+++ b/cypress.json
@@ -2,5 +2,6 @@
   "baseUrl": "http://localhost:3000",
   "testFiles": "**/*.cypress.js",
   "video": false,
-  "chromeWebSecurity": false
+  "chromeWebSecurity": false,
+  "trashAssetsBeforeRun": true
 }

--- a/cypress/download-tests/1-download-latest-release/download.cypress.js
+++ b/cypress/download-tests/1-download-latest-release/download.cypress.js
@@ -1,0 +1,17 @@
+import { waitForApplication } from '../../integration/utils'
+
+describe('download page', () => {
+  beforeEach(() => {
+    waitForApplication()
+  })
+
+  it('loaded ok', () => {
+    cy.get('main')
+      .find('a').contains('Tutorials and templates')
+      .click()
+
+    cy.get('a[data-link="download"]')
+      .should('contains.text', 'Download the Prototype Kit (zip file)')
+      .download()
+  })
+})

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -17,8 +17,12 @@ const fsp = fs.promises
 const path = require('path')
 
 const waitOn = require('wait-on')
+const extract = require('extract-zip')
+const https = require('https')
 
 const { sleep } = require('../integration/utils')
+
+const log = (message) => console.log(`${new Date().toLocaleTimeString()} => ${message}`)
 
 const createFolderForFile = async (filepath) => {
   const dir = filepath.substring(0, filepath.lastIndexOf('/'))
@@ -28,6 +32,23 @@ const createFolderForFile = async (filepath) => {
     })
   }
 }
+
+const validateExtractedVersion = async fullFilename => {
+  // Retrieve the name and version from the package.json from the extracted zip file
+  const extractFolder = path.resolve(fullFilename.substring(0, fullFilename.lastIndexOf('.zip')))
+  log(`validating extract => ${extractFolder}`)
+  const data = fs.readFileSync(path.join(extractFolder, 'package.json'))
+  const { name, version } = JSON.parse(data)
+  // Retrieve the directory name of the extracted files
+  const separator = (extractFolder.indexOf('/') > -1) ? '/' : '\\'
+  const dirname = extractFolder.substring(extractFolder.lastIndexOf(separator) + 1)
+  // Make sure they match
+  if (`${name}-${version}` !== dirname) {
+    throw new Error(`Extracted folder ${extractFolder} contains wrong version in package.json >> ${name}-${version}`)
+  }
+}
+
+const downloadsFolder = path.resolve('cypress', 'downloads')
 
 /**
  * @type {Cypress.PluginConfig}
@@ -74,6 +95,53 @@ module.exports = (on, config) => {
 
   const makeSureCypressCanInterpretTheResult = () => null
 
+  const deleteFile = (filename, timeout = 0) => fsp.unlink(filename)
+    .then(() => sleep(timeout))
+    .catch((err) => err.code !== 'ENOENT' ? err : null
+    )
+
+  const deleteFolder = (folder, timeout = 0) => fsp.rmdir(folder, { recursive: true })
+    .then(() => sleep(timeout))
+    .catch((err) => err.code !== 'ENOENT' ? err : null
+    )
+
+  const download = async (url, zipFile) => {
+    return new Promise((resolve, reject) => {
+      log(`downloading => ${url}`)
+      const request = https.get(url, response => {
+        if (response.statusCode === 200) {
+          const filename = path.join(downloadsFolder, zipFile)
+          log(`writing => ${filename}`)
+          const file = fs.createWriteStream(filename, { flags: 'wx' })
+          file.on('finish', () => resolve(filename))
+          file.on('error', (err) => {
+            file.close()
+            fs.unlink(downloadsFolder, () => {
+              log(`writing => ${filename} => ${err.message}`)
+              reject(err.message)
+            }) // Delete temp file
+          })
+          response.pipe(file)
+        } else if (response.statusCode === 302 || response.statusCode === 301) {
+          // Recursively follow redirects, only a 200 will resolve.
+          const { location } = response.headers
+          if (!zipFile && location.endsWith('.zip')) {
+            const uri = new URL(location)
+            zipFile = uri.pathname.split('/').pop()
+          }
+          return download(location, zipFile).then((filename) =>
+            resolve(filename))
+        } else {
+          reject(new Error(`Server responded with ${response.statusCode}: ${response.statusMessage}`))
+        }
+      })
+
+      request.on('error', err => {
+        reject(err.message)
+      })
+    })
+  }
+
   on('task', {
     copyFile: ({ source, target }) => createFolderForFile(target)
       .then(() => fsp.copyFile(source, target))
@@ -91,11 +159,8 @@ module.exports = (on, config) => {
     appendFile: ({ filename, data }) => fsp.appendFile(filename, data)
       .then(makeSureCypressCanInterpretTheResult),
 
-    deleteFile: ({ filename, timeout }) => fsp.unlink(filename)
-      .then(() => sleep(timeout))
-      .then(makeSureCypressCanInterpretTheResult)
-      .catch((err) => err.code !== 'ENOENT' ? err : null
-      ),
+    deleteFile: ({ filename, timeout }) => deleteFile(filename, timeout)
+      .then(makeSureCypressCanInterpretTheResult),
 
     waitUntilAppRestarts: (config) => {
       const { timeout = 20000 } = config || {}
@@ -113,8 +178,23 @@ module.exports = (on, config) => {
       .then((text) => fsp.writeFile(filename, text.toString()))
       .then(makeSureCypressCanInterpretTheResult),
 
+    download: async ({ filename }) => {
+      log(`deleting folder => ${downloadsFolder}`)
+      return deleteFolder(downloadsFolder, 2000)
+        .then(() => fsp.mkdir(downloadsFolder, { recursive: true }))
+        .then(() => download(filename))
+        .then((fullFilename) => {
+          log(`extracting => ${fullFilename}`)
+          return extract(fullFilename, { dir: downloadsFolder })
+            .then(() => {
+              return validateExtractedVersion(fullFilename)
+            })
+        })
+        .then(makeSureCypressCanInterpretTheResult)
+    },
+
     log: (message) => {
-      console.log(`${new Date().toLocaleTimeString()} => ${message}`)
+      log(message)
       return makeSureCypressCanInterpretTheResult()
     }
   })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -65,6 +65,22 @@ Cypress.Commands.add('waitForResource', (name, options = {}) => {
   )
 })
 
+Cypress.Commands.add(
+  'download',
+  { prevSubject: true },
+  (subject) => {
+    return cy.get(subject)
+      .invoke('attr', 'href')
+      .then((filename) => {
+        cy.url().then((uri) => {
+          const url = new URL(uri)
+          cy.task('log', `Downloading ${url.origin}${filename}`)
+          cy.task('download', { filename: `${url.origin}${filename}` })
+        })
+      })
+  }
+)
+
 // ***********************************************
 // This example commands.js shows you how to
 // create various custom commands and overwrite

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
       "devDependencies": {
         "cypress": "^9.6.0",
         "eslint-plugin-cypress": "^2.12.1",
+        "extract-zip": "^2.0.1",
         "glob": "^7.1.4",
         "jest": "^28.1.1",
         "proper-lockfile": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:heroku": "echo 'test:heroku' needs to be implemented",
     "test:acceptance": "KIT_TEST_DIR=tmp/test-prototype-package start-server-and-test 'node cypress/scripts/run-starter-prototype' 3000 'cypress run'",
     "test:acceptance:open": "KIT_TEST_DIR=tmp/test-prototype-package start-server-and-test 'node cypress/scripts/run-starter-prototype' 3000 'cypress open'",
+    "test:acceptance:download": "KIT_TEST_DIR=tmp/test-prototype-package start-server-and-test 'node cypress/scripts/run-starter-prototype' 3000 'cypress run --config integrationFolder=cypress/download-tests'",
     "test:smoke": "cypress run --spec \"cypress/integration/0-smoke-tests/*\"",
     "test:unit": "jest lib",
     "test:integration": "jest --testTimeout=30000 __tests__",
@@ -55,6 +56,7 @@
   "devDependencies": {
     "cypress": "^9.6.0",
     "eslint-plugin-cypress": "^2.12.1",
+    "extract-zip": "^2.0.1",
     "glob": "^7.1.4",
     "jest": "^28.1.1",
     "proper-lockfile": "^4.1.2",
@@ -77,6 +79,7 @@
       "__tests__/util/",
       "/node_modules/",
       "/tmp/"
-    ]
+    ],
+    "testTimeout": 30000
   }
 }


### PR DESCRIPTION
Tests to download and extract the latest zip file of the prototype kit.
Please note that as cypress has an issue testing a download from an external page, I have created a custom cypress command to retrieve the href of the download and then download the file manually.
Note also that the download test runs in a seperate action.