### PR TITLE
Fix unbranded template

### DIFF
--- a/lib/nunjucks/govuk-prototype-kit/includes/stylesheets-extensions.njk
+++ b/lib/nunjucks/govuk-prototype-kit/includes/stylesheets-extensions.njk
@@ -1,0 +1,3 @@
+{% for stylesheetUrl in extensionConfig.stylesheets %}
+  <link href="{{ stylesheetUrl }}" rel="stylesheet" type="text/css" />
+{% endfor %}

--- a/lib/nunjucks/govuk-prototype-kit/includes/stylesheets.html
+++ b/lib/nunjucks/govuk-prototype-kit/includes/stylesheets.html
@@ -1,3 +1,5 @@
+<link href="/public/stylesheets/application.css" rel="stylesheet" type="text/css" />
+
 {% for stylesheetUrl in extensionConfig.stylesheets %}
   <link href="{{ stylesheetUrl }}" rel="stylesheet" type="text/css" />
 {% endfor %}

--- a/lib/nunjucks/govuk-prototype-kit/includes/stylesheets.html
+++ b/lib/nunjucks/govuk-prototype-kit/includes/stylesheets.html
@@ -1,5 +1,3 @@
 <link href="/public/stylesheets/application.css" rel="stylesheet" type="text/css" />
 
-{% for stylesheetUrl in extensionConfig.stylesheets %}
-  <link href="{{ stylesheetUrl }}" rel="stylesheet" type="text/css" />
-{% endfor %}
+{% include "./stylesheets-extensions.njk" %}

--- a/lib/nunjucks/govuk-prototype-kit/layouts/unbranded.html
+++ b/lib/nunjucks/govuk-prototype-kit/layouts/unbranded.html
@@ -7,9 +7,7 @@
 {% block stylesheets %}
   <link href="/public/stylesheets/unbranded.css" media="all" rel="stylesheet" type="text/css" />
 
-  {% for stylesheetUrl in extensionConfig.stylesheets %}
-    <link href="{{ stylesheetUrl }}" rel="stylesheet" type="text/css" />
-  {% endfor %}
+  {% include "govuk-prototype-kit/includes/stylesheets-extensions.njk" %}
 {% endblock %}
 
 {% block header %}{% endblock %}

--- a/server.js
+++ b/server.js
@@ -59,8 +59,7 @@ if (extensions.legacyGovukFrontendFixesNeeded()) {
   scripts.push('/extension-assets/govuk-prototype-kit/lib/assets/javascripts/optional/legacy-govuk-frontend-init.js')
 }
 app.locals.extensionConfig = extensions.getAppConfig({
-  scripts: scripts,
-  stylesheets: ['/public/stylesheets/application.css']
+  scripts: scripts
 })
 
 // use cookie middleware for reading authentication cookie


### PR DESCRIPTION
When we added `application.css` to the plugins system [[1]], we accidentally broke the unbranded layout. There isn't an alternative quick fix because of the way the unbranded layout hooks into and basically duplicates `application.css`, so we're just going to back out that change and revisit after v13.

This PR removes `application.css` from extensionsConfig, and adds it to the stylesheets template include. Now you don't need to have `application.css` included in every page.

[1]: https://github.com/alphagov/govuk-prototype-kit/blob/bf4474e0b05957465c91b87d76e055250c0fd06c/server.js#L56

Fixes #1705.