### PR TITLE
Show output from npm install when running create script

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -117,10 +117,17 @@ const getChosenKitDependency = () => {
 
     console.log('Creating your prototype')
 
-    await spawn('npm', ['install', kitDependency, 'govuk-frontend'], {
-      stdio: 'inherit',
-      cwd: installDirectory
-    })
+    await spawn(
+      'npm', [
+        'install',
+        '--no-audit',
+        '--loglevel', 'error',
+        kitDependency,
+        'govuk-frontend'
+      ], {
+        stdio: 'inherit',
+        cwd: installDirectory
+      })
 
     await spawn('npx', ['govuk-prototype-kit', 'init', '--', installDirectory], {
       stdio: 'inherit',

--- a/bin/cli
+++ b/bin/cli
@@ -125,13 +125,15 @@ const getChosenKitDependency = () => {
         kitDependency,
         'govuk-frontend'
       ], {
-        stdio: 'inherit',
-        cwd: installDirectory
+        cwd: installDirectory,
+        shell: true,
+        stdio: 'inherit'
       })
 
     await spawn('npx', ['govuk-prototype-kit', 'init', '--', installDirectory], {
-      stdio: 'inherit',
-      cwd: installDirectory
+      cwd: installDirectory,
+      shell: true,
+      stdio: 'inherit'
     })
   } else if (argv.command === 'init') {
     // `init` is stage two of the install process (see above), it should be

--- a/bin/cli
+++ b/bin/cli
@@ -4,7 +4,7 @@ const fs = require('fs-extra')
 const os = require('os')
 const path = require('path')
 
-const { exec } = require('../lib/exec')
+const { spawn } = require('../lib/exec')
 const { runUpgrade } = require('../lib/upgradeToV13')
 const { parse } = require('./utils/argvParser')
 
@@ -116,21 +116,16 @@ const getChosenKitDependency = () => {
     await fs.writeJson(path.join(installDirectory, 'package.json'), {}, packageJsonFormat)
 
     console.log('Creating your prototype')
-    const dots = setInterval(() => {
-      process.stdout.write('.')
-    }, 500)
 
-    await exec(`npm install ${kitDependency} govuk-frontend`, {
+    await spawn('npm', ['install', kitDependency, 'govuk-frontend'], {
       stdio: 'inherit',
       cwd: installDirectory
-    }, console.log)
+    })
 
-    clearInterval(dots)
-
-    await exec(`npx govuk-prototype-kit init -- ${installDirectory}`, {
+    await spawn('npx', ['govuk-prototype-kit', 'init', '--', installDirectory], {
       stdio: 'inherit',
       cwd: installDirectory
-    }, console.log)
+    })
   } else if (argv.command === 'init') {
     // `init` is stage two of the install process (see above), it should be
     // called by `create` with the correct arguments.

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,4 +1,4 @@
-const { exec } = require('child_process')
+const { exec, spawn } = require('child_process')
 const colors = require('ansi-colors')
 
 module.exports = {
@@ -27,6 +27,25 @@ module.exports = {
           resolve(true)
         } else {
           console.error(colors.red(errorOutput.join('\n')))
+          reject(new Error(`Exit code was ${code}`))
+        }
+      })
+    })
+  },
+  spawn: (command, args, options) => {
+    const optionsProcessed = Object.assign({}, options || {})
+
+    optionsProcessed.env = optionsProcessed.env || {}
+    optionsProcessed.env.LANG = optionsProcessed.env.LANG || process.env.LANG
+    optionsProcessed.env.PATH = optionsProcessed.env.PATH || process.env.PATH
+
+    const child = spawn(command, args, optionsProcessed)
+
+    return new Promise(function (resolve, reject) {
+      child.on('close', function (code) {
+        if (code === 0) {
+          resolve(true)
+        } else {
           reject(new Error(`Exit code was ${code}`))
         }
       })


### PR DESCRIPTION
Use spawn instead of exec so we can inherit stdio. This makes for a nicer user experience when running `npx govuk-prototype-kit create`, as they can see the full colourful output from npm.