### PR TITLE
Interface update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   - Generated assets are all inside .tmp
   - The core prototype-kit files have been moved into the package
   - The start script uses the new govuk-prototype-kit cli
-  - To start a new kit the user will need to either run `npx govuk-prototype-kit install` or be provided the results of running this command in a zip format
+  - To start a new kit the user will need to either run `npx govuk-prototype-kit create` or be provided the results of running this command in a zip format
 - [#1471: Update step by step and install it as an extension](https://github.com/alphagov/govuk-prototype-kit/pull/1471)
 - [#1394: Remove Internet Explorer 8 support](https://github.com/alphagov/govuk-prototype-kit/issues/1394)
 - [#1432: Remove v6 backwards compatibility support](https://github.com/alphagov/govuk-prototype-kit/pull/1432)

--- a/__tests__/spec/sanity-checks.js
+++ b/__tests__/spec/sanity-checks.js
@@ -24,7 +24,6 @@ function readFile (pathFromRoot) {
  */
 describe('The Prototype Kit', () => {
   beforeAll(async () => {
-    process.env.IS_INTEGRATION_TEST = 'true'
     await mkPrototype(tmpDir, { allowTracking: false, overwrite: true })
     app = require(path.join(tmpDir, 'node_modules', 'govuk-prototype-kit', 'server.js'))
     jest.spyOn(fse, 'writeFileSync').mockImplementation(() => {})

--- a/__tests__/util/index.js
+++ b/__tests__/util/index.js
@@ -86,7 +86,7 @@ async function mkPrototype (prototypePath, {
 
     // Generate starter project and start
     child_process.execSync(
-      'govuk-prototype-kit install local',
+      'govuk-prototype-kit create local .',
       { cwd: prototypePath, env: { ...process.env, env: 'test' }, stdio: 'inherit' }
     )
 

--- a/__tests__/util/index.js
+++ b/__tests__/util/index.js
@@ -86,7 +86,7 @@ async function mkPrototype (prototypePath, {
 
     // Generate starter project and start
     child_process.execSync(
-      'govuk-prototype-kit create local .',
+      'govuk-prototype-kit create --version local',
       { cwd: prototypePath, env: { ...process.env, env: 'test' }, stdio: 'inherit' }
     )
 

--- a/bin/cli
+++ b/bin/cli
@@ -8,9 +8,8 @@ const { runUpgrade } = require('../lib/upgradeToV13')
 const currentDirectory = process.cwd()
 const kitRoot = path.join(__dirname, '..')
 
-const command = process.argv[2]
-const option = process.argv[3]
-const lastOption = process.argv.length > 3 ? process.argv[process.argv.length - 1] : undefined
+const additionalOptions = [].concat(...process.argv).splice(2)
+const command = additionalOptions.shift()
 
 const npmrc = `
 audit=false
@@ -37,28 +36,61 @@ ${prog} <command>
 
 Usage:
 
-${prog} install
+${prog} create
+${prog} create /exact/location/to/create/in
+${prog} create relative/location/to/create/in
+${prog}
 ${prog} start`
   )
 }
 
 const getInstallLocation = () => {
-    if (lastOption) {
-      if (lastOption.startsWith('/')) {
-        return lastOption
-      }
-      return path.join(currentDirectory, lastOption)
+  const lastOption = ('' + additionalOptions[additionalOptions.length - 2]).startsWith('-') ? undefined : additionalOptions[additionalOptions.length - 1]
+  if (lastOption) {
+    if (lastOption.startsWith('/')) {
+      return lastOption
     }
-    return currentDirectory
+    return path.join(currentDirectory, lastOption)
+  }
+  return currentDirectory
+}
+
+const getChosenKitDependency = () => {
+  const defaultValue = 'govuk-prototype-kit'
+  let versionFlagIndex = additionalOptions.indexOf('--version')
+  if (versionFlagIndex === -1) {
+    versionFlagIndex = additionalOptions.indexOf('-v')
+  }
+  if (versionFlagIndex === -1) {
+    return defaultValue
   }
 
-;(async () => {
+  const versionRequested = additionalOptions[versionFlagIndex + 1]
+
+  if (versionRequested === 'local') {
+    return kitRoot
+  } else if (versionRequested) {
+    if (versionRequested.match(/\d+\.\d+\.\d+/) ||
+      versionRequested.match(/\d+\.\d+\.\d+-alpha\.\d+]/) ||
+      versionRequested.match(/\d+\.\d+\.\d+-beta\.\d+]/)
+    ) {
+      return `${defaultValue}@${versionRequested}`
+    } else {
+      return versionRequested
+    }
+  }
+  return defaultValue
+};
+
+(async () => {
   if (command === 'create') {
     const installDirectory = getInstallLocation()
+    const kitDependency = getChosenKitDependency()
+
     const copyFile = (fileName) => fs.copy(path.join(kitRoot, fileName), path.join(installDirectory, fileName))
-    
+
     await fs.ensureDir(installDirectory)
-    
+
     await Promise.all([
       fs.copy(path.join(kitRoot, 'prototype-starter'), installDirectory),
       fs.writeFile(path.join(installDirectory, '.gitignore'), gitignore, 'utf8'),
@@ -66,26 +98,11 @@ const getInstallLocation = () => {
       copyFile('LICENCE.txt')
     ])
 
-    let kitDependency = 'govuk-prototype-kit'
-
-    if (option === 'local') {
-      kitDependency = kitRoot
-    } else if (option && option !== lastOption) {
-      if (option.match(/\d+\.\d+\.\d+/) ||
-        option.match(/\d+\.\d+\.\d+-alpha\.\d+]/) ||
-        option.match(/\d+\.\d+\.\d+-beta\.\d+]/)
-      ) {
-        kitDependency = `govuk-prototype-kit@${option}`
-      } else {
-        kitDependency = option
-      }
-    }
-
     console.log('Creating your prototype')
     const dots = setInterval(() => {
       process.stdout.write('.')
     }, 500)
-    await exec(`npm install ${kitDependency} govuk-frontend`, { 
+    await exec(`npm install ${kitDependency} govuk-frontend`, {
       stdio: 'inherit',
       cwd: installDirectory
     }, console.log)

--- a/bin/cli
+++ b/bin/cli
@@ -5,12 +5,12 @@ const path = require('path')
 const { exec } = require('../lib/exec')
 const { runUpgrade } = require('../lib/upgradeToV13')
 
-const installDirectory = process.cwd()
+const currentDirectory = process.cwd()
 const kitRoot = path.join(__dirname, '..')
 
-const copyFile = (fileName) => fs.copy(path.join(kitRoot, fileName), path.join(installDirectory, fileName))
 const command = process.argv[2]
 const option = process.argv[3]
+const lastOption = process.argv.length > 3 ? process.argv[process.argv.length - 1] : undefined
 
 const npmrc = `
 audit=false
@@ -42,8 +42,23 @@ ${prog} start`
   )
 }
 
+const getInstallLocation = () => {
+    if (lastOption) {
+      if (lastOption.startsWith('/')) {
+        return lastOption
+      }
+      return path.join(currentDirectory, lastOption)
+    }
+    return currentDirectory
+  }
+
 ;(async () => {
-  if (command === 'install') {
+  if (command === 'create') {
+    const installDirectory = getInstallLocation()
+    const copyFile = (fileName) => fs.copy(path.join(kitRoot, fileName), path.join(installDirectory, fileName))
+    
+    await fs.ensureDir(installDirectory)
+    
     await Promise.all([
       fs.copy(path.join(kitRoot, 'prototype-starter'), installDirectory),
       fs.writeFile(path.join(installDirectory, '.gitignore'), gitignore, 'utf8'),
@@ -55,7 +70,7 @@ ${prog} start`
 
     if (option === 'local') {
       kitDependency = kitRoot
-    } else if (option) {
+    } else if (option && option !== lastOption) {
       if (option.match(/\d+\.\d+\.\d+/) ||
         option.match(/\d+\.\d+\.\d+-alpha\.\d+]/) ||
         option.match(/\d+\.\d+\.\d+-beta\.\d+]/)
@@ -66,13 +81,16 @@ ${prog} start`
       }
     }
 
-    console.log('Installing the kit')
+    console.log('Creating your prototype')
     const dots = setInterval(() => {
-      process.stdout.write('.');
+      process.stdout.write('.')
     }, 500)
-    await exec(`npm install ${kitDependency} govuk-frontend`, { stdio: 'inherit' }, console.log)
+    await exec(`npm install ${kitDependency} govuk-frontend`, { 
+      stdio: 'inherit',
+      cwd: installDirectory
+    }, console.log)
     clearInterval(dots)
-    
+
   } else if (command === 'start') {
     require('../start')
   } else if (command === 'upgrade') {

--- a/lib/routes/prototype-admin-routes.js
+++ b/lib/routes/prototype-admin-routes.js
@@ -43,9 +43,10 @@ const updateLatestReleaseVersions = async () => {
   return latestReleaseVersions
 }
 
-updateLatestReleaseVersions()
-
-// setInterval(lookupLatestPackageVersion, 1000 * 60 * 20)
+if (process.env.IS_INTEGRATION_TEST !== 'true') {
+  updateLatestReleaseVersions()
+  setInterval(lookupLatestPackageVersion, 1000 * 60 * 20)
+}
 
 templateRenderNunjucks.configure(appViews, {
   autoescape: true,

--- a/lib/upgradeToV13/known-old-versions/app-views-layout.html/v12.2.0.html
+++ b/lib/upgradeToV13/known-old-versions/app-views-layout.html/v12.2.0.html
@@ -41,7 +41,7 @@
 {% endblock %}
 
 {% block header %}
-  {# Set serviceName in config.json. #}
+  {# Set serviceName in config.js. #}
   {{ govukHeader({
     homepageUrl: "/",
     serviceName: serviceName,

--- a/lib/upgradeToV13/known-old-versions/app-views-layout.html/v7.0.0.html
+++ b/lib/upgradeToV13/known-old-versions/app-views-layout.html/v7.0.0.html
@@ -33,7 +33,7 @@
 
 {% block header %}
   {% include "includes/cookie-banner.html" %}
-  {# Set serviceName in config.json. #}
+  {# Set serviceName in config.js. #}
   {{ govukHeader({
     homepageUrl: "/",
     serviceName: serviceName,

--- a/lib/upgradeToV13/known-old-versions/app-views-layout.html/v7.1.0.html
+++ b/lib/upgradeToV13/known-old-versions/app-views-layout.html/v7.1.0.html
@@ -33,7 +33,7 @@
 
 {% block header %}
   {% include "includes/cookie-banner.html" %}
-  {# Set serviceName in config.json. #}
+  {# Set serviceName in config.js. #}
   {{ govukHeader({
     homepageUrl: "/",
     serviceName: serviceName,

--- a/lib/upgradeToV13/known-old-versions/app-views-layout.html/v8.0.0.html
+++ b/lib/upgradeToV13/known-old-versions/app-views-layout.html/v8.0.0.html
@@ -33,7 +33,7 @@
 
 {% block header %}
   {% include "includes/cookie-banner.html" %}
-  {# Set serviceName in config.json. #}
+  {# Set serviceName in config.js. #}
   {{ govukHeader({
     homepageUrl: "/",
     serviceName: serviceName,

--- a/lib/upgradeToV13/known-old-versions/app-views-layout.html/v8.2.0.html
+++ b/lib/upgradeToV13/known-old-versions/app-views-layout.html/v8.2.0.html
@@ -34,7 +34,7 @@
 
 {% block header %}
   {% include "includes/cookie-banner.html" %}
-  {# Set serviceName in config.json. #}
+  {# Set serviceName in config.js. #}
   {{ govukHeader({
     homepageUrl: "/",
     serviceName: serviceName,

--- a/lib/upgradeToV13/known-old-versions/app-views-layout.html/v8.5.0.html
+++ b/lib/upgradeToV13/known-old-versions/app-views-layout.html/v8.5.0.html
@@ -36,7 +36,7 @@
 
 {% block header %}
   {% include "includes/cookie-banner.html" %}
-  {# Set serviceName in config.json. #}
+  {# Set serviceName in config.js. #}
   {{ govukHeader({
     homepageUrl: "/",
     serviceName: serviceName,

--- a/lib/upgradeToV13/known-old-versions/app-views-layout.html/v9.0.0.html
+++ b/lib/upgradeToV13/known-old-versions/app-views-layout.html/v9.0.0.html
@@ -39,7 +39,7 @@
 
 {% block header %}
   {% include "includes/cookie-banner.html" %}
-  {# Set serviceName in config.json. #}
+  {# Set serviceName in config.js. #}
   {{ govukHeader({
     homepageUrl: "/",
     serviceName: serviceName,

--- a/lib/upgradeToV13/known-old-versions/app-views-layout.html/v9.11.1.html
+++ b/lib/upgradeToV13/known-old-versions/app-views-layout.html/v9.11.1.html
@@ -40,7 +40,7 @@
 
 {% block header %}
   {% include "includes/cookie-banner.html" %}
-  {# Set serviceName in config.json. #}
+  {# Set serviceName in config.js. #}
   {{ govukHeader({
     homepageUrl: "/",
     serviceName: serviceName,

--- a/lib/upgradeToV13/known-old-versions/app-views-layout.html/v9.12.0.html
+++ b/lib/upgradeToV13/known-old-versions/app-views-layout.html/v9.12.0.html
@@ -39,7 +39,7 @@
 {% endblock %}
 
 {% block header %}
-  {# Set serviceName in config.json. #}
+  {# Set serviceName in config.js. #}
   {{ govukHeader({
     homepageUrl: "/",
     serviceName: serviceName,

--- a/lib/upgradeToV13/known-old-versions/app-views-layout.html/v9.12.1.html
+++ b/lib/upgradeToV13/known-old-versions/app-views-layout.html/v9.12.1.html
@@ -40,7 +40,7 @@
 {% endblock %}
 
 {% block header %}
-  {# Set serviceName in config.json. #}
+  {# Set serviceName in config.js. #}
   {{ govukHeader({
     homepageUrl: "/",
     serviceName: serviceName,

--- a/lib/upgradeToV13/known-old-versions/app-views-layout.html/v9.15.0.html
+++ b/lib/upgradeToV13/known-old-versions/app-views-layout.html/v9.15.0.html
@@ -40,7 +40,7 @@
 {% endblock %}
 
 {% block header %}
-  {# Set serviceName in config.json. #}
+  {# Set serviceName in config.js. #}
   {{ govukHeader({
     homepageUrl: "/",
     serviceName: serviceName,

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "test:acceptance": "KIT_TEST_DIR=tmp/test-prototype-package start-server-and-test 'node cypress/scripts/run-starter-prototype' 3000 'cypress run'",
     "test:acceptance:open": "KIT_TEST_DIR=tmp/test-prototype-package start-server-and-test 'node cypress/scripts/run-starter-prototype' 3000 'cypress open'",
     "test:smoke": "cypress run --spec \"cypress/integration/0-smoke-tests/*\"",
-    "test:unit": "jest lib",
-    "test:integration": "jest --testTimeout=30000 __tests__",
+    "test:unit": "jest --detectOpenHandles lib",
+    "test:integration": "IS_INTEGRATION_TEST=true jest --detectOpenHandles --testTimeout=30000 __tests__",
     "test": "npm run test:unit && npm run test:integration && npm run lint"
   },
   "dependencies": {


### PR DESCRIPTION
(updated)

New interface is:

`npx govuk-prototype-kit create` - creates a prototype in the current directory
`npx govuk-prototype-kit create /tmp/abc` - creates a prototype an absolute location
`npx govuk-prototype-kit create ../abc` - creates a prototype a relative location 
`npx govuk-prototype-kit create abc` - creates a prototype in a relative location
`npx govuk-prototype-kit create --version 13.0.0` - creates a specific version of a prototype in the current directory
`npx govuk-prototype-kit create --version 13.0.0 abc` - creates a specific version of a prototype in a relative location