### PR TITLE
Make govuk-prototype-kit install command work with npm

### DIFF
--- a/__tests__/util/index.js
+++ b/__tests__/util/index.js
@@ -4,6 +4,8 @@ const fs = require('fs-extra')
 const os = require('os')
 const path = require('path')
 
+const { packageDir: repoDir } = require('../../lib/path-utils')
+
 /**
  * An ID that will be shared between all process in the same Jest test run,
  * this is useful for sharing fixture files. Normally sharing state across Jest
@@ -78,16 +80,15 @@ async function mkPrototype (prototypePath, {
     // Create test starter project folder
     await fs.mkdirp(prototypePath)
 
-    // Generate starter project and start
-    child_process.execSync(
-      'npm i -g',
-      { stdio: 'inherit' }
+    await fs.writeJson(
+      path.join(prototypePath, 'package.json'),
+      { dependencies: { 'govuk-prototype-kit': `file:${repoDir}` } }
     )
 
     // Generate starter project and start
     child_process.execSync(
-      'govuk-prototype-kit install',
-      { cwd: prototypePath, env: { ...process.env, env: 'test' }, stdio: 'inherit' }
+      `node bin/cli install -- ${prototypePath}`,
+      { env: { ...process.env, env: 'test' }, stdio: 'inherit' }
     )
 
     if (allowTracking !== undefined) {

--- a/bin/cli
+++ b/bin/cli
@@ -2,7 +2,7 @@
 
 const fs = require('fs-extra')
 const path = require('path')
-const { exec } = require('child_process')
+const { execSync } = require('child_process')
 
 const installDirectory = process.cwd()
 const kitRoot = path.join(__dirname, '..')
@@ -49,10 +49,7 @@ ${prog} start`
       copyFile('LICENCE.txt')
     ])
 
-    const installProcess = exec(`npm install ${kitRoot} govuk-frontend express`, { inherit: true })
-    installProcess.stdout.on('data', function (data) {
-      console.log(data)
-    })
+    execSync(`npm install ${kitRoot} govuk-frontend express`, { stdio: 'inherit' })
   } else if (command === 'start') {
     require('../start')
   } else {

--- a/bin/cli
+++ b/bin/cli
@@ -102,9 +102,9 @@ function isSafeToCreateProjectIn (root, name) {
     // as possible into stage two; stage one should ideally be able to install
     // any future version of the kit.
 
-    argv = process.argv
-    argc = process.argv.length
-    if (argc === 3 || (argc === 5 && argv[3] === '--package-spec')) {
+    const argv = process.argv
+    const numberOfArguments = process.argv.length
+    if (numberOfArguments === 3 || (numberOfArguments === 5 && argv[3] === '--package-spec')) {
       // stage one
       const installDirectory = process.cwd()
       if (!isSafeToCreateProjectIn(installDirectory, path.basename(installDirectory))) {
@@ -126,7 +126,7 @@ function isSafeToCreateProjectIn (root, name) {
           stdio: 'inherit'
         }
       )
-    } else if (argc === 5 && argv[3] === '--') {
+    } else if (numberOfArguments === 5 && argv[3] === '--') {
       // stage two
       const installDirectory = process.argv[4]
       await fs.access(installDirectory, fs.constants.W_OK)

--- a/bin/cli
+++ b/bin/cli
@@ -116,9 +116,10 @@ function isSafeToCreateProjectIn (root, name) {
       const packageSpec = argv[4] || 'govuk-prototype-kit'
 
       await fs.writeFile(path.join(installDirectory, 'package.json'), '{}' + os.EOL, 'utf8')
+      console.log(`Installing ${packageSpec}, this may take a few minutes...`)
       execSync(`npm install ${packageSpec}`, { stdio: 'inherit' })
       execSync(
-        `npm exec -- govuk-prototype-kit install -- ${installDirectory}`,
+        `${process.execPath} node_modules/.bin/govuk-prototype-kit install -- ${installDirectory}`,
         {
           env: { LANG: process.env.LANG, PATH: process.env.PATH }, // clearing the env of any npm_ stuff is important,
                                                                    // otherwise npx won't be able to use the package we just installed
@@ -147,7 +148,7 @@ function isSafeToCreateProjectIn (root, name) {
       stageTwoPackageJson.dependencies = stageOnePackageJson.dependencies
       await fs.writeFile(packageJsonPath, JSON.stringify(stageTwoPackageJson, null, 2) + os.EOL, 'utf8')
 
-      execSync('npm install govuk-frontend express', { cwd: installDirectory, stdio: 'inherit' })
+      execSync('npm install govuk-frontend express', { cwd: installDirectory, stdio: 'ignore' })
     } else {
       usage()
       process.exitCode = 2

--- a/bin/cli
+++ b/bin/cli
@@ -145,10 +145,10 @@ function isSafeToCreateProjectIn (root, name) {
 
       // Add govuk-prototype-kit from stage one package.json back into the starter files package.json
       const stageTwoPackageJson = await fs.readJson(packageJsonPath, 'utf8')
-      stageTwoPackageJson.dependencies = stageOnePackageJson.dependencies
+      stageTwoPackageJson.dependencies = Object.assign(stageTwoPackageJson.dependencies || {}, stageOnePackageJson.dependencies || {})
       await fs.writeFile(packageJsonPath, JSON.stringify(stageTwoPackageJson, null, 2) + os.EOL, 'utf8')
 
-      execSync('npm install govuk-frontend express', { cwd: installDirectory, stdio: 'ignore' })
+      execSync('npm install', { cwd: installDirectory, stdio: 'ignore' })
     } else {
       usage()
       process.exitCode = 2

--- a/bin/cli
+++ b/bin/cli
@@ -52,11 +52,17 @@ ${prog} start`
     // as possible into stage two; stage one should ideally be able to install
     // any future version of the kit.
 
-    if (process.argv.length === 3) {
+    argv = process.argv
+    argc = process.argv.length
+    if (argc === 3 || (argc === 5 && argv[3] === '--package-spec')) {
       // stage one
+
+      // undocumented command line arg to specify package spec of kit to install
+      const packageSpec = argv[4] || 'govuk-prototype-kit'
+
       const installDirectory = process.cwd()
       await fs.writeFile(path.join(installDirectory, 'package.json'), '{}' + os.EOL, 'utf8')
-      execSync('npm install govuk-prototype-kit', { stdio: 'inherit' })
+      execSync(`npm install ${packageSpec}`, { stdio: 'inherit' })
       execSync(
         `npm exec -- govuk-prototype-kit install -- ${installDirectory}`,
         {
@@ -65,7 +71,7 @@ ${prog} start`
           stdio: 'inherit'
         }
       )
-    } else if (process.argv.length === 5 && process.argv[3] === '--') {
+    } else if (argc === 5 && argv[3] === '--') {
       // stage two
       const installDirectory = process.argv[4]
       await fs.access(installDirectory, fs.constants.W_OK)

--- a/bin/cli
+++ b/bin/cli
@@ -28,6 +28,18 @@ public/
 .idea
 `
 
+function usage () {
+  const prog = 'govuk-prototype-kit'
+  console.log(`
+${prog} <command>
+
+Usage:
+
+${prog} install
+${prog} start`
+  )
+}
+
 ;(async () => {
   if (command === 'install') {
     await Promise.all([
@@ -44,7 +56,7 @@ public/
   } else if (command === 'start') {
     require('../start')
   } else {
-    console.log(`I don't know how to handle ${command}`)
-    process.exit(2)
+    usage()
+    process.exitCode = 2
   }
 })()

--- a/bin/cli
+++ b/bin/cli
@@ -1,13 +1,10 @@
 #!/usr/bin/env node
 
 const fs = require('fs-extra')
+const os = require('os')
 const path = require('path')
 const { execSync } = require('child_process')
 
-const installDirectory = process.cwd()
-const kitRoot = path.join(__dirname, '..')
-
-const copyFile = (fileName) => fs.copy(path.join(kitRoot, fileName), path.join(installDirectory, fileName))
 const command = process.argv[2]
 
 const npmrc = `
@@ -42,14 +39,59 @@ ${prog} start`
 
 ;(async () => {
   if (command === 'install') {
-    await Promise.all([
-      fs.copy(path.join(kitRoot, 'prototype-starter'), installDirectory),
-      fs.writeFile(path.join(installDirectory, '.gitignore'), gitignore, 'utf8'),
+    // Install as a two-stage bootstrap process.
+    //
+    // In the first stage, when install has no arguments, we just install the
+    // latest version of govuk-prototype-kit, then bootstrap stage two.
+    //
+    // In the second stage, when install has the magic arguments, we do the
+    // actual setup of the starter files.
+    //
+    // Doing it this way means we can be sure the version of the cli matches
+    // the version of the kit the user ends up with. Try to put as much logic
+    // as possible into stage two; stage one should ideally be able to install
+    // any future version of the kit.
+
+    if (process.argv.length === 3) {
+      // stage one
+      const installDirectory = process.cwd()
+      await fs.writeFile(path.join(installDirectory, 'package.json'), '{}' + os.EOL, 'utf8')
+      execSync('npm install govuk-prototype-kit', { stdio: 'inherit' })
+      execSync(
+        `npm exec -- govuk-prototype-kit install -- ${installDirectory}`,
+        {
+          env: { LANG: process.env.LANG, PATH: process.env.PATH }, // clearing the env of any npm_ stuff is important,
+                                                                   // otherwise npx won't be able to use the package we just installed
+          stdio: 'inherit'
+        }
+      )
+    } else if (process.argv.length === 5 && process.argv[3] === '--') {
+      // stage two
+      const installDirectory = process.argv[4]
+      await fs.access(installDirectory, fs.constants.W_OK)
+      const kitRoot = path.resolve(__dirname, '..')
+      const packageJsonPath = path.join(installDirectory, 'package.json')
+      const stageOnePackageJson = await fs.readJson(packageJsonPath, 'utf8')
+
+      const copyFile = (fileName) => fs.copy(path.join(kitRoot, fileName), path.join(installDirectory, fileName))
+
+      await Promise.all([
+        fs.copy(path.join(kitRoot, 'prototype-starter'), installDirectory),
+        fs.writeFile(path.join(installDirectory, '.gitignore'), gitignore, 'utf8'),
       fs.writeFile(path.join(installDirectory, '.npmrc'), npmrc, 'utf8'),
       copyFile('LICENCE.txt')
     ])
 
-    execSync(`npm install ${kitRoot} govuk-frontend express`, { stdio: 'inherit' })
+      // Add govuk-prototype-kit from stage one package.json back into the starter files package.json
+      const stageTwoPackageJson = await fs.readJson(packageJsonPath, 'utf8')
+      stageTwoPackageJson.dependencies = stageOnePackageJson.dependencies
+      await fs.writeFile(packageJsonPath, JSON.stringify(stageTwoPackageJson, null, 2) + os.EOL, 'utf8')
+
+      execSync('npm install govuk-frontend express', { cwd: installDirectory, stdio: 'inherit' })
+    } else {
+      usage()
+      process.exitCode = 2
+    }
   } else if (command === 'start') {
     require('../start')
   } else {

--- a/bin/cli
+++ b/bin/cli
@@ -37,6 +37,56 @@ ${prog} start`
   )
 }
 
+function isSafeToCreateProjectIn (root, name) {
+    const validFiles = [
+    '.DS_Store',
+    '.git',
+    '.gitattributes',
+    '.gitignore',
+    '.gitlab-ci.yml',
+    '.hg',
+    '.hgcheck',
+    '.hgignore',
+    '.idea',
+    '.npmignore',
+    '.travis.yml',
+    'docs',
+    'README.md',
+    'Thumbs.db',
+  ]
+
+  const conflicts = fs
+    .readdirSync(root)
+    .filter(file => !validFiles.includes(file))
+
+  if (conflicts.length > 0) {
+    console.log(
+      `The directory ${name} contains files that could conflict:`
+    );
+    console.log();
+    for (const file of conflicts) {
+      try {
+        const stats = fs.lstatSync(path.join(root, file));
+        if (stats.isDirectory()) {
+          console.log(`  ${file}/`);
+        } else {
+          console.log(`  ${file}`);
+        }
+      } catch (e) {
+        console.log(`  ${file}`);
+      }
+    }
+    console.log();
+    console.log(
+      'Either try using a new directory name, or remove the files listed above.'
+    );
+
+    return false
+  }
+
+  return true
+}
+
 ;(async () => {
   if (command === 'install') {
     // Install as a two-stage bootstrap process.
@@ -56,11 +106,15 @@ ${prog} start`
     argc = process.argv.length
     if (argc === 3 || (argc === 5 && argv[3] === '--package-spec')) {
       // stage one
+      const installDirectory = process.cwd()
+      if (!isSafeToCreateProjectIn(installDirectory, path.basename(installDirectory))) {
+        process.exitCode = 1
+        return
+      }
 
       // undocumented command line arg to specify package spec of kit to install
       const packageSpec = argv[4] || 'govuk-prototype-kit'
 
-      const installDirectory = process.cwd()
       await fs.writeFile(path.join(installDirectory, 'package.json'), '{}' + os.EOL, 'utf8')
       execSync(`npm install ${packageSpec}`, { stdio: 'inherit' })
       execSync(

--- a/prototype-starter/package.json
+++ b/prototype-starter/package.json
@@ -1,5 +1,9 @@
 {
   "scripts": {
     "start": "govuk-prototype-kit start"
+  },
+  "dependencies": {
+    "express": "^4.18.1",
+    "govuk-frontend": "^4.3.1"
   }
 }


### PR DESCRIPTION
We want users to be able to run

    npx govuk-prototype-kit install

and have it do the thing they expect; i.e install the kit and create the project for them.

To get this to work I had to make a few changes; see the commits for details.