### PR TITLE
Use file store for session data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## Unreleased
 
 ### Breaking changes
-- [#1658: Remove support for cookie session store](https://github.com/alphagov/govuk-prototype-kit/pull/1658) Option `useCookieSessionStore` is no longer supported.
+- [#1658: Use file store for session data](https://github.com/alphagov/govuk-prototype-kit/pull/1658)
+  - When running locally the kit will now preserve user session data between restarts
+  - Option `useCookieSessionStore` is no longer supported
 - [#1638: Make serve default command](https://github.com/alphagov/govuk-prototype-kit/pull/1638)
   - Running `npm start` after creating starter prototype will now run 'production' command
   - Users now need to run `npm run dev` when they want to start their prototype on their local machine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Breaking changes
-- [#1648: Change default session store to cookie store when in production mode](https://github.com/alphagov/govuk-prototype-kit/pull/1648) When hosted online the kit will now preserve user session data between server restarts by default.
+- [#1658: Remove support for cookie session store](https://github.com/alphagov/govuk-prototype-kit/pull/1658) Option `useCookieSessionStore` is no longer supported.
 - [#1638: Make serve default command](https://github.com/alphagov/govuk-prototype-kit/pull/1638)
   - Running `npm start` after creating starter prototype will now run 'production' command
   - Users now need to run `npm run dev` when they want to start their prototype on their local machine

--- a/lib/build/tasks.js
+++ b/lib/build/tasks.js
@@ -13,15 +13,14 @@ const extensions = require('../extensions/extensions')
 const utils = require('../utils')
 
 const buildConfig = require('./config.json')
-const { projectDir, packageDir } = require('../path-utils')
+const { projectDir, packageDir, tempDir } = require('../path-utils')
 const { paths } = buildConfig
 
 const appSassPath = path.join(projectDir, paths.assets, 'sass')
 const shadowNunjucks = path.join(projectDir, paths.shadowNunjucks)
 const libAssetsPath = path.join(packageDir, paths.libAssets)
 const libSassPath = path.join(libAssetsPath, 'sass')
-const tempPath = path.join(projectDir, '.tmp')
-const tempSassPath = path.join(tempPath, 'sass')
+const tempSassPath = path.join(tempDir, 'sass')
 
 const appCssPath = path.join(paths.public, 'stylesheets')
 
@@ -62,9 +61,9 @@ function clean () {
   del.sync(['public/**', '.port.tmp'])
 }
 
-function ensureTempDirExists (dir = tempPath) {
+function ensureTempDirExists (dir = tempDir) {
   fse.ensureDirSync(dir, { recursive: true })
-  fse.writeFileSync(path.join(tempPath, '.gitignore'), '*')
+  fse.writeFileSync(path.join(tempDir, '.gitignore'), '*')
 }
 
 function sassExtensions () {

--- a/lib/config.js
+++ b/lib/config.js
@@ -68,7 +68,6 @@ const getConfig = () => {
   overrideOrDefault('port', 'PORT', asNumber, 3000)
   overrideOrDefault('useBrowserSync', 'USE_BROWSER_SYNC', asBoolean, true)
   overrideOrDefault('useAutoStoreData', 'USE_AUTO_STORE_DATA', asBoolean, true)
-  overrideOrDefault('useCookieSessionStore', 'USE_COOKIE_SESSION_STORE', asBoolean, config.isProduction)
 
   if (config.serviceName === undefined) {
     config.serviceName = 'GOV.UK Prototype Kit'

--- a/lib/config.test.js
+++ b/lib/config.test.js
@@ -23,7 +23,6 @@ describe('config', () => {
     useHttps: true,
     useAutoStoreData: true,
     useBrowserSync: true,
-    useCookieSessionStore: false,
     isProduction: false,
     isDevelopment: false,
     onGlitch: false
@@ -85,15 +84,6 @@ describe('config', () => {
     expect(config.getConfig()).toStrictEqual(mergeWithDefaults({
       serviceName: 'My Test Service',
       useBrowserSync: false
-    }))
-  })
-
-  it('defaults to using cookie session store when in production', () => {
-    process.env.NODE_ENV = 'production'
-
-    expect(config.getConfig()).toStrictEqual(mergeWithDefaults({
-      isProduction: true,
-      useCookieSessionStore: true
     }))
   })
 

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -1,6 +1,7 @@
+const path = require('path')
 
 // Directory locations
-const path = require('path')
 exports.packageDir = path.resolve(__dirname, '..')
 exports.projectDir = process.cwd()
 exports.appDir = path.join(exports.projectDir, 'app')
+exports.tempDir = path.join(exports.projectDir, '.tmp')

--- a/lib/sessionUtils.js
+++ b/lib/sessionUtils.js
@@ -1,5 +1,4 @@
 const { getConfig } = require('./config')
-const sessionInCookie = require('client-sessions')
 const sessionInMemory = require('express-session')
 const path = require('path')
 const { projectDir } = require('./path-utils')
@@ -126,20 +125,11 @@ const getSessionMiddleware = () => {
     }
   }
 
-  // Support session data in cookie or memory
-  if (getConfig().useCookieSessionStore) {
-    return sessionInCookie(Object.assign(sessionOptions, {
-      cookieName: sessionName,
-      proxy: true,
-      requestKey: 'session'
-    }))
-  } else {
-    return sessionInMemory(Object.assign(sessionOptions, {
-      name: sessionName,
-      resave: false,
-      saveUninitialized: false
-    }))
-  }
+  return sessionInMemory(Object.assign(sessionOptions, {
+    name: sessionName,
+    resave: false,
+    saveUninitialized: false
+  }))
 }
 
 module.exports = {

--- a/lib/sessionUtils.js
+++ b/lib/sessionUtils.js
@@ -1,8 +1,11 @@
-const { getConfig } = require('./config')
-const sessionInMemory = require('express-session')
 const path = require('path')
-const { projectDir } = require('./path-utils')
+
+const session = require('express-session')
+const FileStore = require('session-file-store')(session)
 const { get: getKeypath } = require('lodash')
+
+const { getConfig } = require('./config')
+const { projectDir, tempDir } = require('./path-utils')
 
 // Add Nunjucks function called 'checked' to populate radios and checkboxes
 const addCheckedFunction = function (env) {
@@ -114,8 +117,10 @@ const getSessionNameFromServiceName = (serviceName) => {
 }
 
 const getSessionMiddleware = () => {
+  const config = getConfig()
+
   // Session uses service name to avoid clashes with other prototypes
-  const sessionName = getSessionNameFromServiceName(getConfig().serviceName)
+  const sessionName = getSessionNameFromServiceName(config.serviceName)
   const sessionHours = 4
   const sessionOptions = {
     secret: sessionName,
@@ -125,10 +130,19 @@ const getSessionMiddleware = () => {
     }
   }
 
-  return sessionInMemory(Object.assign(sessionOptions, {
+  const fileStoreOptions = {
+    path: path.join(tempDir, 'sessions')
+  }
+
+  if (config.isProduction) {
+    fileStoreOptions.secret = sessionName
+  }
+
+  return session(Object.assign(sessionOptions, {
     name: sessionName,
     resave: false,
-    saveUninitialized: false
+    saveUninitialized: false,
+    store: new FileStore(fileStoreOptions)
   }))
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "portscanner": "^2.1.1",
         "require-dir": "^1.0.0",
         "sass": "^1.49.10",
+        "session-file-store": "^1.5.0",
         "sync-request": "^6.0.0",
         "universal-analytics": "^0.5.3",
         "uuid": "^8.3.2"
@@ -1955,6 +1956,17 @@
         "safer-buffer": "~2.1.0"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -2167,6 +2179,11 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/bagpipe": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/bagpipe/-/bagpipe-0.3.5.tgz",
+      "integrity": "sha512-42sAlmPDKes1nLm/aly+0VdaopSU9br+jkRELedhQxI5uXHgtk47I83Mpmf4zoNTRMASdLFtUkimlu/Z9zQ8+g=="
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2260,6 +2277,11 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/body-parser": {
       "version": "1.19.0",
@@ -8344,6 +8366,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/kruptein": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/kruptein/-/kruptein-2.2.3.tgz",
+      "integrity": "sha512-BTwprBPTzkFT9oTugxKd3WnWrX630MqUDsnmBuoa98eQs12oD4n4TeI0GbpdGcYn/73Xueg2rfnw+oK4dovnJg==",
+      "dependencies": {
+        "asn1.js": "^5.4.1"
+      },
+      "engines": {
+        "node": ">6"
+      }
+    },
     "node_modules/latest-version": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
@@ -8870,6 +8903,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "node_modules/minimatch": {
       "version": "3.0.4",
@@ -10199,7 +10237,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -10441,6 +10478,43 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
       "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0="
+    },
+    "node_modules/session-file-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/session-file-store/-/session-file-store-1.5.0.tgz",
+      "integrity": "sha512-60IZaJNzyu2tIeHutkYE8RiXVx3KRvacOxfLr2Mj92SIsRIroDsH0IlUUR6fJAjoTW4RQISbaOApa2IZpIwFdQ==",
+      "dependencies": {
+        "bagpipe": "^0.3.5",
+        "fs-extra": "^8.0.1",
+        "kruptein": "^2.0.4",
+        "object-assign": "^4.1.1",
+        "retry": "^0.12.0",
+        "write-file-atomic": "3.0.3"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/session-file-store/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/session-file-store/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/setprototypeof": {
       "version": "1.1.1",
@@ -13683,6 +13757,17 @@
         "safer-buffer": "~2.1.0"
       }
     },
+    "asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -13843,6 +13928,11 @@
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
+    "bagpipe": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/bagpipe/-/bagpipe-0.3.5.tgz",
+      "integrity": "sha512-42sAlmPDKes1nLm/aly+0VdaopSU9br+jkRELedhQxI5uXHgtk47I83Mpmf4zoNTRMASdLFtUkimlu/Z9zQ8+g=="
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -13915,6 +14005,11 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
+    },
+    "bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -18417,6 +18512,14 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "kruptein": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/kruptein/-/kruptein-2.2.3.tgz",
+      "integrity": "sha512-BTwprBPTzkFT9oTugxKd3WnWrX630MqUDsnmBuoa98eQs12oD4n4TeI0GbpdGcYn/73Xueg2rfnw+oK4dovnJg==",
+      "requires": {
+        "asn1.js": "^5.4.1"
+      }
+    },
     "latest-version": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
@@ -18805,6 +18908,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -19800,8 +19908,7 @@
     "retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="
     },
     "reusify": {
       "version": "1.0.4",
@@ -19985,6 +20092,39 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
       "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0="
+    },
+    "session-file-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/session-file-store/-/session-file-store-1.5.0.tgz",
+      "integrity": "sha512-60IZaJNzyu2tIeHutkYE8RiXVx3KRvacOxfLr2Mj92SIsRIroDsH0IlUUR6fJAjoTW4RQISbaOApa2IZpIwFdQ==",
+      "requires": {
+        "bagpipe": "^0.3.5",
+        "fs-extra": "^8.0.1",
+        "kruptein": "^2.0.4",
+        "object-assign": "^4.1.1",
+        "retry": "^0.12.0",
+        "write-file-atomic": "3.0.3"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        }
+      }
     },
     "setprototypeof": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "body-parser": "^1.14.1",
         "browser-sync": "^2.27.10",
         "chokidar": "^3.5.3",
-        "client-sessions": "^0.8.0",
         "cookie-parser": "^1.4.6",
         "cross-spawn": "^7.0.2",
         "del": "^6.0.0",
@@ -2870,17 +2869,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/client-sessions": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/client-sessions/-/client-sessions-0.8.0.tgz",
-      "integrity": "sha1-p9jFVYrV1W8qGZ81M+tlS134k/0=",
-      "dependencies": {
-        "cookies": "^0.7.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -3126,18 +3114,6 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
       "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
       "dev": true
-    },
-    "node_modules/cookies": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.7.3.tgz",
-      "integrity": "sha512-+gixgxYSgQLTaTIilDHAdlNPZDENDQernEMiIcZpYYP14zgHsCt4Ce1FEjFtcp6GefhozebB6orvhAAWx/IS0A==",
-      "dependencies": {
-        "depd": "~1.1.2",
-        "keygrip": "~1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -8349,14 +8325,6 @@
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/keygrip": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.3.tgz",
-      "integrity": "sha512-/PpesirAIfaklxUzp4Yb7xBper9MwP6hNRA6BGGUFCgbJ+BM5CKBtsoxinNXkLHAr+GXS1/lSlF2rP7cv5Fl+g==",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/keyv": {
@@ -14382,14 +14350,6 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
       "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
     },
-    "client-sessions": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/client-sessions/-/client-sessions-0.8.0.tgz",
-      "integrity": "sha1-p9jFVYrV1W8qGZ81M+tlS134k/0=",
-      "requires": {
-        "cookies": "^0.7.0"
-      }
-    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -14585,15 +14545,6 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
       "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
       "dev": true
-    },
-    "cookies": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.7.3.tgz",
-      "integrity": "sha512-+gixgxYSgQLTaTIilDHAdlNPZDENDQernEMiIcZpYYP14zgHsCt4Ce1FEjFtcp6GefhozebB6orvhAAWx/IS0A==",
-      "requires": {
-        "depd": "~1.1.2",
-        "keygrip": "~1.0.3"
-      }
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -18451,11 +18402,6 @@
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "keygrip": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.3.tgz",
-      "integrity": "sha512-/PpesirAIfaklxUzp4Yb7xBper9MwP6hNRA6BGGUFCgbJ+BM5CKBtsoxinNXkLHAr+GXS1/lSlF2rP7cv5Fl+g=="
     },
     "keyv": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "body-parser": "^1.14.1",
     "browser-sync": "^2.27.10",
     "chokidar": "^3.5.3",
-    "client-sessions": "^0.8.0",
     "cookie-parser": "^1.4.6",
     "cross-spawn": "^7.0.2",
     "del": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "portscanner": "^2.1.1",
     "require-dir": "^1.0.0",
     "sass": "^1.49.10",
+    "session-file-store": "^1.5.0",
     "sync-request": "^6.0.0",
     "universal-analytics": "^0.5.3",
     "uuid": "^8.3.2"

--- a/server.js
+++ b/server.js
@@ -11,8 +11,6 @@ const cookieParser = require('cookie-parser')
 const dotenv = require('dotenv')
 const express = require('express')
 const nunjucks = require('nunjucks')
-const sessionInCookie = require('client-sessions')
-const sessionInMemory = require('express-session')
 
 // Run before other code to make sure variables from .env are available
 dotenv.config()
@@ -62,31 +60,8 @@ app.locals.extensionConfig = extensions.getAppConfig({
 // use cookie middleware for reading authentication cookie
 app.use(cookieParser())
 
-// Session uses service name to avoid clashes with other prototypes
-const sessionName = 'govuk-prototype-kit-' + (Buffer.from(app.locals.serviceName, 'utf8')).toString('hex')
-const sessionHours = 4
-const sessionOptions = {
-  secret: sessionName,
-  cookie: {
-    maxAge: 1000 * 60 * 60 * sessionHours,
-    secure: isSecure
-  }
-}
-
-// Support session data in cookie or memory
-if (config.useCookieSessionStore) {
-  app.use(sessionInCookie(Object.assign(sessionOptions, {
-    cookieName: sessionName,
-    proxy: true,
-    requestKey: 'session'
-  })))
-} else {
-  app.use(sessionInMemory(Object.assign(sessionOptions, {
-    name: sessionName,
-    resave: false,
-    saveUninitialized: false
-  })))
-}
+// Support session data storage
+middlewareFunctions.push(sessionUtils.getSessionMiddleware())
 
 // Authentication middleware must be loaded before other middleware such as
 // static assets to prevent unauthorised access

--- a/server.js
+++ b/server.js
@@ -44,7 +44,6 @@ if (isSecure) {
 // Add variables that are available in all views
 app.locals.asset_path = '/public/'
 app.locals.useAutoStoreData = config.useAutoStoreData
-app.locals.useCookieSessionStore = config.useCookieSessionStore
 app.locals.releaseVersion = 'v' + releaseVersion
 app.locals.serviceName = config.serviceName
 // extensionConfig sets up variables used to add the scripts and stylesheets to each page.


### PR DESCRIPTION
 This PR removes support for the cookie session data store, and uses a [file store](https://www.npmjs.com/package/session-file-store) instead.

When running the kit locally this will preserve session data between restarts, which is useful for users when they are editing their routes file a lot.

When running online with a PaaS such as Heroku we expect for most service providers the storage will be ephemeral, so we can't guarantee the data will be preserved there. There is a possibility that some service providers might make it difficult for the kit to save data to disk, but since we're doing this already with compiled CSS files and the like I think if that becomes an issue session storage will not be the only blocker.

File storage is potentially slower and more resource-intensive than memory storage, however for local development the advantage of preserving data is very clear, and even in production using this library has a it has a few advantages over the default memory store - the main one being that it makes sure to prune expired sessions, so is less liable to 'leak' memory over time. Using the same store locally and when hosted also seems preferable in terms of reducing complexity and failure modes.

The file store also has a major advantage over the previous solution, cookie storage, or any other client store, in that it is not bound by browser or HTTP restrictions, so prototypes can store a lot more data. For this reason this PR also removes the cookie store support, as we have no evidence of it being used, and we know that for some users the cookie store storage limits are considered harmful. The use case that the cookie store was added for, preserving session data during restarts while doing local development, is covered better by the file store, and we shouldn't keep code no one is using.

This PR resolves #1655.
