### PR TITLE
Fix file existence checks in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "tmp-kit": "mkdir -p $TMPDIR/govuk-prototype-kit-playground && cd $TMPDIR/govuk-prototype-kit-playground && rm -Rf ./* && govuk-prototype-kit create --version local . && npm run dev",
     "start": "echo 'This project cannot be started, in order to test this project please create a prototype kit using the cli.'",
-    "start:package": "npm run tmp-kit",
+    "start:package": "cross-env KIT_TEST_DIR=tmp/test-prototype-package node cypress/scripts/run-starter-prototype",
     "lint": "standard '**/*.js' bin/cli",
     "rapidtest": "jest --bail",
     "cypress:run": "cypress run",


### PR DESCRIPTION
Fix timeouts in file existence checks so they work correctly.
Also allow npm script run:package to work when system temp folder is not accessable.