### PR TITLE
Setup router api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Breaking changes
-
+- [#1572: Set up router](https://github.com/alphagov/govuk-prototype-kit/pull/1572) Providing a way for users who want to set up routers now that the kit is a package.
 - [#1550: Allow extensions to add filters](https://github.com/alphagov/govuk-prototype-kit/issues/1550) Adding the ability for extensions to add filters, providing an API for filters
 - [#1522: Create govuk-branded.html template](https://github.com/alphagov/govuk-prototype-kit/pull/1522) This changes the way layouts are used, it also means you'll need to import nunjucks macros before using them (code snippets from the design system have the import in them).
 - [#1533: Generate Starter Files](https://github.com/alphagov/govuk-prototype-kit/pull/1533) This is a major change to the way the kit is used including:

--- a/cypress/e2e/3-link-page-tests/link-page-utils.js
+++ b/cypress/e2e/3-link-page-tests/link-page-utils.js
@@ -102,7 +102,7 @@ const setUpBranchingPages = () => {
   cy.task('replaceTextInFile', { filename: jugglingBallsView, originalText: jugglingTrickPath, newText: jugglingBallsAnswerRoute })
 
   // Update routes with juggling balls answer component
-  cy.task('replaceTextInFile', { filename: appRoutes, originalText: '// Add your routes here - above the module.exports line', source: jugglingBallsAnswerComponent })
+  cy.task('replaceTextInFile', { filename: appRoutes, originalText: '// Add your routes here', source: jugglingBallsAnswerComponent })
 }
 
 const cleanUpBranchingPages = () => {

--- a/cypress/fixtures/extensions/extension-bar/filters.js
+++ b/cypress/fixtures/extensions/extension-bar/filters.js
@@ -1,4 +1,4 @@
-const { addFilter } = require('govuk-prototype-kit').nunjucks
+const { addFilter } = require('govuk-prototype-kit').views
 
 addFilter('bar__link',
   (content, url) => `<a href="${url || '#'}">${content}</a>`,

--- a/cypress/fixtures/extensions/extension-bar/package-lock.json
+++ b/cypress/fixtures/extensions/extension-bar/package-lock.json
@@ -44,7 +44,7 @@
         "uuid": "^8.3.2"
       },
       "bin": {
-        "govuk-prototype-kit": "scripts/cli"
+        "govuk-prototype-kit": "bin/cli"
       },
       "devDependencies": {
         "cypress": "^10.6.0",
@@ -59,7 +59,7 @@
         "wait-on": "^6.0.1"
       },
       "engines": {
-        "node": ">=12.0.0 <17.0.0"
+        "node": ">=12.0.0 <19.0.0"
       }
     },
     "node_modules/govuk-prototype-kit": {

--- a/cypress/fixtures/extensions/extension-foo/filters.js
+++ b/cypress/fixtures/extensions/extension-foo/filters.js
@@ -1,4 +1,4 @@
-const { addFilter, getFilter } = require('govuk-prototype-kit').nunjucks
+const { addFilter, getFilter } = require('govuk-prototype-kit').views
 
 const safe = getFilter('safe')
 addFilter('foo__strong', (content) => safe(`<strong>${content}</strong>`))

--- a/cypress/fixtures/extensions/extension-foo/package-lock.json
+++ b/cypress/fixtures/extensions/extension-foo/package-lock.json
@@ -44,7 +44,7 @@
         "uuid": "^8.3.2"
       },
       "bin": {
-        "govuk-prototype-kit": "scripts/cli"
+        "govuk-prototype-kit": "bin/cli"
       },
       "devDependencies": {
         "cypress": "^10.6.0",
@@ -59,7 +59,7 @@
         "wait-on": "^6.0.1"
       },
       "engines": {
-        "node": ">=12.0.0 <17.0.0"
+        "node": ">=12.0.0 <19.0.0"
       }
     },
     "node_modules/govuk-prototype-kit": {

--- a/cypress/fixtures/routes.js
+++ b/cypress/fixtures/routes.js
@@ -1,5 +1,4 @@
-const express = require('express')
-const router = express.Router()
+const router = require('govuk-prototype-kit').requests.setupRouter()
 
 router.get('/cypress-test', (req, res) => {
   const heading = 'CYPRESS TEST PAGE'
@@ -14,5 +13,3 @@ router.get('/cypress-test', (req, res) => {
     </html>
 `)
 })
-
-module.exports = router

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
-const { getFilter, addFilter } = require('./lib/filters/api')
+const filtersApi = require('./lib/filters/api').external
+const routesApi = require('./lib/routes/api').external
 
 module.exports = {
-  nunjucks: {
-    getFilter,
-    addFilter
-  }
+  requests: routesApi,
+  views: filtersApi
 }

--- a/lib/filters/api.js
+++ b/lib/filters/api.js
@@ -42,7 +42,9 @@ const setEnvironment = (env) => {
   }
 }
 module.exports = {
-  addFilter,
-  getFilter,
+  external: {
+    addFilter,
+    getFilter
+  },
   setEnvironment
 }

--- a/lib/filters/coreFilters.js
+++ b/lib/filters/coreFilters.js
@@ -1,4 +1,4 @@
-const { addFilter, getFilter } = require('../../').nunjucks
+const { addFilter, getFilter } = require('../../').views
 
 const nunjucksSafe = getFilter('safe')
 

--- a/lib/filters/filters.test.js
+++ b/lib/filters/filters.test.js
@@ -11,7 +11,7 @@ describe('Filters', () => {
     const fn = () => {}
 
     api.setEnvironment(env)
-    api.addFilter('my-great-filter', fn)
+    api.external.addFilter('my-great-filter', fn)
 
     expect(env.addFilter).toHaveBeenCalledWith('my-great-filter', fn)
   })
@@ -21,12 +21,12 @@ describe('Filters', () => {
 
     api.setEnvironment(env)
 
-    expect(api.getFilter('my-great-filter')).toBe(fn)
+    expect(api.external.getFilter('my-great-filter')).toBe(fn)
   })
   it('Should log a warning when trying to get a filter before the environment is set', () => {
     jest.spyOn(console, 'warn').mockImplementation(() => {})
 
-    api.getFilter('my-great-filter')
+    api.external.getFilter('my-great-filter')
 
     expect(console.warn).toHaveBeenCalledWith('Trying to get filter before the environment is set, couldn\'t retrieve filter [my-great-filter]')
   })
@@ -38,7 +38,7 @@ describe('Filters', () => {
     }
 
     api.setEnvironment(env)
-    api.getFilter('my-great-filter')
+    api.external.getFilter('my-great-filter')
 
     expect(console.warn).toHaveBeenCalledWith('Couldn\'t retrieve filter [my-great-filter]')
   })
@@ -54,14 +54,14 @@ describe('Filters', () => {
     api.setEnvironment(env)
 
     expect(() => {
-      api.getFilter('my-great-filter')
+      api.external.getFilter('my-great-filter')
     }).toThrow(error)
   })
   it('Should allow adding filters before setting environment', () => {
     const env = { addFilter: jest.fn() }
     const fn = () => {}
 
-    api.addFilter('my-great-filter', fn)
+    api.external.addFilter('my-great-filter', fn)
     api.setEnvironment(env)
 
     expect(env.addFilter).toHaveBeenCalledWith('my-great-filter', fn)
@@ -70,9 +70,9 @@ describe('Filters', () => {
     const namesInOrder = []
     const env = { addFilter: jest.fn((name, fn) => { namesInOrder.push(name) }) }
 
-    api.addFilter('my-great-filter', () => {})
-    api.addFilter('someone-elses-filter', () => {})
-    api.addFilter('a-third-filter', () => {})
+    api.external.addFilter('my-great-filter', () => {})
+    api.external.addFilter('someone-elses-filter', () => {})
+    api.external.addFilter('a-third-filter', () => {})
     api.setEnvironment(env)
 
     expect(namesInOrder).toEqual(['my-great-filter', 'someone-elses-filter', 'a-third-filter'])
@@ -96,11 +96,11 @@ describe('Filters', () => {
       })
     }
 
-    api.addFilter('myHtmlFilter1', (content) => `__FILTER1_START__ ${content} __FILTER1_END__`, { renderAsHtml: true })
+    api.external.addFilter('myHtmlFilter1', (content) => `__FILTER1_START__ ${content} __FILTER1_END__`, { renderAsHtml: true })
     api.setEnvironment(env)
-    api.addFilter('myHtmlFilter2', (content) => `__FILTER2_START__ ${content} __FILTER2_END__`, { renderAsHtml: true })
+    api.external.addFilter('myHtmlFilter2', (content) => `__FILTER2_START__ ${content} __FILTER2_END__`, { renderAsHtml: true })
 
-    expect(api.getFilter('myHtmlFilter1')('CONTENT')).toBe(expected(1))
-    expect(api.getFilter('myHtmlFilter2')('CONTENT')).toBe(expected(2))
+    expect(api.external.getFilter('myHtmlFilter1')('CONTENT')).toBe(expected(1))
+    expect(api.external.getFilter('myHtmlFilter2')('CONTENT')).toBe(expected(2))
   })
 })

--- a/lib/routes/api.js
+++ b/lib/routes/api.js
@@ -3,8 +3,12 @@ const express = require('express')
 let expressApp
 const routersBeforeAppWasSet = []
 
-const configureAppToUseRouter = (router, path) => {
-  expressApp.use(path, router)
+const configureAppToUseRouter = (path, router) => {
+  if (expressApp) {
+    expressApp.use(path, router)
+  } else {
+    routersBeforeAppWasSet.push({ router, path })
+  }
 }
 
 module.exports = {
@@ -16,18 +20,17 @@ module.exports = {
         throw new Error(errorMessage)
       }
       const router = express.Router()
-      if (expressApp) {
-        configureAppToUseRouter(router, path)
-      } else {
-        routersBeforeAppWasSet.push({ router, path })
-      }
+      configureAppToUseRouter(path, router)
       return router
+    },
+    serveDirectory: (urlPath, directoryPath) => {
+      configureAppToUseRouter(urlPath, express.static(directoryPath))
     }
   },
   setApp: (app) => {
     expressApp = app
     routersBeforeAppWasSet.forEach(config => {
-      configureAppToUseRouter(config.router, config.path)
+      configureAppToUseRouter(config.path, config.router)
     })
   },
   resetState: () => {

--- a/lib/routes/api.js
+++ b/lib/routes/api.js
@@ -1,0 +1,37 @@
+const express = require('express')
+
+let expressApp
+const routersBeforeAppWasSet = []
+
+const configureAppToUseRouter = (router, path) => {
+  expressApp.use(path, router)
+}
+
+module.exports = {
+  external: {
+    setupRouter: (path = '/') => {
+      if (typeof path !== 'string' && path !== undefined) {
+        const errorMessage = 'setupRouter cannot be provided with a router,' +
+          ' it sets up a router and returns it to you.'
+        throw new Error(errorMessage)
+      }
+      const router = express.Router()
+      if (expressApp) {
+        configureAppToUseRouter(router, path)
+      } else {
+        routersBeforeAppWasSet.push({ router, path })
+      }
+      return router
+    }
+  },
+  setApp: (app) => {
+    expressApp = app
+    routersBeforeAppWasSet.forEach(config => {
+      configureAppToUseRouter(config.router, config.path)
+    })
+  },
+  resetState: () => {
+    expressApp = undefined
+    routersBeforeAppWasSet.splice(0, routersBeforeAppWasSet.length)
+  }
+}

--- a/lib/routes/api.spec.js
+++ b/lib/routes/api.spec.js
@@ -1,0 +1,69 @@
+/* eslint-env jest */
+
+const routers = require('./api')
+const fakeValues = {
+  router: {}
+}
+
+jest.mock('express', () => {
+  return { Router: jest.fn(() => fakeValues.router) }
+})
+
+describe('routes API', () => {
+  afterEach(() => {
+    routers.resetState()
+  })
+  it('should return a router', () => {
+    const fakeRouter = {}
+
+    const router = routers.external.setupRouter()
+
+    expect(router).toEqual(fakeRouter)
+  })
+  it('should set the router up with the app', () => {
+    const fakeRouter = {}
+    const fakeApp = { use: jest.fn() }
+
+    routers.setApp(fakeApp)
+    routers.external.setupRouter()
+
+    expect(fakeApp.use).toHaveBeenCalledWith('/', fakeRouter)
+  })
+  it('should set the router up with the app even if the app is included after the router is created', () => {
+    const fakeRouter = {}
+    const fakeApp = { use: jest.fn() }
+
+    routers.external.setupRouter()
+    routers.setApp(fakeApp)
+
+    expect(fakeApp.use).toHaveBeenCalledWith('/', fakeRouter)
+  })
+  it('should allow the user to set the path of the router', () => {
+    const fakeRouter = {}
+    const fakeApp = { use: jest.fn() }
+
+    routers.setApp(fakeApp)
+    routers.external.setupRouter('/my-path')
+
+    expect(fakeApp.use).toHaveBeenCalledWith('/my-path', fakeRouter)
+  })
+  it('should allow the user to set the path of the router when the app is included after the router', () => {
+    const fakeRouter = {}
+    const fakeApp = { use: jest.fn() }
+
+    routers.external.setupRouter('/my-path')
+    routers.setApp(fakeApp)
+
+    expect(fakeApp.use).toHaveBeenCalledWith('/my-path', fakeRouter)
+  })
+  it('should error if anything other than a string is provided for the path', () => {
+    const expectedError = new Error('setupRouter cannot be provided with a router, it sets up a router and returns it to you.')
+    expect(() => {
+      routers.external.setupRouter(() => {})
+    }).toThrow(expectedError)
+
+    expect(() => {
+      routers.external.setupRouter({})
+    }).toThrow(expectedError)
+  })
+})

--- a/lib/routes/api.spec.js
+++ b/lib/routes/api.spec.js
@@ -1,12 +1,17 @@
 /* eslint-env jest */
+const express = require('express')
 
 const routers = require('./api')
 const fakeValues = {
-  router: {}
+  router: {},
+  static: {}
 }
 
 jest.mock('express', () => {
-  return { Router: jest.fn(() => fakeValues.router) }
+  return {
+    Router: jest.fn(() => fakeValues.router),
+    static: jest.fn(() => fakeValues.static)
+  }
 })
 
 describe('routes API', () => {
@@ -65,5 +70,23 @@ describe('routes API', () => {
     expect(() => {
       routers.external.setupRouter({})
     }).toThrow(expectedError)
+  })
+  it('should set up a static router', () => {
+    const fakeApp = { use: jest.fn() }
+
+    routers.setApp(fakeApp)
+    routers.external.serveDirectory('/abc', '/tmp/abcd')
+
+    expect(fakeApp.use).toHaveBeenCalledWith('/abc', fakeValues.static)
+    expect(express.static).toHaveBeenCalledWith('/tmp/abcd')
+  })
+  it('should set up a static router when app is set after', () => {
+    const fakeApp = { use: jest.fn() }
+
+    routers.external.serveDirectory('/abc', '/tmp/efgh')
+    routers.setApp(fakeApp)
+
+    expect(fakeApp.use).toHaveBeenCalledWith('/abc', fakeValues.static)
+    expect(express.static).toHaveBeenCalledWith('/tmp/efgh')
   })
 })

--- a/lib/routes/extensions.js
+++ b/lib/routes/extensions.js
@@ -1,13 +1,11 @@
-const express = require('express')
-
-const router = require('../../index').requests.setupRouter()
+const requests = require('../../index').requests
 const extensions = require('../extensions/extensions')
 
 // Serve assets from extensions
 function setupPathsFor (item) {
   extensions.getPublicUrlAndFileSystemPaths(item)
     .forEach(paths => {
-      router.use(paths.publicUrl, express.static(paths.fileSystemPath))
+      requests.serveDirectory(paths.publicUrl, paths.fileSystemPath)
     })
 }
 

--- a/lib/routes/extensions.js
+++ b/lib/routes/extensions.js
@@ -1,6 +1,7 @@
 const express = require('express')
-const extensions = require('../../extensions/extensions')
-const router = express.Router()
+
+const router = require('../../index').requests.setupRouter()
+const extensions = require('../extensions/extensions')
 
 // Serve assets from extensions
 function setupPathsFor (item) {
@@ -13,5 +14,3 @@ function setupPathsFor (item) {
 setupPathsFor('scripts')
 setupPathsFor('stylesheets')
 setupPathsFor('assets')
-
-module.exports = router

--- a/lib/routes/prototype-admin-routes.js
+++ b/lib/routes/prototype-admin-routes.js
@@ -1,9 +1,7 @@
-// NPM dependencies
-const express = require('express')
-const router = express.Router()
+const router = require('../../index').requests.setupRouter('/prototype-admin')
 
 // Local dependencies
-const encryptPassword = require('./utils').encryptPassword
+const encryptPassword = require('../utils').encryptPassword
 
 const password = process.env.PASSWORD
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,6 +13,7 @@ const inquirer = require('inquirer')
 const config = require('./config')
 const { appDir, projectDir } = require('./path-utils')
 const filters = require('./filters/api')
+const routes = require('./routes/api')
 const extensions = require('./extensions/extensions')
 
 // Are we running on Glitch.com?
@@ -62,6 +63,14 @@ exports.addNunjucksFilters = function (env) {
   }
   const filterFiles = extensions.getFileSystemPaths('nunjucksFilters').concat(additionalFilters)
   filterFiles.forEach(x => require(x))
+}
+
+exports.addRouters = function (app) {
+  routes.setApp(app)
+  const routesPath = path.join(appDir, 'routes.js')
+  if (fs.existsSync(routesPath)) {
+    require(routesPath)
+  }
 }
 
 // Add Nunjucks function called 'checked' to populate radios and checkboxes

--- a/prototype-starter/app/filters.js
+++ b/prototype-starter/app/filters.js
@@ -1,3 +1,2 @@
-const addFilter = require('govuk-prototype-kit').nunjucks.addFilter
-
-addFilter('sayHi', (name, tone) => (tone === 'formal' ? 'Greetings' : 'Hi') + ' ' + name + '!')
+/* eslint-disable-next-line no-unused-vars */
+const addFilter = require('govuk-prototype-kit').views.addFilter

--- a/prototype-starter/app/routes.js
+++ b/prototype-starter/app/routes.js
@@ -1,6 +1,4 @@
-const express = require('express')
-const router = express.Router()
+/* eslint-disable-next-line no-unused-vars */
+const router = require('govuk-prototype-kit').requests.setupRouter()
 
-// Add your routes here - above the module.exports line
-
-module.exports = router
+// Add your routes here


### PR DESCRIPTION
Allowing the user to create a router.

We explored ideas around more fine grained control instead of providing router functionality but I've reconsidered and think that's better to grow over time alongside providing routers.  We can deprecate the routers at a later date if we want to replace them with more fine grained methods.