### PR TITLE
Namespace SCSS

### DIFF
--- a/cypress/e2e/6-management-tests/change-service-name.cypress.js
+++ b/cypress/e2e/6-management-tests/change-service-name.cypress.js
@@ -37,18 +37,18 @@ describe('change service name', () => {
     cy.task('log', 'Visit the manage prototype page')
 
     cy.get(serverNameQuery).should('contains.text', originalText)
-    cy.get('.app-task-list__item')
+    cy.get('.govuk-prototype-kit-task-list__item')
       .eq(0).should('contains.text', appConfigPath)
-      .get('.app-task-list__tag').should('contains.text', 'To do')
+      .get('.govuk-prototype-kit-task-list__tag').should('contains.text', 'To do')
 
     cy.task('replaceTextInFile', { filename: appConfig, originalText, newText })
 
     waitForApplication(managePagePath)
 
     cy.get(serverNameQuery).should('contains.text', newText)
-    cy.get('.app-task-list__item')
+    cy.get('.govuk-prototype-kit-task-list__item')
       .eq(0).should('contains.text', appConfigPath)
-      .get('.app-task-list__tag').should('contains.text', 'Done')
+      .get('.govuk-prototype-kit-task-list__tag').should('contains.text', 'Done')
 
     cy.visit('/index')
     cy.get('.govuk-heading-xl').should('contains.text', newText)

--- a/cypress/e2e/6-management-tests/edit-home-page.cypress.js
+++ b/cypress/e2e/6-management-tests/edit-home-page.cypress.js
@@ -29,9 +29,9 @@ describe('edit home page', () => {
   it(`The home page heading should change to "${newText}" and the task should be set to "Done"`, () => {
     cy.task('log', 'Visit the manage prototype templates page')
 
-    cy.get('.app-task-list__item')
+    cy.get('.govuk-prototype-kit-task-list__item')
       .eq(1).should('contains.text', appHomePath)
-      .get('.app-task-list__tag').should('contains.text', 'To do')
+      .get('.govuk-prototype-kit-task-list__tag').should('contains.text', 'To do')
 
     cy.visit('/index')
     cy.get('.govuk-heading-xl').should('contains.text', originalText)
@@ -40,9 +40,9 @@ describe('edit home page', () => {
 
     waitForApplication(managePagePath)
 
-    cy.get('.app-task-list__item')
+    cy.get('.govuk-prototype-kit-task-list__item')
       .eq(1).should('contains.text', appHomePath)
-      .get('.app-task-list__tag').should('contains.text', 'Done')
+      .get('.govuk-prototype-kit-task-list__tag').should('contains.text', 'Done')
 
     cy.visit('/index')
     cy.get('.govuk-heading-xl').should('contains.text', newText)

--- a/lib/assets/sass/patterns/_contents-list.scss
+++ b/lib/assets/sass/patterns/_contents-list.scss
@@ -1,7 +1,7 @@
 // Based on https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
 // Note - this code for prototype purposes only. It is not production code.
 
-.app-contents-list {
+.govuk-prototype-kit-contents-list {
   // Always render the contents list above a
   // back to contents link
   position: relative;
@@ -11,28 +11,28 @@
   box-shadow: 0 20px 15px -10px govuk-colour("white");
 }
 
-.app-contents-list__title {
+.govuk-prototype-kit-contents-list__title {
   @include govuk-text-colour;
   @include govuk-font($size: 16, $weight: regular, $line-height: 1.5);
   margin: 0;
 }
 
-.app-contents-list__list,
-.app-contents-list__nested-list {
+.govuk-prototype-kit-contents-list__list,
+.govuk-prototype-kit-contents-list__nested-list {
   margin: 0;
   padding: 0;
   list-style-type: none;
 }
 
-.app-contents-list__list-item {
+.govuk-prototype-kit-contents-list__list-item {
   padding-top: govuk-spacing(2);
   line-height: 1.3;
   list-style-type: none;
 }
 
 
-.app-contents-list__list,
-.app-contents-list__nested-list {
+.govuk-prototype-kit-contents-list__list,
+.govuk-prototype-kit-contents-list__nested-list {
   @include govuk-text-colour;
   @include govuk-font($size: 16);
   margin: 0;
@@ -40,7 +40,7 @@
   list-style-type: none;
 }
 
-.app-contents-list__list-item--dashed {
+.govuk-prototype-kit-contents-list__list-item--dashed {
   $contents-spacing: govuk-spacing(5);
   position: relative;
   padding-left: $contents-spacing;

--- a/lib/assets/sass/patterns/_mainstream-guide.scss
+++ b/lib/assets/sass/patterns/_mainstream-guide.scss
@@ -1,4 +1,4 @@
-.app-mainstream-guide-contents-list {
+.govuk-prototype-kit-mainstream-guide-contents-list {
     margin-top: 30px;
     margin-bottom: 30px;
     padding-bottom: 15px;
@@ -10,6 +10,6 @@
     }
   }
 
-.app-mainstream-guide-body{
+.govuk-prototype-kit-mainstream-guide-body{
     margin-top: 20px;
 }

--- a/lib/assets/sass/patterns/_pagination.scss
+++ b/lib/assets/sass/patterns/_pagination.scss
@@ -1,17 +1,17 @@
 // Based on https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/stylesheets/govuk_publishing_components/components/_previous-and-next-navigation.scss
 // Note - this code for prototype purposes only. It is not production code.
 
-.app-pagination {
+.govuk-prototype-kit-pagination {
   display: block;
   margin: govuk-spacing(8) 0;
 }
 
-.app-pagination__list {
+.govuk-prototype-kit-pagination__list {
   margin: 0;
   padding: 0;
 }
 
-.app-pagination__item {
+.govuk-prototype-kit-pagination__item {
   @include govuk-font($size: 19);
   list-style: none;
 
@@ -20,7 +20,7 @@
   }
 }
 
-.app-pagination__link {
+.govuk-prototype-kit-pagination__link {
   display: block;
   text-decoration: none;
   padding-bottom: govuk-spacing(4);
@@ -36,12 +36,12 @@
     background-color: govuk-colour("light-grey", $legacy: "grey-4");
 
     // Add govuk-link hover decoration to title if no label present
-    .app-pagination__link-text--decorated {
+    .govuk-prototype-kit-pagination__link-text--decorated {
       @include govuk-link-decoration;
     }
 
-    .app-pagination__link-label,
-    .app-pagination__link-text--decorated {
+    .govuk-prototype-kit-pagination__link-label,
+    .govuk-prototype-kit-pagination__link-text--decorated {
       @include govuk-link-hover-decoration;
     }
   }
@@ -49,32 +49,32 @@
   &:focus {
     @include govuk-focused-text;
 
-    .app-pagination__link-title {
+    .govuk-prototype-kit-pagination__link-title {
       border-top-color: transparent;
     }
 
-    .app-pagination__link-icon {
+    .govuk-prototype-kit-pagination__link-icon {
       fill: $govuk-text-colour;
     }
   }
 }
 
-.app-pagination__link-title {
+.govuk-prototype-kit-pagination__link-title {
   display: block;
   border-top: 1px solid $govuk-border-colour;
   padding-top: govuk-spacing(3);
 }
 
-.app-pagination__link-divider {
+.govuk-prototype-kit-pagination__link-divider {
   @include govuk-visually-hidden;
 }
 
-.app-pagination__link-text {
+.govuk-prototype-kit-pagination__link-text {
   @include govuk-font(19, $weight: bold);
   margin-left: govuk-spacing(2);
 }
 
-.app-pagination__link-icon {
+.govuk-prototype-kit-pagination__link-icon {
   @include govuk-font($size: 24, $line-height: calc(33.75 / 27));
   display: inline-block;
   margin-bottom: 1px;
@@ -83,7 +83,7 @@
   fill: govuk-colour("dark-grey", $legacy: "grey-1");
 }
 
-.app-pagination__link-label {
+.govuk-prototype-kit-pagination__link-label {
   display: inline-block;
   margin-top: .1em;
   margin-left: govuk-spacing(5);

--- a/lib/assets/sass/patterns/_related-items.scss
+++ b/lib/assets/sass/patterns/_related-items.scss
@@ -1,11 +1,11 @@
 // This is a GOV.UK Publishing specific component that
 // can be seen at http://govuk-static.herokuapp.com/component-guide/related_items
 
-.app-related-items {
+.govuk-prototype-kit-related-items {
   border-top: 2px solid govuk-colour("blue");
   padding-top: govuk-spacing(2);
 }
 
-.app-related-items .govuk-list > li {
+.govuk-prototype-kit-related-items .govuk-list > li {
   margin-bottom: govuk-spacing(2);
 }

--- a/lib/assets/sass/patterns/_task-list.scss
+++ b/lib/assets/sass/patterns/_task-list.scss
@@ -1,6 +1,6 @@
 // Task list pattern
 
-.app-task-list {
+.govuk-prototype-kit-task-list {
   list-style-type: none;
   padding-left: 0;
   margin-top: 0;
@@ -10,12 +10,12 @@
   }
 }
 
-.app-task-list__section {
+.govuk-prototype-kit-task-list__section {
   display: table;
   @include govuk-font($size:24, $weight: bold);
 }
 
-.app-task-list__section-number {
+.govuk-prototype-kit-task-list__section-number {
   display: table-cell;
 
   @include govuk-media-query($from: tablet) {
@@ -24,7 +24,7 @@
   }
 }
 
-.app-task-list__items {
+.govuk-prototype-kit-task-list__items {
   @include govuk-font($size: 19);
   @include govuk-responsive-margin(9, "bottom");
   list-style: none;
@@ -34,7 +34,7 @@
   }
 }
 
-.app-task-list__item {
+.govuk-prototype-kit-task-list__item {
   border-bottom: 1px solid $govuk-border-colour;
   margin-bottom: 0 !important;
   padding-top: govuk-spacing(2);
@@ -42,22 +42,22 @@
   @include govuk-clearfix;
 }
 
-.app-task-list__item:first-child {
+.govuk-prototype-kit-task-list__item:first-child {
   border-top: 1px solid $govuk-border-colour;
 }
 
-.app-task-list__task-name {
+.govuk-prototype-kit-task-list__task-name {
   display: block;
   @include govuk-media-query($from: 450px) {
     float: left;
   }
 }
 
-// The `app-task-list__task-completed` class was previously used on the task
+// The `govuk-prototype-kit-task-list__task-completed` class was previously used on the task
 // list for the completed tag (changed in 86c90ec) – it's still included here to
 // avoid breaking task lists in existing prototypes.
-.app-task-list__tag,
-.app-task-list__task-completed {
+.govuk-prototype-kit-task-list__tag,
+.govuk-prototype-kit-task-list__task-completed {
   margin-top: govuk-spacing(2);
   margin-bottom: govuk-spacing(1);
 

--- a/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/index.njk
+++ b/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/index.njk
@@ -28,13 +28,13 @@
         <h2 class="govuk-heading-m">
           Start a new prototype
         </h2>
-        <ul class="app-task-list__items govuk-prototype-kit-manage-prototype-task-list__items">
+        <ul class="govuk-prototype-kit-task-list__items govuk-prototype-kit-manage-prototype-task-list__items">
           {% for task in tasks %}
-          <li class="app-task-list__item">
-          <span class="app-task-list__task-name">
+          <li class="govuk-prototype-kit-task-list__item">
+          <span class="govuk-prototype-kit-task-list__task-name">
             {{ task.html | safe }}
           </span>
-            <strong class="govuk-tag govuk-prototype-kit-manage-prototype-govuk-tag app-task-list__tag">
+            <strong class="govuk-tag govuk-prototype-kit-manage-prototype-govuk-tag govuk-prototype-kit-task-list__tag">
               {% if task.done %}Done{% else %}To do{% endif %}
             </strong>
           </li>

--- a/lib/templates/mainstream-guide.html
+++ b/lib/templates/mainstream-guide.html
@@ -34,21 +34,21 @@
         Page title
       </h1>
 
-      <aside class="app-mainstream-guide-contents-list" role="complementary">
-        <nav class="app-contents-list" aria-label="Pages in this guide" role="navigation">
-          <h2 class="app-contents-list__title">
+      <aside class="govuk-prototype-kit-mainstream-guide-contents-list" role="complementary">
+        <nav class="govuk-prototype-kit-contents-list" aria-label="Pages in this guide" role="navigation">
+          <h2 class="govuk-prototype-kit-contents-list__title">
             Contents
           </h2>
-          <ol class="app-contents-list__list">
-            <li class="app-contents-list__list-item app-contents-list__list-item--dashed app-contents-list__list-item--active">
+          <ol class="govuk-prototype-kit-contents-list__list">
+            <li class="govuk-prototype-kit-contents-list__list-item govuk-prototype-kit-contents-list__list-item--dashed govuk-prototype-kit-contents-list__list-item--active">
               <a href="#">
                 Page 1
               </a>
             </li>
-            <li aria-current="true" class="app-contents-list__list-item app-contents-list__list-item--dashed">
+            <li aria-current="true" class="govuk-prototype-kit-contents-list__list-item govuk-prototype-kit-contents-list__list-item--dashed">
               Page 2
             </li>
-            <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+            <li class="govuk-prototype-kit-contents-list__list-item govuk-prototype-kit-contents-list__list-item--dashed">
               <a href="#">
                 Page 3
               </a>
@@ -62,7 +62,7 @@
   </div>
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds app-mainstream-guide-body">
+    <div class="govuk-grid-column-two-thirds govuk-prototype-kit-mainstream-guide-body">
       
       <h2 class="govuk-heading-m">
         Page content heading
@@ -70,36 +70,36 @@
       
       <p>Content goes here.</p>
 
-      <nav class="app-pagination" role="navigation" aria-label="Pagination">
-        <ul class="app-pagination__list">
-          <li class="app-pagination__item app-pagination__item--previous">
-            <a href="#" class="govuk-link app-pagination__link" rel="prev">
-              <span class="app-pagination__link-title">
-                <svg class="app-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+      <nav class="govuk-prototype-kit-pagination" role="navigation" aria-label="Pagination">
+        <ul class="govuk-prototype-kit-pagination__list">
+          <li class="govuk-prototype-kit-pagination__item govuk-prototype-kit-pagination__item--previous">
+            <a href="#" class="govuk-link govuk-prototype-kit-pagination__link" rel="prev">
+              <span class="govuk-prototype-kit-pagination__link-title">
+                <svg class="govuk-prototype-kit-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
                   <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
                 </svg>
-                <span class="app-pagination__link-text">
+                <span class="govuk-prototype-kit-pagination__link-text">
                   Previous
                 </span>
               </span>
-              <span class="app-pagination__link-divider visually-hidden">:</span>
-              <span class="app-pagination__link-label">
+              <span class="govuk-prototype-kit-pagination__link-divider visually-hidden">:</span>
+              <span class="govuk-prototype-kit-pagination__link-label">
                 Page 1 title
               </span>
             </a>
           </li>
-          <li class="app-pagination__item app-pagination__item--next">
-            <a href="#" class="govuk-link app-pagination__link" rel="next">
-              <span class="app-pagination__link-title">
-                <svg class="app-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+          <li class="govuk-prototype-kit-pagination__item govuk-prototype-kit-pagination__item--next">
+            <a href="#" class="govuk-link govuk-prototype-kit-pagination__link" rel="next">
+              <span class="govuk-prototype-kit-pagination__link-title">
+                <svg class="govuk-prototype-kit-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
                   <path d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
                 </svg>
-                <span class="app-pagination__link-text">
+                <span class="govuk-prototype-kit-pagination__link-text">
                   Next
                 </span>
               </span>
-              <span class="app-pagination__link-divider visually-hidden">:</span>
-              <span class="app-pagination__link-label">
+              <span class="govuk-prototype-kit-pagination__link-divider visually-hidden">:</span>
+              <span class="govuk-prototype-kit-pagination__link-label">
                 Page 3 title
               </span>
             </a>
@@ -117,7 +117,7 @@
 
     <div class="govuk-grid-column-one-third">
 
-      <aside class="app-related-items" role="complementary">
+      <aside class="govuk-prototype-kit-related-items" role="complementary">
         <h2 class="govuk-heading-m" id="subsection-title">
           Subsection
         </h2>

--- a/lib/templates/start.html
+++ b/lib/templates/start.html
@@ -62,7 +62,7 @@
 
     <div class="govuk-grid-column-one-third">
 
-      <aside class="app-related-items" role="complementary">
+      <aside class="govuk-prototype-kit-related-items" role="complementary">
         <h2 class="govuk-heading-m" id="subsection-title">
           Subsection
         </h2>

--- a/lib/templates/task-list.html
+++ b/lib/templates/task-list.html
@@ -15,85 +15,85 @@
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Application incomplete</h2>
       <p class="govuk-body govuk-!-margin-bottom-7">You have completed 3 of 8 sections.</p>
 
-      <ol class="app-task-list">
+      <ol class="govuk-prototype-kit-task-list">
         <li>
-          <h2 class="app-task-list__section">
-            <span class="app-task-list__section-number">1. </span> Check before you start
+          <h2 class="govuk-prototype-kit-task-list__section">
+            <span class="govuk-prototype-kit-task-list__section-number">1. </span> Check before you start
           </h2>
-          <ul class="app-task-list__items">
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
+          <ul class="govuk-prototype-kit-task-list__items">
+            <li class="govuk-prototype-kit-task-list__item">
+              <span class="govuk-prototype-kit-task-list__task-name">
                 <a href="#" aria-describedby="eligibility-status">
                   Check eligibility
                 </a>
               </span>
-              <strong class="govuk-tag app-task-list__tag" id="eligibility-status">Completed</strong>
+              <strong class="govuk-tag govuk-prototype-kit-task-list__tag" id="eligibility-status">Completed</strong>
             </li>
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
+            <li class="govuk-prototype-kit-task-list__item">
+              <span class="govuk-prototype-kit-task-list__task-name">
                 <a href="#" aria-describedby="read-declaration-status">
                   Read declaration
                 </a>
               </span>
-              <strong class="govuk-tag app-task-list__tag" id="read-declaration-status">Completed</strong>
+              <strong class="govuk-tag govuk-prototype-kit-task-list__tag" id="read-declaration-status">Completed</strong>
             </li>
           </ul>
         </li>
 
         <li>
-          <h2 class="app-task-list__section">
-            <span class="app-task-list__section-number">2. </span> Prepare application
+          <h2 class="govuk-prototype-kit-task-list__section">
+            <span class="govuk-prototype-kit-task-list__section-number">2. </span> Prepare application
           </h2>
-          <ul class="app-task-list__items">
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
+          <ul class="govuk-prototype-kit-task-list__items">
+            <li class="govuk-prototype-kit-task-list__item">
+              <span class="govuk-prototype-kit-task-list__task-name">
                 <a href="#" aria-describedby="company-information-status">
                   Company information
                 </a>
               </span>
-              <strong class="govuk-tag app-task-list__tag" id="company-information-status">Completed</strong>
+              <strong class="govuk-tag govuk-prototype-kit-task-list__tag" id="company-information-status">Completed</strong>
             </li>
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
+            <li class="govuk-prototype-kit-task-list__item">
+              <span class="govuk-prototype-kit-task-list__task-name">
                 <a href="#" aria-describedby="contact-details-status">
                   Your contact details
                 </a>
               </span>
-              <strong class="govuk-tag govuk-tag--blue app-task-list__tag" id="contact-details-status">In progress</strong>
+              <strong class="govuk-tag govuk-tag--blue govuk-prototype-kit-task-list__tag" id="contact-details-status">In progress</strong>
             </li>
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
+            <li class="govuk-prototype-kit-task-list__item">
+              <span class="govuk-prototype-kit-task-list__task-name">
                 <a href="#" aria-describedby="list-convictions-status">
                   List convictions
                 </a>
               </span>
-              <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="list-convictions-status">Not started</strong>
+              <strong class="govuk-tag govuk-tag--grey govuk-prototype-kit-task-list__tag" id="list-convictions-status">Not started</strong>
             </li>
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
+            <li class="govuk-prototype-kit-task-list__item">
+              <span class="govuk-prototype-kit-task-list__task-name">
                 Provide financial evidence
               </span>
-              <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="financial-evidence-status">Cannot start yet</strong>
+              <strong class="govuk-tag govuk-tag--grey govuk-prototype-kit-task-list__tag" id="financial-evidence-status">Cannot start yet</strong>
             </li>
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
+            <li class="govuk-prototype-kit-task-list__item">
+              <span class="govuk-prototype-kit-task-list__task-name">
                 Give medical information
               </span>
-              <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="medical-information-status">Cannot start yet</strong>
+              <strong class="govuk-tag govuk-tag--grey govuk-prototype-kit-task-list__tag" id="medical-information-status">Cannot start yet</strong>
             </li>
           </ul>
         </li>
 
         <li>
-          <h2 class="app-task-list__section">
-            <span class="app-task-list__section-number">3. </span> Apply
+          <h2 class="govuk-prototype-kit-task-list__section">
+            <span class="govuk-prototype-kit-task-list__section-number">3. </span> Apply
           </h2>
-          <ul class="app-task-list__items">
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
+          <ul class="govuk-prototype-kit-task-list__items">
+            <li class="govuk-prototype-kit-task-list__item">
+              <span class="govuk-prototype-kit-task-list__task-name">
                 Submit and pay
               </span>
-              <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="submit-pay-status">Cannot start yet</strong>
+              <strong class="govuk-tag govuk-tag--grey govuk-prototype-kit-task-list__tag" id="submit-pay-status">Cannot start yet</strong>
             </li>
           </ul>
         </li>

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "tmp-kit": "mkdir -p $TMPDIR/govuk-prototype-kit-playground && cd $TMPDIR/govuk-prototype-kit-playground && rm -Rf ./* && govuk-prototype-kit create --version local . && npm start",
-    "start": "echo 'This project cannot be started, in order to test this project please create a prototype kit using the cli.'",
+    "start": "echo 'This project cannot be started, in order to test this project please create a prototype kit using the cli or run \"npm run tmp-kit\".'",
     "start:package": "npm run tmp-kit",
     "lint": "standard '**/*.js' bin/cli",
     "rapidtest": "jest --bail",


### PR DESCRIPTION
We discussed namespacing our SCSS a while ago but hadn't actually implemented it fully.

This change leaves the `app-` namespace for user code.