### PR TITLE
Fix formatting of .tmp/sass/_extensions.scss

### DIFF
--- a/lib/build/tasks.js
+++ b/lib/build/tasks.js
@@ -70,7 +70,7 @@ function ensureTempDirExists (dir = tempPath) {
 }
 
 function sassExtensions () {
-  let fileContents = '$govuk-extensions-url-context: "/extension-assets"; $govuk-prototype-kit-major-version: 13; '
+  let fileContents = '$govuk-extensions-url-context: "/extension-assets"; $govuk-prototype-kit-major-version: 13;\n'
   fileContents += extensions.getFileSystemPaths('sass')
     .map(filePath => `@import "${filePath.split(path.sep).join('/')}";`)
     .join('\n')


### PR DESCRIPTION
Make sure first line is separated from second by a newline character.