### PR TITLE
Make serve default command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Breaking changes
 - [#1648: Change default session store to cookie store when in production mode](https://github.com/alphagov/govuk-prototype-kit/pull/1648) When hosted online the kit will now preserve user session data between server restarts by default.
+- [#1638: Make serve default command](https://github.com/alphagov/govuk-prototype-kit/pull/1638)
+  - Running `npm start` after creating starter prototype will now run 'production' command
+  - Users now need to run `npm run dev` when they want to start their prototype on their local machine
+  - We try and warn users in some circumstances where we think they may have run `npm start` accidentally
 - [#1617: Making most files optional](https://github.com/alphagov/govuk-prototype-kit/pull/1617) This alongside other work we've been doing allows users of the kit to delete files they're not using.
 - [#1589: Create management pages](https://github.com/alphagov/govuk-prototype-kit/issues/1589) Providing pages for the user to manage their prototype.
 - [#1615: Removing GOVUK Frontend specific integration](https://github.com/alphagov/govuk-prototype-kit/pull/1615) GOV.UK Frontend now integrates in the same way as any other plugin can.  We're allowing SASS settings to be set before the plugins run if they're put in app/assets/sass/settings.scss.

--- a/__tests__/util/index.js
+++ b/__tests__/util/index.js
@@ -116,7 +116,7 @@ async function npmInstall (pathToRunInstallIn) {
 
 async function startPrototype (prototypePath) {
   return exec(
-    'npm start',
+    'npm run dev',
     { cwd: prototypePath, env: { ...process.env, env: 'test' }, stdio: 'inherit' }
   )
 }

--- a/bin/cli
+++ b/bin/cli
@@ -91,9 +91,27 @@ const getChosenKitDependency = () => {
     }
   }
   return defaultValue
-};
+}
 
-(async () => {
+// do some heuristics to try and catch situations where a user has run
+// `npm start` (the wrong command) locally and warn them.
+function warnIfNpmStart (argv, env) {
+  if (
+    argv.command === 'start' && // if user ran serve script then assume they know what they want
+    env.NODE_ENV !== 'production' && // some hosting services set NODE_ENV
+    env.PORT === undefined && // some hosting services set PORT
+    env.PASSWORD === undefined // user should have set PASSWORD when setting up hosting
+  ) {
+    console.warn('Warning: It looks like you may have run the command `npm start` locally.')
+    console.warn('try running `npm run dev`')
+    console.warn()
+    console.warn('If you see the above warning when trying to host your prototype online,')
+    console.warn('it may be that your hosting service needs further configuration.')
+    console.warn()
+  }
+}
+
+;(async () => {
   if (argv.command === 'create') {
     // Install as a two-stage bootstrap process.
     //
@@ -169,6 +187,7 @@ const getChosenKitDependency = () => {
   } else if (argv.command === 'dev') {
     require('../start')
   } else if (argv.command === 'start' || argv.command === 'serve') {
+    warnIfNpmStart(argv, process.env)
     process.env.NODE_ENV = process.env.NODE_ENV || 'production'
     require('../lib/build/tasks.js').generateAssetsSync()
     require('../listen-on-port')

--- a/bin/cli
+++ b/bin/cli
@@ -166,9 +166,9 @@ const getChosenKitDependency = () => {
       copyFile('LICENCE.txt'),
       updatePackageJson(path.join(installDirectory, 'package.json'))
     ])
-  } else if (argv.command === 'start' || argv.command === 'dev') {
+  } else if (argv.command === 'dev') {
     require('../start')
-  } else if (argv.command === 'serve') {
+  } else if (argv.command === 'start' || argv.command === 'serve') {
     process.env.NODE_ENV = process.env.NODE_ENV || 'production'
     require('../lib/build/tasks.js').generateAssetsSync()
     require('../listen-on-port')

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "start.js"
   ],
   "scripts": {
-    "tmp-kit": "mkdir -p $TMPDIR/govuk-prototype-kit-playground && cd $TMPDIR/govuk-prototype-kit-playground && rm -Rf ./* && govuk-prototype-kit create --version local . && npm start",
+    "tmp-kit": "mkdir -p $TMPDIR/govuk-prototype-kit-playground && cd $TMPDIR/govuk-prototype-kit-playground && rm -Rf ./* && govuk-prototype-kit create --version local . && npm run dev",
     "start": "echo 'This project cannot be started, in order to test this project please create a prototype kit using the cli.'",
     "start:package": "npm run tmp-kit",
     "lint": "standard '**/*.js' bin/cli",
@@ -32,7 +32,7 @@
     "cypress:run": "cypress run",
     "cypress:open": "cypress open",
     "test:heroku": "start-server-and-test test:heroku:start 3000 test:smoke",
-    "test:heroku:start": "node scripts/create-prototype-and-start 'npx --yes heroku local --port 3000'",
+    "test:heroku:start": "cross-env USE_AUTH=false USE_HTTPS=false node scripts/create-prototype-and-start 'npx --yes heroku local --port 3000'",
     "test:acceptance": "cross-env KIT_TEST_DIR=tmp/test-prototype-package start-server-and-test test:acceptance:start 3000 cypress:run",
     "test:acceptance:open": "cross-env KIT_TEST_DIR=tmp/test-prototype-package start-server-and-test test:acceptance:start 3000 cypress:open",
     "test:acceptance:start": "node cypress/scripts/run-starter-prototype",

--- a/scripts/create-prototype-and-start.js
+++ b/scripts/create-prototype-and-start.js
@@ -13,7 +13,7 @@ if (process.argv.length > 3) {
   process.exit(2)
 }
 
-const command = process.argv.length === 3 ? process.argv[2] : 'npm start'
+const command = process.argv.length === 3 ? process.argv[2] : 'npm run dev'
 
 console.log(`creating test prototype in ${testDir}`)
 console.log('and after changing directory')


### PR DESCRIPTION
We want to make sure that whatever service a user might be running their prototype online, they use the production scripts and configuration. Unfortunately, there isn't a standard way to detect whether a project is running in production or not; not all services set NODE_ENV [[1]], not all services will read a Procfile, etc. The only surefire way we can think of is to make it so that running `npm start` in a prototype runs the production code by default.

[1]: https://github.com/alphagov/govuk-prototype-kit/issues/1202

Unfortunately, this is a breaking change, as previously we told users to run `npm start`. We want to catch what we suspect will be a common case, where the user runs `npm start` having been used to that from before, and then ends up with a prototype that isn't working and no idea why. In those circumstances we should give the users a heads-up by outputting something to the terminal. While we can't be certain of when this might have happened, we can make a reasonable guess, and the downside of logging to a hosting services console erroneously is negligible.

---

Resolves #1202.