### PR TITLE
Setting template type

### DIFF
--- a/govuk-prototype-kit.config.json
+++ b/govuk-prototype-kit.config.json
@@ -14,39 +14,48 @@
   "templates": [
     {
       "name": "Blank GOV.UK page",
-      "path": "/lib/templates/blank-govuk.html"
+      "path": "/lib/templates/blank-govuk.html",
+      "type": "nunjucks"
     },
     {
       "name": "Blank unbranded page",
-      "path": "/lib/templates/blank-unbranded.html"
+      "path": "/lib/templates/blank-unbranded.html",
+      "type":  "nunjucks"
     },
     {
       "name": "Start page",
-      "path": "/lib/templates/start.html"
+      "path": "/lib/templates/start.html",
+      "type":  "nunjucks"
     },
     {
       "name": "Question page",
-      "path": "/lib/templates/question.html"
+      "path": "/lib/templates/question.html",
+      "type":  "nunjucks"
     },
     {
       "name": "Content page",
-      "path": "/lib/templates/content.html"
+      "path": "/lib/templates/content.html",
+      "type":  "nunjucks"
     },
     {
       "name": "Task list page",
-      "path": "/lib/templates/task-list.html"
+      "path": "/lib/templates/task-list.html",
+      "type":  "nunjucks"
     },
     {
       "name": "Check answers page",
-      "path": "/lib/templates/check-answers.html"
+      "path": "/lib/templates/check-answers.html",
+      "type":  "nunjucks"
     },
     {
       "name": "Confirmation page",
-      "path": "/lib/templates/confirmation.html"
+      "path": "/lib/templates/confirmation.html",
+      "type":  "nunjucks"
     },
     {
       "name": "Mainstream guide page",
-      "path": "/lib/templates/mainstream-guide.html"
+      "path": "/lib/templates/mainstream-guide.html",
+      "type":  "nunjucks"
     }
   ]
 }

--- a/lib/routes/prototype-admin-routes.js
+++ b/lib/routes/prototype-admin-routes.js
@@ -171,6 +171,7 @@ function getPluginTemplates () {
     const matchingPackages = output.filter(x => x.packageName === packageName)
     if (item.type !== 'nunjucks') {
       console.warn(`Omitting ${item.name} from ${packageName} because the type ${JSON.stringify(item.type)} isn't supported.  The only currently supported type is "nunjucks".`)
+      return
     }
     let packageDescription
     if (matchingPackages.length > 0) {


### PR DESCRIPTION
We decided to insist on templates having a type, I added a console warning but didn't actually omit them from the list.  As a result we didn't actually include the type on our own templates.

This PR actually omits templates without a "nunjucks" type and sets our templates to "nunjucks".