### PR TITLE
Ensure that create script installs same version of starter files and kit

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 const fs = require('fs-extra')
+const os = require('os')
 const path = require('path')
+
 const { exec } = require('../lib/exec')
 const { runUpgrade } = require('../lib/upgradeToV13')
 
@@ -28,6 +30,12 @@ public/
 .DS_Store
 .idea
 `
+
+const packageJson = {
+  scripts: {
+    start: 'govuk-prototype-kit start'
+  }
+}
 
 function usage () {
   const prog = 'npx govuk-prototype-kit'
@@ -99,6 +107,7 @@ const getChosenKitDependency = () => {
       fs.copy(path.join(kitRoot, 'prototype-starter'), installDirectory),
       fs.writeFile(path.join(installDirectory, '.gitignore'), gitignore, 'utf8'),
       fs.writeFile(path.join(installDirectory, '.npmrc'), npmrc, 'utf8'),
+      fs.writeJson(path.join(installDirectory, 'package.json'), packageJson, { encoding: 'utf8', EOL: os.EOL, spaces: 2 }),
       copyFile('LICENCE.txt')
     ])
 

--- a/bin/cli
+++ b/bin/cli
@@ -111,7 +111,6 @@ const getChosenKitDependency = () => {
       cwd: installDirectory
     }, console.log)
     clearInterval(dots)
-
   } else if (command === 'start') {
     require('../start')
   } else if (command === 'upgrade') {

--- a/bin/cli
+++ b/bin/cli
@@ -96,69 +96,71 @@ const getChosenKitDependency = () => {
   if (command === 'create') {
     // Install as a two-stage bootstrap process.
     //
-    // In stage one we create an empty project folder and install
+    // In stage one (`create`) we create an empty project folder and install
     // govuk-prototype-kit and govuk-frontend, then bootstrap stage two from
     // the newly installed package.
     //
-    // In stage two we do the actual setup of the starter files.
+    // In stage two (`init`) we do the actual setup of the starter files.
     //
     // Doing it this way means we can be sure the version of the cli matches
     // the version of the kit the user ends up with. Try to put as much logic
     // as possible into stage two; stage one should ideally be able to install
     // any future version of the kit.
 
-    const stage = additionalOptions[0] === '--' ? 'two' : 'one'
+    const installDirectory = getInstallLocation()
+    const kitDependency = getChosenKitDependency()
 
-    if (stage === 'one') {
-      const installDirectory = getInstallLocation()
-      const kitDependency = getChosenKitDependency()
-
-      await fs.ensureDir(installDirectory)
-      if ((await fs.readdir(installDirectory)).length > 0) {
-        console.error(`Directory ${installDirectory} is not empty, please specify an empty location.`)
-        process.exitCode = 3
-        return
-      }
-
-      await fs.writeJson(path.join(installDirectory, 'package.json'), {}, packageJsonFormat)
-
-      console.log('Creating your prototype')
-      const dots = setInterval(() => {
-        process.stdout.write('.')
-      }, 500)
-
-      await exec(`npm install ${kitDependency} govuk-frontend`, {
-        stdio: 'inherit',
-        cwd: installDirectory
-      }, console.log)
-
-      clearInterval(dots)
-
-      await exec(`npx govuk-prototype-kit create -- ${installDirectory}`, {
-        stdio: 'inherit',
-        cwd: installDirectory
-      }, console.log)
-    } else if (stage === 'two') {
-      const installDirectory = additionalOptions[1]
-
-      const copyFile = (fileName) => fs.copy(path.join(kitRoot, fileName), path.join(installDirectory, fileName))
-      const updatePackageJson = async (packageJsonPath) => {
-        let newPackageJson = Object.assign({}, packageJson)
-        newPackageJson = Object.assign(newPackageJson, await fs.readJson(packageJsonPath))
-        await fs.writeJson(packageJsonPath, newPackageJson, packageJsonFormat)
-      }
-
-      await Promise.all([
-        fs.copy(path.join(kitRoot, 'prototype-starter'), installDirectory),
-        fs.writeFile(path.join(installDirectory, '.gitignore'), gitignore, 'utf8'),
-        fs.writeFile(path.join(installDirectory, '.npmrc'), npmrc, 'utf8'),
-        copyFile('LICENCE.txt'),
-        updatePackageJson(path.join(installDirectory, 'package.json'))
-      ])
-    } else {
-      usage()
-      process.exitCode = 1
+    await fs.ensureDir(installDirectory)
+    if ((await fs.readdir(installDirectory)).length > 0) {
+      console.error(`Directory ${installDirectory} is not empty, please specify an empty location.`)
+      process.exitCode = 3
+      return
     }
+
+    await fs.writeJson(path.join(installDirectory, 'package.json'), {}, packageJsonFormat)
+
+    console.log('Creating your prototype')
+    const dots = setInterval(() => {
+      process.stdout.write('.')
+    }, 500)
+
+    await exec(`npm install ${kitDependency} govuk-frontend`, {
+      stdio: 'inherit',
+      cwd: installDirectory
+    }, console.log)
+
+    clearInterval(dots)
+
+    await exec(`npx govuk-prototype-kit init -- ${installDirectory}`, {
+      stdio: 'inherit',
+      cwd: installDirectory
+    }, console.log)
+  } else if (command === 'init') {
+    // `init` is stage two of the install process (see above), it should be
+    // called by `create` with the correct arguments.
+
+    if (additionalOptions[0] !== '--') {
+      usage()
+      process.exitCode = 2
+      return
+    }
+
+    const installDirectory = additionalOptions[1]
+
+    const copyFile = (fileName) => fs.copy(path.join(kitRoot, fileName), path.join(installDirectory, fileName))
+    const updatePackageJson = async (packageJsonPath) => {
+      let newPackageJson = Object.assign({}, packageJson)
+      newPackageJson = Object.assign(newPackageJson, await fs.readJson(packageJsonPath))
+      await fs.writeJson(packageJsonPath, newPackageJson, packageJsonFormat)
+    }
+
+    await Promise.all([
+      fs.copy(path.join(kitRoot, 'prototype-starter'), installDirectory),
+      fs.writeFile(path.join(installDirectory, '.gitignore'), gitignore, 'utf8'),
+      fs.writeFile(path.join(installDirectory, '.npmrc'), npmrc, 'utf8'),
+      copyFile('LICENCE.txt'),
+      updatePackageJson(path.join(installDirectory, 'package.json'))
+    ])
   } else if (command === 'start') {
     require('../start')
   } else if (command === 'upgrade') {

--- a/bin/cli
+++ b/bin/cli
@@ -37,6 +37,8 @@ const packageJson = {
   }
 }
 
+const packageJsonFormat = { encoding: 'utf8', EOL: os.EOL, spaces: 2 }
+
 function usage () {
   const prog = 'npx govuk-prototype-kit'
   console.log(`
