### PR TITLE
Change order of start messages

### DIFF
--- a/listen-on-port.js
+++ b/listen-on-port.js
@@ -10,11 +10,11 @@ if (process.env.IS_INTEGRATION_TEST === 'true') {
   server.listen()
 } else {
   utils.findAvailablePort(server, function (port) {
-    console.log('The Prototype Kit is now running at:')
-    console.log(`http://localhost:${port}`)
-    console.log('')
     console.log('You can manage your prototype at:')
     console.log(`http://localhost:${port}/manage-prototype`)
+    console.log('')
+    console.log('The Prototype Kit is now running at:')
+    console.log(`http://localhost:${port}`)
     console.log('')
 
     if (config.isProduction || !config.useBrowserSync) {


### PR DESCRIPTION
Put the URL of the main page last, so it is most prominent.

Also, only show the start message when running prototype locally.

---

Example:

```
/tmp/govuk-prototype-kit-test at 16:31:56
% npm start

> start
> govuk-prototype-kit start

GOV.UK Prototype Kit 0.0.1-beta.1

starting...

You can manage your prototype at:
http://localhost:3000/manage-prototype

The Prototype Kit is now running at:
http://localhost:3000


```