### PR TITLE
Update management pages

### DIFF
--- a/govuk-prototype-kit.config.json
+++ b/govuk-prototype-kit.config.json
@@ -15,28 +15,36 @@
       "path": "/lib/templates/blank-govuk.html"
     },
     {
-      "name": "Check answers page",
-      "path": "/lib/templates/check-answers.html"
+      "name": "Blank unbranded page",
+      "path": "/lib/templates/blank-unbranded.html"
+    },
+    {
+      "name": "Start page",
+      "path": "/lib/templates/start.html"
     },
     {
       "name": "Question page",
       "path": "/lib/templates/question.html"
     },
     {
-      "name": "Confirmation page",
-      "path": "/lib/templates/confirmation.html"
-    },
-    {
       "name": "Content page",
       "path": "/lib/templates/content.html"
     },
     {
-      "name": "Mainstream guide page",
-      "path": "/lib/templates/mainstream-guide.html"
+      "name": "Task list page",
+      "path": "/lib/templates/task-list.html"
     },
     {
-      "name": "Start page",
-      "path": "/lib/templates/start.html"
+      "name": "Check answers page",
+      "path": "/lib/templates/check-answers.html"
+    },
+    {
+      "name": "Confirmation page",
+      "path": "/lib/templates/confirmation.html"
+    },
+    {
+      "name": "Mainstream guide page",
+      "path": "/lib/templates/mainstream-guide.html"
     }
   ]
 }

--- a/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/index.njk
+++ b/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/index.njk
@@ -3,7 +3,7 @@
 {% block content %}
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       <div class="govuk-!-margin-bottom-8">
         <h1 class="govuk-heading-l">
           Manage your prototype

--- a/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/plugin-install-or-uninstall.njk
+++ b/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/plugin-install-or-uninstall.njk
@@ -1,13 +1,19 @@
 {% extends "govuk-prototype-kit/internal/views/manage-prototype/layout.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+{% block beforeContent %}
+  {{ super() }}
+  <a class="govuk-back-link" href="/manage-prototype/plugins">Back</a>
+{% endblock %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-m">
         {{ verb.title }} {{ chosenPlugin.name }} {% if chosenPlugin.scope %} from {{ chosenPlugin.scope }} {% endif %}
       </h1>
-      <p>{{ verb.title }} to version {{ chosenPlugin.latestVersion }} by using the command:</p>
+      <p>
+        In terminal, run:</p>
       <p><code>{{ command }}</code></p>
     </div>
   </div>

--- a/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/plugins.njk
+++ b/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/plugins.njk
@@ -3,7 +3,7 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ successBanner | log }}
       {% if successBanner %}
 
@@ -19,6 +19,13 @@
           type: 'success'
         }) }}
       {% endif %}
+
+      <h1 class="govuk-heading-l">Plug-ins</h1>
+
+      <p class="govuk-body">
+        Plug-ins provide you with new components, styles and other features
+      </p>
+
       {% for group in groupsOfPlugins %}
         <h2 class="govuk-heading-m">{{ group.name }}</h2>
 

--- a/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/plugins.njk
+++ b/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/plugins.njk
@@ -32,8 +32,7 @@
         <ul class="govuk-list govuk-prototype-kit-manage-prototype-plugin-list-plugin-list">
           {% for plugin in group.plugins %}
             <li class="govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item">
-              <div
-                class="govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item-name">
+              <div class="govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item-name">
                 {{ plugin.name }}
                 {% if plugin.scope %}
                 <br/>
@@ -50,19 +49,19 @@
               <div class="govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item-links">
                 {% if not plugin.installedVersion %}
                   <a class="govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item-link"
-                     href="{{ plugin.installLink }}">Install</a>
+                     href="{{ plugin.installLink }}">Install<span class="govuk-visually-hidden"> {{ plugin.name }}</span></a>
                 {% endif %}
                 {% if plugin.uninstallLink %}
                   <a class="govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item-link"
