### PR TITLE
Copy .npmrc to prototype starter files as npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-audit=false
 script-shell=bash

--- a/bin/cli
+++ b/bin/cli
@@ -17,6 +17,11 @@ const command = process.argv[2]
       copyFile('LICENCE.txt'),
       copyFile('.nvmrc')
     ])
+
+    // Rename npmrc after the fact because npm will never include a file called .npmrc in a release.
+    // See https://docs.npmjs.com/cli/v8/configuring-npm/package-json#files
+    await fs.move(path.join(installDirectory, 'npmrc'), path.join(installDirectory, '.npmrc'))
+
     const installProcess = exec(`npm install ${kitRoot} govuk-frontend express`, { inherit: true })
     installProcess.stdout.on('data', function (data) {
       console.log(data)

--- a/prototype-starter/npmrc
+++ b/prototype-starter/npmrc
@@ -1,0 +1,2 @@
+audit=false
+script-shell=bash


### PR DESCRIPTION
npm will never pack a file called `.npmrc` [[1]], so we need to call it `npmrc` in our prototype starter and rename it during install with our script.

[1]: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#files