### PR TITLE
Allow Node 18 to be used (v12)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false  # continue other tests if one test in matrix fails
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x, 18.x]
         os: [macos-latest, windows-latest, ubuntu-latest]
 
     name: Test kit on Node v${{ matrix.node-version }} (${{ matrix.os }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New features
+
+- [Pull request #1700: Allow Node 18 to be used](https://github.com/alphagov/govuk-prototype-kit/pull/1700)
+
 ## 12.2.0
 
 This release updates the step by step pattern and ensures the GOV.UK Prototype Kit reflects the latest release of the GOV.UK Frontend, v4.3.1.

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "wait-on": "^6.0.1"
       },
       "engines": {
-        "node": ">=12.0.0 <17.0.0"
+        "node": ">=12.0.0 <19.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "12.2.0",
   "private": true,
   "engines": {
-    "node": ">=12.0.0 <17.0.0"
+    "node": ">=12.0.0 <19.0.0"
   },
   "scripts": {
     "start": "node start",


### PR DESCRIPTION
Update engines directive in package.json to show that we support Node 18 LTS. Add tests on Node 18 to make sure that we do.