### PR TITLE
Display a message on management pages when not dev mode

### DIFF
--- a/lib/nunjucks/govuk-prototype-kit/includes/homepage-top.njk
+++ b/lib/nunjucks/govuk-prototype-kit/includes/homepage-top.njk
@@ -1,7 +1,11 @@
 <h2 class="govuk-heading-l">
   GOV.UK Prototype Kit
 </h2>
+
+{% if (GOVUKPrototypeKit.isDevelopment) %}
 <p>
   <a href="/manage-prototype">Manage your prototype</a>
 </p>
+{% endif %}
+
 <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">

--- a/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/manage-prototype-not-available.njk
+++ b/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/manage-prototype-not-available.njk
@@ -1,0 +1,31 @@
+{% extends "govuk-prototype-kit/internal/views/manage-prototype/layout.njk" %}
+
+{% block pageTitle %}
+  How to manage your prototype
+{% endblock %}
+
+{% block content %}
+
+  <p>
+    <a href="/">
+      Prototype home page
+    </a>
+  </p>
+
+  <h1 class="govuk-heading-l">
+    How to manage your prototype
+  </h1>
+
+  <p>
+    To manage this prototype it needs to run locally on your computer, in dev mode.
+  </p>
+
+  <p>
+    In the terminal run:
+  </p>
+
+  <p>
+    <code>npm run dev</code>
+  </p>
+
+{% endblock %}

--- a/lib/nunjucks/govuk-prototype-kit/layouts/govuk-branded.html
+++ b/lib/nunjucks/govuk-prototype-kit/layouts/govuk-branded.html
@@ -22,19 +22,29 @@
   }) }}
 {% endblock %}
 
+{% if (GOVUKPrototypeKit.isDevelopment) %}
+  {% set footerItems = [
+    {
+      href: "/manage-prototype",
+      text: "Manage your prototype"
+    }, {
+      href: "/manage-prototype/clear-data",
+      text: "Clear data"
+    }
+  ] %}
+{% else %}
+  {% set footerItems = [
+    {
+      href: "/manage-prototype/clear-data",
+      text: "Clear data"
+    }
+  ] %}
+{% endif %}
+
 {% block footer %}
   {{ govukFooter({
     meta: {
-      items: [
-        {
-          href: "/manage-prototype",
-          text: "Manage your prototype"
-        },
-        {
-          href: "/manage-prototype/clear-data",
-          text: "Clear data"
-        }
-      ],
+      items: footerItems,
       visuallyHiddenTitle: "Footer links"
     }
   }) }}

--- a/lib/routes/prototype-admin-routes.js
+++ b/lib/routes/prototype-admin-routes.js
@@ -104,6 +104,16 @@ router.post('/password', function (req, res) {
   }
 })
 
+// Middleware to ensure the routes specified below will render the manage-prototype-not-available
+// view when the prototype is not running in development
+router.use((req, res, next) => {
+  if (config.isDevelopment) {
+    next()
+  } else {
+    res.render(getManagementView('manage-prototype-not-available.njk'))
+  }
+})
+
 const managementLinks = [
   {
     text: 'Home',

--- a/listen-on-port.js
+++ b/listen-on-port.js
@@ -10,9 +10,11 @@ if (process.env.IS_INTEGRATION_TEST === 'true') {
   server.listen()
 } else {
   utils.findAvailablePort(server, function (port) {
-    console.log('You can manage your prototype at:')
-    console.log(`http://localhost:${port}/manage-prototype`)
-    console.log('')
+    if (config.isDevelopment) {
+      console.log('You can manage your prototype at:')
+      console.log(`http://localhost:${port}/manage-prototype`)
+      console.log('')
+    }
     console.log('The Prototype Kit is now running at:')
     console.log(`http://localhost:${port}`)
     console.log('')

--- a/server.js
+++ b/server.js
@@ -48,7 +48,10 @@ app.locals.asset_path = '/public/'
 app.locals.useAutoStoreData = config.useAutoStoreData
 app.locals.releaseVersion = 'v' + releaseVersion
 app.locals.serviceName = config.serviceName
-app.locals.GOVUKPrototypeKit = {}
+app.locals.GOVUKPrototypeKit = {
+  isProduction: config.isProduction,
+  isDevelopment: config.isDevelopment
+}
 if (extensions.legacyGovukFrontendFixesNeeded()) {
   app.locals.GOVUKPrototypeKit.legacyGovukFrontendFixesNeeded = true
 }


### PR DESCRIPTION
When not in dev mode:
- Starting banner displaying management pages address is not displayed
- Links to the management pages are removed
- Attempts to access the management pages (excluding password and clearing data) will display a page displaying a message indicating the pages are not available. 