### PR TITLE
Fix integration tests so they run in test folder rather than in repo

### DIFF
--- a/__tests__/spec/build.js
+++ b/__tests__/spec/build.js
@@ -7,7 +7,13 @@ const path = require('path')
 const del = require('del')
 const sass = require('sass')
 
-const { projectDir } = require('../../lib/path-utils')
+const { mkdtempSync } = require('../util')
+const testDir = path.join(mkdtempSync(), 'build')
+
+process.env.KIT_PROJECT_DIR = testDir
+process.env.IS_INTEGRATION_TEST = 'true'
+
+const { packageDir, projectDir } = require('../../lib/path-utils')
 const { generateAssetsSync } = require('../../lib/build/tasks')
 
 describe('the build pipeline', () => {
@@ -61,11 +67,14 @@ describe('the build pipeline', () => {
         sourceMap: true,
         style: 'expanded'
       }
-      expect(sass.compile).toHaveBeenCalledWith(expect.stringContaining(path.join(projectDir, 'lib', 'assets', 'sass', 'prototype.scss')), expect.objectContaining(options))
+      expect(sass.compile).toHaveBeenCalledWith(
+        expect.stringContaining(path.join(packageDir, 'lib', 'assets', 'sass', 'prototype.scss')),
+        expect.objectContaining(options)
+      )
 
       expect(fse.writeFileSync).toHaveBeenCalledWith(
-        path.join('.tmp', 'public', 'stylesheets', 'application.css'),
-        path.join(projectDir, 'lib', 'assets', 'sass', 'prototype.scss')
+        path.join(projectDir, '.tmp', 'public', 'stylesheets', 'application.css'),
+        path.join(packageDir, 'lib', 'assets', 'sass', 'prototype.scss')
       )
 
       expect(sass.compile).not.toHaveBeenCalledWith(expect.stringContaining(path.join('app', 'assets', 'sass', 'application.scss')), expect.objectContaining(options))

--- a/__tests__/spec/force-https-redirect.js
+++ b/__tests__/spec/force-https-redirect.js
@@ -1,9 +1,17 @@
 /* eslint-env jest */
+const path = require('path')
+
 const request = require('supertest')
 
+const { mkdtempSync } = require('../util')
+const testDir = path.join(mkdtempSync(), 'force-https-redirect')
+
 /* Setup Environment Variables before setting App */
+process.env.IS_INTEGRATION_TEST = 'true'
+process.env.KIT_PROJECT_DIR = testDir
 process.env.NODE_ENV = 'production'
 process.env.USE_HTTPS = 'true'
+
 const app = require('../../server.js')
 
 describe('The Prototype Kit - force HTTPS redirect functionality', () => {

--- a/lib/build/tasks.js
+++ b/lib/build/tasks.js
@@ -16,13 +16,12 @@ const buildConfig = require('./config.json')
 const { projectDir, packageDir, tempDir } = require('../path-utils')
 const { paths } = buildConfig
 
+const appCssPath = path.join(projectDir, paths.public, 'stylesheets')
 const appSassPath = path.join(projectDir, paths.assets, 'sass')
 const shadowNunjucks = path.join(projectDir, paths.shadowNunjucks)
 const libAssetsPath = path.join(packageDir, paths.libAssets)
 const libSassPath = path.join(libAssetsPath, 'sass')
 const tempSassPath = path.join(tempDir, 'sass')
-
-const appCssPath = path.join(paths.public, 'stylesheets')
 
 const appSassOptions = {
   filesToSkip: [

--- a/lib/extensions/extensions.js
+++ b/lib/extensions/extensions.js
@@ -95,7 +95,8 @@ const getBaseExtensions = () => appConfig.getConfig().basePlugins
 // Get baseExtensions in the order defined in `baseExtensions` in config.js
 // Then place baseExtensions before npm dependencies (and remove duplicates)
 const getPackageNamesInOrder = () => {
-  const dependencies = readJsonFile(getPathFromProjectRoot('package.json')).dependencies || {}
+  const pkg = fs.existsSync(pkgPath) ? readJsonFile(pkgPath) : {}
+  const dependencies = pkg.dependencies || {}
   const allNpmDependenciesInAlphabeticalOrder = Object.keys(dependencies).sort()
   const installedBaseExtensions = getBaseExtensions()
     .filter(packageName => allNpmDependenciesInAlphabeticalOrder.includes(packageName))
@@ -229,8 +230,9 @@ function expandToIncludeShadowNunjucks (arr) {
 }
 
 function getCurrentPlugins () {
-  const pkg = fse.readJsonSync(pkgPath)
-  return Object.keys(pkg.dependencies).filter((dependency) => fse.pathExistsSync(pathToPackageConfigFile(dependency)))
+  const pkg = fs.existsSync(pkgPath) ? fse.readJsonSync(pkgPath) : {}
+  const dependencies = pkg.dependencies || {}
+  return Object.keys(dependencies).filter((dependency) => fse.pathExistsSync(pathToPackageConfigFile(dependency)))
 }
 
 let previousPlugins = getCurrentPlugins()

--- a/lib/path-utils.js
+++ b/lib/path-utils.js
@@ -2,6 +2,6 @@ const path = require('path')
 
 // Directory locations
 exports.packageDir = path.resolve(__dirname, '..')
-exports.projectDir = process.cwd()
+exports.projectDir = path.resolve(process.env.KIT_PROJECT_DIR || process.cwd())
 exports.appDir = path.join(exports.projectDir, 'app')
 exports.tempDir = path.join(exports.projectDir, '.tmp')

--- a/server.js
+++ b/server.js
@@ -78,11 +78,6 @@ var appViews = extensions.getAppViews([
   path.join(projectDir, '/app/views/')
 ])
 
-if (process.env.IS_INTEGRATION_TEST) {
-  appViews.push(path.join(packageDir, 'lib', 'nunjucks'))
-  appViews.push(path.join(packageDir, 'prototype-starter', 'app', 'views'))
-}
-
 var nunjucksConfig = {
   autoescape: true,
   noCache: true,


### PR DESCRIPTION
Previously integration tests were running the kit incorrectly, with `projectDir` being equal to the kit repo folder.

This was result in some weird behaviours: the `.tmp` folder was being created in the repo directory rather than the project directory; tests of `govuk-frontend` assets were testing the versions in the repo, not the version installed in the project.
