### PR TITLE
Manage pages updates

### DIFF
--- a/cypress/e2e/6-management-tests/create-new-page-from-template.cypress.js
+++ b/cypress/e2e/6-management-tests/create-new-page-from-template.cypress.js
@@ -55,9 +55,9 @@ describe('create new start page', () => {
 
     cy.task('log', 'Create the page')
     cy.get('.govuk-heading-l')
-      .should('contains.text', 'Create new page from template')
-    cy.get('.govuk-body')
-      .should('contains.text', 'Using template "Start page".')
+      .should('contains.text', 'Create new Start page')
+    cy.get('.govuk-label')
+      .should('contains.text', 'Path for the new page')
     cy.get('#chosen-url')
       .type(startPagePath)
     cy.get('.govuk-button')

--- a/lib/assets/sass/internal/manage-prototype.scss
+++ b/lib/assets/sass/internal/manage-prototype.scss
@@ -311,6 +311,10 @@
   padding-right: 5px
 }
 
+.govuk-prototype-kit-manage-prototype-version{
+  color: #505a5f;
+}
+
 
 .govuk-prototype-kit-manage-prototype-template-list-template-list {
   border-top: 1px solid govuk-colour('mid-grey');

--- a/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/index.njk
+++ b/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/index.njk
@@ -8,7 +8,7 @@
         <h1 class="govuk-heading-l">
           Manage your prototype
         </h1>
-        <p>
+        <p class="govuk-prototype-kit-manage-prototype-version">
           GOV.UK Prototype Kit {{ releaseVersion }}
         </p>
         {% if kitUpgradeAvailable %}
@@ -45,14 +45,14 @@
         <a href="{{ currentUrl }}/templates">Templates</a>
       </h2>
       <p>
-        Create pages from common templates
+        Create pages from templates
       </p>
 
       <h2 class="govuk-heading-m">
         <a href="{{ currentUrl }}/plugins">Plug-ins</a>
       </h2>
       <p>
-        Install plug-ins that provide you with new components and styles
+        Plug-ins provide you with new components, styles and other features
       </p>
 
       <a class="govuk-heading-m" href="{{ currentUrl }}/clear-data">

--- a/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/index.njk
+++ b/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/index.njk
@@ -45,7 +45,7 @@
         <a href="{{ currentUrl }}/templates">Templates</a>
       </h2>
       <p>
-        Add templates of common pages to your prototype
+        Create pages from common templates
       </p>
 
       <h2 class="govuk-heading-m">

--- a/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/template-install.njk
+++ b/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/template-install.njk
@@ -24,17 +24,11 @@
         }) }}
       {% endif %}
 
-      <h1 class="govuk-heading-l">Create new page from template</h1>
-
-      <p class="govuk-body">Using template "{{ templateName }}".</p>
-
+      <h1 class="govuk-heading-l">Create new {{ templateName }}</h1>
 
       <form action="{{ currentUrl }}" method="post">
 
         {{ govukInput({
-          hint: {
-            text: "For example /my-useful-page"
-          },
           errorMessage: {
             text: error
           } if error,
@@ -42,6 +36,9 @@
             text: "Path for the new page",
 
             classes: "govuk-label--m"
+          },
+          hint: {
+            text: "For example: /my-useful-page"
           },
           id: "chosen-url",
           name: "chosen-url",

--- a/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/templates.njk
+++ b/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/templates.njk
@@ -8,7 +8,7 @@
       <h1 class="govuk-heading-l">Templates</h1>
 
       <p class="govuk-body">
-        Add templates of common pages to your prototype
+        Create pages from common templates
       </p>
 
       {% for plugin in availableTemplates %}

--- a/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/templates.njk
+++ b/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/templates.njk
@@ -8,7 +8,7 @@
       <h1 class="govuk-heading-l">Templates</h1>
 
       <p class="govuk-body">
-        Create pages from common templates
+        Create pages from templates
       </p>
 
       {% for plugin in availableTemplates %}
@@ -25,7 +25,7 @@
                 <a class="govuk-prototype-kit-manage-prototype-template-list-template-list__item-link" href="{{ template.viewLink }}">
                    View<span class="govuk-visually-hidden"> {{ template.name }}</span></a>
                 <a class="govuk-prototype-kit-manage-prototype-template-list-template-list__item-link" href="{{ template.installLink }}">
-                   Install<span class="govuk-visually-hidden"> {{ template.name }}</span></a>
+                   Create<span class="govuk-visually-hidden"> {{ template.name }}</span></a>
               </div>
             </li>
           {% endfor %}

--- a/lib/routes/prototype-admin-routes.js
+++ b/lib/routes/prototype-admin-routes.js
@@ -111,6 +111,10 @@ const managementLinks = [
   {
     text: 'Plug-ins',
     url: '/manage-prototype/plugins'
+  },
+  {
+    text: 'Go to prototype',
+    url: '/'
   }
 ]
 

--- a/listen-on-port.js
+++ b/listen-on-port.js
@@ -13,7 +13,7 @@ if (process.env.IS_INTEGRATION_TEST === 'true') {
     console.log('The Prototype Kit is now running at:')
     console.log(`http://localhost:${port}`)
     console.log('')
-    console.log('You can access the settings at:')
+    console.log('You can manage your prototype at:')
     console.log(`http://localhost:${port}/manage-prototype`)
     console.log('')
 


### PR DESCRIPTION
Includes:

 - add a link to the prototype
 - update start up message to match the 'manage' wording elsewhere
 - Update template pages with new text