-                     href="{{ plugin.uninstallLink }}">Uninstall</a>
+                     href="{{ plugin.uninstallLink }}">Uninstall<span class="govuk-visually-hidden"> {{ plugin.name }}</span></a>
                 {% endif %}
                 {% if plugin.upgradeLink %}
                   <a class="govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item-link"
-                     href="{{ plugin.upgradeLink }}">Upgrade</a>
+                     href="{{ plugin.upgradeLink }}">Upgrade<span class="govuk-visually-hidden"> {{ plugin.name }}</span></a>
                 {% endif %}
                 {% if plugin.helpLink %}
                   <a class="govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item-link"
-                     href="{{ plugin.helpLink }}">Help</a>
+                     href="{{ plugin.helpLink }}">Help<span class="govuk-visually-hidden"> - {{ plugin.name }}</span></a>
                 {% endif %}
               </div>
             </li>

--- a/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/templates.njk
+++ b/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/templates.njk
@@ -3,7 +3,7 @@
 {% block content %}
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
 
       <h1 class="govuk-heading-l">Templates</h1>
 

--- a/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/templates.njk
+++ b/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/templates.njk
@@ -7,27 +7,30 @@
 
       <h1 class="govuk-heading-l">Templates</h1>
 
-      <p class="govuk-body">Add templates of common pages to your prototype</p>
+      <p class="govuk-body">
+        Add templates of common pages to your prototype
+      </p>
 
       {% for plugin in availableTemplates %}
+
         <h2 class="govuk-heading-m">{{ plugin.pluginDisplayName.name }}</h2>
 
         <ul class="govuk-list govuk-prototype-kit-manage-prototype-template-list-template-list">
           {% for template in plugin.templates %}
             <li class="govuk-prototype-kit-manage-prototype-template-list-template-list__item">
-              <div
-                class="govuk-prototype-kit-manage-prototype-template-list-template-list__item-name">{{ template.name }}</div>
+              <div class="govuk-prototype-kit-manage-prototype-template-list-template-list__item-name">
+                {{ template.name }}
+              </div>
               <div class="govuk-prototype-kit-manage-prototype-template-list-template-list__item-links">
-                <a class="govuk-prototype-kit-manage-prototype-template-list-template-list__item-link"
-                   href="{{ template.viewLink }}">View</a>
-                <a class="govuk-prototype-kit-manage-prototype-template-list-template-list__item-link"
-                   href="{{ template.installLink }}">Install</a>
+                <a class="govuk-prototype-kit-manage-prototype-template-list-template-list__item-link" href="{{ template.viewLink }}">
+                   View<span class="govuk-visually-hidden"> {{ template.name }}</span></a>
+                <a class="govuk-prototype-kit-manage-prototype-template-list-template-list__item-link" href="{{ template.installLink }}">
+                   Install<span class="govuk-visually-hidden"> {{ template.name }}</span></a>
               </div>
             </li>
           {% endfor %}
         </ul>
       {% endfor %}
-
     </div>
   </div>
 {% endblock %}

--- a/lib/routes/prototype-admin-routes.js
+++ b/lib/routes/prototype-admin-routes.js
@@ -304,8 +304,8 @@ async function getPluginDetails () {
       const pack = await packageDetails
       Object.assign(pack, extensions.preparePackageNameForDisplay(pack.packageName), {
         installLink: `${contextPath}/plugins/install?package=${encodeURIComponent(pack.packageName)}&mode=install`,
-        installCommand: `npm i ${pack.packageName}`,
-        upgradeCommand: `npm i ${pack.packageName}@${pack.latestVersion}`,
+        installCommand: `npm install ${pack.packageName}`,
+        upgradeCommand: `npm install ${pack.packageName}@${pack.latestVersion}`,
         uninstallCommand: `npm uninstall ${pack.packageName}`
       })
       if (installed.includes(pack.packageName)) {


### PR DESCRIPTION
includes:

 - make links accessible on templates and plugins page
 - use `column-two-thirds-from-desktop` class for full width on tablet
 - add an h1 to plug-ins page
 - fix the templates list order and add missing templates
 - simplify plugins install page and add back link