### PR TITLE
Change default session store to cookie store when in production mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Breaking changes
+- [#1648: Change default session store to cookie store when in production mode](https://github.com/alphagov/govuk-prototype-kit/pull/1648) When hosted online the kit will now preserve user session data between server restarts by default.
 - [#1617: Making most files optional](https://github.com/alphagov/govuk-prototype-kit/pull/1617) This alongside other work we've been doing allows users of the kit to delete files they're not using.
 - [#1589: Create management pages](https://github.com/alphagov/govuk-prototype-kit/issues/1589) Providing pages for the user to manage their prototype.
 - [#1615: Removing GOVUK Frontend specific integration](https://github.com/alphagov/govuk-prototype-kit/pull/1615) GOV.UK Frontend now integrates in the same way as any other plugin can.  We're allowing SASS settings to be set before the plugins run if they're put in app/assets/sass/settings.scss.

--- a/bin/cli
+++ b/bin/cli
@@ -5,9 +5,10 @@ const os = require('os')
 const path = require('path')
 
 const { spawn } = require('../lib/exec')
-const { generateAssetsSync } = require('../lib/build/tasks.js')
-const { runUpgrade } = require('../lib/upgradeToV13')
 const { parse } = require('./utils/argvParser')
+
+// Avoid requiring any kit server code at the top-level as we might want to
+// change environment variables below.
 
 const currentDirectory = process.cwd()
 const kitRoot = path.join(__dirname, '..')
@@ -169,10 +170,10 @@ const getChosenKitDependency = () => {
     require('../start')
   } else if (argv.command === 'serve') {
     process.env.NODE_ENV = process.env.NODE_ENV || 'production'
-    generateAssetsSync()
+    require('../lib/build/tasks.js').generateAssetsSync()
     require('../listen-on-port')
   } else if (argv.command === 'upgrade') {
-    await runUpgrade()
+    await require('../lib/upgradeToV13').runUpgrade()
   } else {
     usage()
     process.exitCode = 2

--- a/lib/config.js
+++ b/lib/config.js
@@ -58,13 +58,17 @@ const getConfig = () => {
     }
   }
 
+  config.onGlitch = onGlitch()
+  config.isProduction = getNodeEnv() === 'production'
+  config.isDevelopment = getNodeEnv() === 'development'
+
   overrideOrDefault('basePlugins', 'BASE_PLUGINS', asJson, ['govuk-prototype-kit', 'govuk-frontend'])
   overrideOrDefault('useAuth', 'USE_AUTH', asBoolean, true)
   overrideOrDefault('useHttps', 'USE_HTTPS', asBoolean, true)
   overrideOrDefault('port', 'PORT', asNumber, 3000)
   overrideOrDefault('useBrowserSync', 'USE_BROWSER_SYNC', asBoolean, true)
   overrideOrDefault('useAutoStoreData', 'USE_AUTO_STORE_DATA', asBoolean, true)
-  overrideOrDefault('useCookieSessionStore', 'USE_COOKIE_SESSION_STORE', asBoolean, false)
+  overrideOrDefault('useCookieSessionStore', 'USE_COOKIE_SESSION_STORE', asBoolean, config.isProduction)
 
   if (config.serviceName === undefined) {
     config.serviceName = 'GOV.UK Prototype Kit'
@@ -73,10 +77,6 @@ const getConfig = () => {
   if (process.env.PASSWORD) {
     config.password = process.env.PASSWORD
   }
-
-  config.onGlitch = onGlitch()
-  config.isProduction = getNodeEnv() === 'production'
-  config.isDevelopment = getNodeEnv() === 'development'
 
   return config
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -64,6 +64,7 @@ const getConfig = () => {
   overrideOrDefault('port', 'PORT', asNumber, 3000)
   overrideOrDefault('useBrowserSync', 'USE_BROWSER_SYNC', asBoolean, true)
   overrideOrDefault('useAutoStoreData', 'USE_AUTO_STORE_DATA', asBoolean, true)
+  overrideOrDefault('useCookieSessionStore', 'USE_COOKIE_SESSION_STORE', asBoolean, false)
 
   if (config.serviceName === undefined) {
     config.serviceName = 'GOV.UK Prototype Kit'

--- a/lib/config.test.js
+++ b/lib/config.test.js
@@ -88,6 +88,15 @@ describe('config', () => {
     }))
   })
 
+  it('defaults to using cookie session store when in production', () => {
+    process.env.NODE_ENV = 'production'
+
+    expect(config.getConfig()).toStrictEqual(mergeWithDefaults({
+      isProduction: true,
+      useCookieSessionStore: true
+    }))
+  })
+
   it('allows the user to set some values in config and others in environment variables', () => {
     testScope.configJs = {
       serviceName: 'Another Test Service'

--- a/lib/config.test.js
+++ b/lib/config.test.js
@@ -23,6 +23,7 @@ describe('config', () => {
     useHttps: true,
     useAutoStoreData: true,
     useBrowserSync: true,
+    useCookieSessionStore: false,
     isProduction: false,
     isDevelopment: false,
     onGlitch: false


### PR DESCRIPTION
Change the default configuration of the kit so that when the kit is run in production (`NODE_ENV=production`) the cookie session store is used instead of the memory session store. The impact of this is that session data will default to be preserved between server restarts, and the user will not see a warning from `express-session` in their server logs every server restart.

This PR still defaults to using the memory session store when running the kit locally, and the configuration can still be overridden.