### PR TITLE
Add Node v18 to supported engines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "wait-on": "^6.0.1"
       },
       "engines": {
-        "node": ">=12.0.0 <17.0.0"
+        "node": ">=12.0.0 <19.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "12.1.1",
   "private": true,
   "engines": {
-    "node": ">=12.0.0 <17.0.0"
+    "node": ">=12.0.0 <19.0.0"
   },
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Stop npm from complaining when we run tests on Node 18.