### PR TITLE
Add .tmp folder to starter .gitignore

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -25,7 +25,7 @@ node_modules/
 
 # Prototype ignores - per-user
 .env
-public/
+.tmp/
 
 # General ignores
 .DS_Store


### PR DESCRIPTION
We've had reports from users that the .tmp folder is shown as not ignored by their IDE (IntelliJ types it seems), even though that folder contains a gitignore. Let's add `.tmp` to the starter .gitignore to stop people being confused by their IDE, but keep the `.tmp/.gitignore` behaviour to cover situations where the `.gitignore` file is missing for some reason. This is a bit belt-and-braces, but doesn't really have a downside.