### PR TITLE
Add serve and dev scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 
 ### New Features
 
+- [#1637: Add serve and dev scripts](https://github.com/alphagov/govuk-prototype-kit/pull/1637)
+  - Add `govuk-prototype-kit dev` and `govuk-prototype-kit serve` commands
+  - After creating prototype with starter files user can run `npm run dev` or `npm run serve`
 - [#1476: Update to GOV.UK Frontend 4.2.0](https://github.com/alphagov/govuk-prototype-kit/pull/1476)
 - [#1624: V13 pre refactor](https://github.com/alphagov/govuk-prototype-kit/pull/1624)
   - Add support for globals

--- a/bin/cli
+++ b/bin/cli
@@ -5,6 +5,7 @@ const os = require('os')
 const path = require('path')
 
 const { spawn } = require('../lib/exec')
+const { generateAssetsSync } = require('../lib/build/tasks.js')
 const { runUpgrade } = require('../lib/upgradeToV13')
 const { parse } = require('./utils/argvParser')
 
@@ -32,6 +33,8 @@ public/
 
 const packageJson = {
   scripts: {
+    dev: 'govuk-prototype-kit dev',
+    serve: 'govuk-prototype-kit serve',
     start: 'govuk-prototype-kit start'
   }
 }
@@ -49,6 +52,8 @@ ${prog} create
 ${prog} create /exact/location/to/create/in
 ${prog} create relative/location/to/create/in
 ${prog}
+${prog} dev
+${prog} serve
 ${prog} start`
   )
 }
@@ -160,8 +165,12 @@ const getChosenKitDependency = () => {
       copyFile('LICENCE.txt'),
       updatePackageJson(path.join(installDirectory, 'package.json'))
     ])
-  } else if (argv.command === 'start') {
+  } else if (argv.command === 'start' || argv.command === 'dev') {
     require('../start')
+  } else if (argv.command === 'serve') {
+    process.env.NODE_ENV = process.env.NODE_ENV || 'production'
+    generateAssetsSync()
+    require('../listen-on-port')
   } else if (argv.command === 'upgrade') {
     await runUpgrade()
   } else {


### PR DESCRIPTION
We want to make sure users have NODE_ENV=production set when their prototypes are hosted online, because that controls a lot of important behaviour including the password control and HTTPS redirects. To make this easier, this commit adds a command to the cli tool that sets NODE_ENV and then does the build and run. We also add these commands to the starter files package scripts.

---

This is part of resolving #1202, although it keeps the behaviour of `npm start` the same for now.