@@ -95,21 +97,13 @@ const getChosenKitDependency = () => {
     const installDirectory = getInstallLocation()
     const kitDependency = getChosenKitDependency()
 
-    const copyFile = (fileName) => fs.copy(path.join(kitRoot, fileName), path.join(installDirectory, fileName))
-
     await fs.ensureDir(installDirectory)
     if ((await fs.readdir(installDirectory)).length > 0) {
       console.error(`Directory ${installDirectory} is not empty, please specify an empty location.`)
       process.exit(3)
     }
 
-    await Promise.all([
-      fs.copy(path.join(kitRoot, 'prototype-starter'), installDirectory),
-      fs.writeFile(path.join(installDirectory, '.gitignore'), gitignore, 'utf8'),
-      fs.writeFile(path.join(installDirectory, '.npmrc'), npmrc, 'utf8'),
-      fs.writeJson(path.join(installDirectory, 'package.json'), packageJson, { encoding: 'utf8', EOL: os.EOL, spaces: 2 }),
-      copyFile('LICENCE.txt')
-    ])
+    await fs.writeJson(path.join(installDirectory, 'package.json'), {}, packageJsonFormat)
 
     console.log('Creating your prototype')
     const dots = setInterval(() => {
@@ -120,6 +114,21 @@ const getChosenKitDependency = () => {
       cwd: installDirectory
     }, console.log)
     clearInterval(dots)
+
+    const copyFile = (fileName) => fs.copy(path.join(kitRoot, fileName), path.join(installDirectory, fileName))
+    const updatePackageJson = async (packageJsonPath) => {
+      let newPackageJson = Object.assign({}, packageJson)
+      newPackageJson = Object.assign(newPackageJson, await fs.readJson(packageJsonPath))
+      await fs.writeJson(packageJsonPath, newPackageJson, packageJsonFormat)
+    }
+
+    await Promise.all([
+      fs.copy(path.join(kitRoot, 'prototype-starter'), installDirectory),
+      fs.writeFile(path.join(installDirectory, '.gitignore'), gitignore, 'utf8'),
+      fs.writeFile(path.join(installDirectory, '.npmrc'), npmrc, 'utf8'),
+      copyFile('LICENCE.txt'),
+      updatePackageJson(path.join(installDirectory, 'package.json'))
+    ])
   } else if (command === 'start') {
     require('../start')
   } else if (command === 'upgrade') {

--- a/bin/cli
+++ b/bin/cli
@@ -94,41 +94,71 @@ const getChosenKitDependency = () => {
 
 (async () => {
   if (command === 'create') {
-    const installDirectory = getInstallLocation()
-    const kitDependency = getChosenKitDependency()
+    // Install as a two-stage bootstrap process.
+    //
+    // In stage one we create an empty project folder and install
+    // govuk-prototype-kit and govuk-frontend, then bootstrap stage two from
+    // the newly installed package.
+    //
+    // In stage two we do the actual setup of the starter files.
+    //
+    // Doing it this way means we can be sure the version of the cli matches
+    // the version of the kit the user ends up with. Try to put as much logic
+    // as possible into stage two; stage one should ideally be able to install
+    // any future version of the kit.
 
-    await fs.ensureDir(installDirectory)
-    if ((await fs.readdir(installDirectory)).length > 0) {
-      console.error(`Directory ${installDirectory} is not empty, please specify an empty location.`)
-      process.exit(3)
+    const stage = additionalOptions[0] === '--' ? 'two' : 'one'
+
+    if (stage === 'one') {
+      const installDirectory = getInstallLocation()
+      const kitDependency = getChosenKitDependency()
+
+      await fs.ensureDir(installDirectory)
+      if ((await fs.readdir(installDirectory)).length > 0) {
+        console.error(`Directory ${installDirectory} is not empty, please specify an empty location.`)
+        process.exitCode = 3
+        return
+      }
+
+      await fs.writeJson(path.join(installDirectory, 'package.json'), {}, packageJsonFormat)
+
+      console.log('Creating your prototype')
+      const dots = setInterval(() => {
+        process.stdout.write('.')
+      }, 500)
+
+      await exec(`npm install ${kitDependency} govuk-frontend`, {
+        stdio: 'inherit',
+        cwd: installDirectory
+      }, console.log)
+
+      clearInterval(dots)
+
+      await exec(`npx govuk-prototype-kit create -- ${installDirectory}`, {
+        stdio: 'inherit',
+        cwd: installDirectory
+      }, console.log)
+    } else if (stage === 'two') {
+      const installDirectory = additionalOptions[1]
+
+      const copyFile = (fileName) => fs.copy(path.join(kitRoot, fileName), path.join(installDirectory, fileName))
+      const updatePackageJson = async (packageJsonPath) => {
+        let newPackageJson = Object.assign({}, packageJson)
+        newPackageJson = Object.assign(newPackageJson, await fs.readJson(packageJsonPath))
+        await fs.writeJson(packageJsonPath, newPackageJson, packageJsonFormat)
+      }
+
+      await Promise.all([
+        fs.copy(path.join(kitRoot, 'prototype-starter'), installDirectory),
+        fs.writeFile(path.join(installDirectory, '.gitignore'), gitignore, 'utf8'),
+        fs.writeFile(path.join(installDirectory, '.npmrc'), npmrc, 'utf8'),
+        copyFile('LICENCE.txt'),
+        updatePackageJson(path.join(installDirectory, 'package.json'))
+      ])
+    } else {
+      usage()
+      process.exitCode = 1
     }
-
-    await fs.writeJson(path.join(installDirectory, 'package.json'), {}, packageJsonFormat)
-
-    console.log('Creating your prototype')
-    const dots = setInterval(() => {
-      process.stdout.write('.')
-    }, 500)
-    await exec(`npm install ${kitDependency} govuk-frontend`, {
-      stdio: 'inherit',
-      cwd: installDirectory
-    }, console.log)
-    clearInterval(dots)
-
-    const copyFile = (fileName) => fs.copy(path.join(kitRoot, fileName), path.join(installDirectory, fileName))
-    const updatePackageJson = async (packageJsonPath) => {
-      let newPackageJson = Object.assign({}, packageJson)
-      newPackageJson = Object.assign(newPackageJson, await fs.readJson(packageJsonPath))
-      await fs.writeJson(packageJsonPath, newPackageJson, packageJsonFormat)
-    }
-
-    await Promise.all([
-      fs.copy(path.join(kitRoot, 'prototype-starter'), installDirectory),
-      fs.writeFile(path.join(installDirectory, '.gitignore'), gitignore, 'utf8'),
-      fs.writeFile(path.join(installDirectory, '.npmrc'), npmrc, 'utf8'),
-      copyFile('LICENCE.txt'),
-      updatePackageJson(path.join(installDirectory, 'package.json'))
-    ])
   } else if (command === 'start') {
     require('../start')
   } else if (command === 'upgrade') {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "tmp-kit": "mkdir -p $TMPDIR/govuk-prototype-kit-playground && cd $TMPDIR/govuk-prototype-kit-playground && rm -Rf ./* && govuk-prototype-kit create --version local . && npm start",
     "start": "echo 'This project cannot be started, in order to test this project please create a prototype kit using the cli.'",
     "start:package": "KIT_TEST_DIR=tmp/test-prototype-package node cypress/scripts/run-starter-prototype",
-    "lint": "standard '**/*.js' scripts/create-release-archive scripts/cli lib/build/dev-server lib/build/generate-assets",
+    "lint": "standard '**/*.js' bin/cli scripts/create-release-archive lib/build/dev-server lib/build/generate-assets",
     "rapidtest": "jest --bail",
     "cypress:open": "cypress open",
     "test:heroku": "echo 'test:heroku' needs to be implemented",

--- a/prototype-starter/package.json
+++ b/prototype-starter/package.json
@@ -1,5 +1,0 @@
-{
-  "scripts": {
-    "start": "govuk-prototype-kit start"
-  }
-}


### PR DESCRIPTION
Splits the process of creating a new prototype into two with copying the starter files done after the version of the kit to be used has been installed. This makes sure the user doesn't end up with starter files that require features not available to the installed kit version. This is similar to what the create-react-app tool does [[1]].

Fixes #1616.

[1]:
https://github.com/facebook/create-react-app/blob/main/packages/create-react-app/createReactApp.js