### PR TITLE
add ctrl c command

### DIFF
--- a/cypress/e2e/6-management-tests/install-available-plugin.cypress.js
+++ b/cypress/e2e/6-management-tests/install-available-plugin.cypress.js
@@ -39,7 +39,7 @@ describe('Management plugins: ', () => {
     cy.get('h1')
       .should('contains.text', `Upgrade ${pluginName}`)
 
-    cy.get('code')
+    cy.get('code').eq(0)
       .should('have.text', `npm install ${plugin}${version2}`)
 
     installPlugin(plugin, version2)
@@ -56,7 +56,7 @@ describe('Management plugins: ', () => {
     cy.get('h1')
       .should('contains.text', `Uninstall ${pluginName}`)
 
-    cy.get('code')
+    cy.get('code').eq(0)
       .should('have.text', `npm uninstall ${plugin}`)
 
     uninstallPlugin(plugin)

--- a/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/plugin-install-or-uninstall.njk
+++ b/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/plugin-install-or-uninstall.njk
@@ -13,11 +13,17 @@
         {{ verb.title }} {{ chosenPlugin.name }} {% if chosenPlugin.scope %} from {{ chosenPlugin.scope }} {% endif %}
       </h1>
       <p>
-        In terminal, run:</p>
-      <p><code>{{ command }}</code></p>
+        In terminal, press <strong>ctrl + c</strong> to stop your prototype, then run:
+      </p>
       <p>
-        When you've {{ verb.status }} the plug-in, restart your prototype in the terminal by typing: npx govuk-prototype-kit start</p>
+        <code>{{ command }}</code>
+      </p>
       <p>
+        When you've {{ verb.status }} the plug-in, restart your prototype in the terminal by typing:
+      </p>
+      <p>
+        <code>npm run dev</code>
+      </p>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
and change the start command to npm run dev

as discussed with @NoraGDS 

Preview (ignore broken fonts)

<img width="711" alt="Install Frontend from HMCTS. In terminal, press ctrl + c to stop your prototype, then run: npm install hmcts/frontend When you've installed the plug-in, restart your prototype in the terminal by typing: npm run dev" src="https://user-images.githubusercontent.com/1132904/194098252-41906e69-4bbc-4770-97a2-5eac9da6a565.png">
