### PR TITLE
Ignore whitespace differences in migration

### DIFF
--- a/lib/migrator/fileHelpers.js
+++ b/lib/migrator/fileHelpers.js
@@ -112,6 +112,8 @@ const copyFileFromStarter = async (partialPath) => {
     })
 }
 
+const ignoreWhitespace = (str) => str.replace(/\s\s+/g, ' ')
+
 const matchAgainstOldVersions = async (filePath) => {
   const oldVersionsDir = path.join(__dirname, 'known-old-versions', filePath.split('/').join('-'))
   const userPath = path.join(projectDir, filePath)
@@ -128,7 +130,7 @@ const matchAgainstOldVersions = async (filePath) => {
     return
   }
 
-  return userFile && listOfKnownReleaseVersions.filter(knownVersion => knownVersion === userFile).length > 0
+  return userFile && listOfKnownReleaseVersions.some(knownVersion => ignoreWhitespace(knownVersion) === ignoreWhitespace(userFile))
 }
 
 module.exports = {


### PR DESCRIPTION
Some files may not have been consciously changed by the user but may have been reformatted by a user's editor.
This change is to prevent these files as being identified as changed.