### PR TITLE
Bump @actions/checkout from 2 to 3

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/test-download.yaml
+++ b/.github/workflows/test-download.yaml
@@ -24,7 +24,7 @@ jobs:
       CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Use Node v${{ matrix.node-version }}
       uses: actions/setup-node@v3

--- a/.github/workflows/test-heroku.yaml
+++ b/.github/workflows/test-heroku.yaml
@@ -17,7 +17,7 @@ jobs:
       CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node v16
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
       CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
Updates the version of Node used by the action from 12 to 16, silencing the warnings from GitHub Actions.