### PR TITLE
Support cmd.exe and PowerShell

### DIFF
--- a/.github/workflows/test-download.yaml
+++ b/.github/workflows/test-download.yaml
@@ -20,10 +20,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
 
-    defaults:
-      run:
-        shell: bash
-
     env:
       CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,10 +20,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
 
-    defaults:
-      run:
-        shell: bash
-
     env:
       CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-script-shell=bash

--- a/bin/cli
+++ b/bin/cli
@@ -15,7 +15,6 @@ const argv = parse(process.argv)
 
 const npmrc = `
 audit=false
-script-shell=bash
 `
 
 const gitignore = `

--- a/cypress/scripts/run-starter-prototype.js
+++ b/cypress/scripts/run-starter-prototype.js
@@ -20,5 +20,5 @@ const testDir = path.resolve(process.env.KIT_TEST_DIR || defaultKitPath)
     `"file:${fooLocation}"`,
     `"file:${barLocation}"`]
   )
-  startPrototype(testDir)
+  await startPrototype(testDir)
 })()

--- a/lib/build/tasks.js
+++ b/lib/build/tasks.js
@@ -56,7 +56,7 @@ function devServer () {
 async function buildWatchAndServe () {
   generateAssetsSync()
   await utils.waitUntilFileExists(path.join(appCssPath, 'application.css'), 5000)
-  devServer()
+  await devServer()
 }
 
 function clean () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "govuk-prototype-kit": "bin/cli"
       },
       "devDependencies": {
+        "cross-env": "^7.0.3",
         "cypress": "^10.6.0",
         "eslint-plugin-cypress": "^2.12.1",
         "extract-zip": "^2.0.1",
@@ -3153,6 +3154,24 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -14588,6 +14607,15 @@
       "requires": {
         "object-assign": "^4",
         "vary": "^1"
+      }
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
       }
     },
     "cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -26,16 +26,16 @@
   "scripts": {
     "tmp-kit": "mkdir -p $TMPDIR/govuk-prototype-kit-playground && cd $TMPDIR/govuk-prototype-kit-playground && rm -Rf ./* && govuk-prototype-kit create --version local . && npm start",
     "start": "echo 'This project cannot be started, in order to test this project please create a prototype kit using the cli.'",
-    "start:package": "KIT_TEST_DIR=tmp/test-prototype-package node cypress/scripts/run-starter-prototype",
+    "start:package": "cross-env KIT_TEST_DIR=tmp/test-prototype-package node cypress/scripts/run-starter-prototype",
     "lint": "standard '**/*.js' bin/cli",
     "rapidtest": "jest --bail",
     "cypress:open": "cypress open",
     "test:heroku": "echo 'test:heroku' needs to be implemented",
-    "test:acceptance": "KIT_TEST_DIR=tmp/test-prototype-package start-server-and-test 'node cypress/scripts/run-starter-prototype' 3000 'cypress run'",
-    "test:acceptance:open": "KIT_TEST_DIR=tmp/test-prototype-package start-server-and-test 'node cypress/scripts/run-starter-prototype' 3000 'cypress open'",
+    "test:acceptance": "cross-env KIT_TEST_DIR=tmp/test-prototype-package start-server-and-test \"node cypress/scripts/run-starter-prototype\" 3000 \"cypress run\"",
+    "test:acceptance:open": "cross-env KIT_TEST_DIR=tmp/test-prototype-package start-server-and-test \"node cypress/scripts/run-starter-prototype\" 3000 \"cypress open\"",
     "test:smoke": "cypress run --spec \"cypress/integration/0-smoke-tests/*\"",
     "test:unit": "jest --detectOpenHandles lib bin",
-    "test:integration": "CREATE_KIT_TIMEOUT=90000 IS_INTEGRATION_TEST=true jest --detectOpenHandles --testTimeout=60000 __tests__",
+    "test:integration": "cross-env CREATE_KIT_TIMEOUT=90000 IS_INTEGRATION_TEST=true jest --detectOpenHandles --testTimeout=60000 __tests__",
     "test": "npm run test:unit && npm run test:integration && npm run lint"
   },
   "dependencies": {
@@ -69,6 +69,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "cypress": "^10.6.0",
     "eslint-plugin-cypress": "^2.12.1",
     "extract-zip": "^2.0.1",


### PR DESCRIPTION
Stop showing users an error if they run the kit on Windows without using Bash.

Bash is no longer a requirement of running our tests or the kit, so this PR changes our tests to use the default shells on Windows rather than forcing the use of Bash.

We also change the `.npmrc` file the user receives so that it does not try and use bash for `npm run` on Windows.