### PR TITLE
Remove changelog from prototype starter files

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -14,7 +14,6 @@ const command = process.argv[2]
   if (command === 'install') {
     await Promise.all([
       fs.copy(path.join(kitRoot, 'prototype-starter'), installDirectory),
-      copyFile('CHANGELOG.md'),
       copyFile('LICENCE.txt'),
       copyFile('.gitignore'),
       copyFile('.npmrc'),


### PR DESCRIPTION
It probably isn't useful for users to have the changelog of the kit when in their own prototype when they start one, we historically haven't done this. This commit stops the install command from copying `CHANGELOG`.