### PR TITLE
Fix global styles for unbranded layout

### DIFF
--- a/lib/assets/sass/unbranded.scss
+++ b/lib/assets/sass/unbranded.scss
@@ -3,14 +3,10 @@
 //
 // See https://govuk-prototype-kit.herokuapp.com/docs/templates/blank-unbranded
 
-// Import settings first so we can override them before importing all of GOV.UK Frontend
-// If you need to enable compatibility mode or the legacy palette, do that *before* this import.
-@import "node_modules/govuk-frontend/govuk/settings/all";
-
 // Override the default GOV.UK Frontend font stack
 $govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
 
 // Override the canvas background colour, which is normally grey to blend with the GOV.UK footer.
-$govuk-canvas-background-colour: $govuk-body-background-colour;
+$govuk-canvas-background-colour: #ffffff;
 
 @import "prototype";

--- a/lib/build/tasks.js
+++ b/lib/build/tasks.js
@@ -66,11 +66,13 @@ function ensureTempDirExists (dir = tempDir) {
 }
 
 function sassExtensions () {
-  let fileContents = '$govuk-extensions-url-context: "/extension-assets"; $govuk-prototype-kit-major-version: 13;\n'
+  let fileContents = ''
+  fileContents += '$govuk-extensions-url-context: "/extension-assets";\n'
+  fileContents += '$govuk-prototype-kit-major-version: 13;\n'
   if (extensions.legacyGovukFrontendFixesNeeded()) {
-    fileContents += '$govuk-global-styles: true !default;'
-    fileContents += '$govuk-new-link-styles: true !default;'
-    fileContents += '$govuk-assets-path: $govuk-extensions-url-context + "/govuk-frontend/govuk/assets/" !default;'
+    fileContents += '$govuk-global-styles: true !default;\n'
+    fileContents += '$govuk-new-link-styles: true !default;\n'
+    fileContents += '$govuk-assets-path: $govuk-extensions-url-context + "/govuk-frontend/govuk/assets/" !default;\n'
   }
   fileContents += extensions.getFileSystemPaths('sass')
     .map(filePath => `@import "${filePath.split(path.sep).join('/')}";`)

--- a/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/password.njk
+++ b/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/password.njk
@@ -1,4 +1,5 @@
 {% extends "govuk-prototype-kit/layouts/unbranded.html" %}
+
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}


### PR DESCRIPTION
I noticed that one of the text lines wasn't formatted correctly on the password page, because it was missing the `govuk-body` class. Digging deeper, it seems that we used to expect that the GOV.UK frontend global styles would work for pages using the 'unbranded' stylesheet, but it stopped in the rework for v13.

The issue is that we import the govuk-frontend settings in the unbranded template, before we set the govuk-global-styles variable to true. Previously this was fine because we were setting that variable strongly, however in v13 we added the `!default` thingy [[1]], because we want users to be able to override the value in `settings.scss`. I think this behaviour is unavoidable, but luckily there is a workaround; we were only importing the settings to get `govuk-body-background-colour`,  but the value of that is just `#fffff` (white). We can set the value to white without needing to import any settings. If the GOV.UK Design System decides to go with an off-white body background colour in the future, that's also fine, the point of the unbranded template is not to look like GOV.UK, so we're not losing anything by hardcoding the value.

[1]: https://github.com/alphagov/govuk-prototype-kit/pull/1640#discussion_r985655213