### PR TITLE
Remove leading newlines from files generated by create script

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -17,7 +17,7 @@ const argv = parse(process.argv)
 
 const npmrc = `
 audit=false
-`
+`.trimStart()
 
 const gitignore = `
 # Node.js ignores
@@ -30,7 +30,7 @@ public/
 # General ignores
 .DS_Store
 .idea
-`
+`.trimStart()
 
 const packageJson = {
   scripts: {


### PR DESCRIPTION
I noticed while looking at the migration stuff that the `.npmrc` and `.gitignore` files had extra lines at the start of the file, which we don't want.