### PR TITLE
Add gitignore to prototype starter files

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -16,6 +16,7 @@ const command = process.argv[2]
       fs.copy(path.join(kitRoot, 'prototype-starter'), installDirectory),
       copyFile('CHANGELOG.md'),
       copyFile('LICENCE.txt'),
+      copyFile('.gitignore'),
       copyFile('.npmrc'),
       copyFile('.nvmrc')
     ])


### PR DESCRIPTION
We want to help users avoid committing files that shouldn't be committed; this commit makes it so the install script copies our `.gitignore` file into the user's project.