### PR TITLE
Make govuk-frontend a peer dependency

### DIFF
--- a/lib/extensions/extensions.test.js
+++ b/lib/extensions/extensions.test.js
@@ -2,7 +2,6 @@
 /* eslint-disable no-prototype-builtins */
 // NPM dependencies
 const path = require('path')
-const fs = require('fs')
 const config = require('../config')
 
 // Local dependencies
@@ -11,7 +10,12 @@ const fakeFileSystem = require('../../__tests__/util/mockFileSystem')
 
 // Local variables
 const rootPath = path.join(__dirname, '..', '..')
-const pkg = fs.readFileSync('package.json', 'utf8')
+const pkg = `{
+  "dependencies": {
+    "govuk-frontend": "^4.3.0"
+  }
+}
+`
 let testScope
 
 // helpers

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "express-session": "^1.13.0",
         "fancy-log": "^1.3.3",
         "fs-extra": "^10.0.1",
-        "govuk-frontend": "^4.2.0",
+        "govuk-frontend": "^4.3.1",
         "inquirer": "^8.2.0",
         "lodash": "^4.17.21",
         "marked": "^4.0.10",
@@ -5574,9 +5574,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.2.0.tgz",
-      "integrity": "sha512-IHbnz5DbnPjuCv4lQvtJGoCNAKAN6byKqmaej8hjd6Y/KTaAuw10npijeqfRJNO4WdDX9a34+n+SC/UmWdjfGQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.3.1.tgz",
+      "integrity": "sha512-uD0KVFds7drOwLEvfp4zRBOXuHCxkWLYDQcYvlbG+2baZ9po2TGZz8WjfzhfueYjo9+Uwk+bM0NQT6g4cg/Q+A==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -15724,9 +15724,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.2.0.tgz",
-      "integrity": "sha512-IHbnz5DbnPjuCv4lQvtJGoCNAKAN6byKqmaej8hjd6Y/KTaAuw10npijeqfRJNO4WdDX9a34+n+SC/UmWdjfGQ=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.3.1.tgz",
+      "integrity": "sha512-uD0KVFds7drOwLEvfp4zRBOXuHCxkWLYDQcYvlbG+2baZ9po2TGZz8WjfzhfueYjo9+Uwk+bM0NQT6g4cg/Q+A=="
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "govuk-prototype-kit",
       "version": "0.0.1-beta.1",
       "dependencies": {
-        "@govuk-prototype-kit/step-by-step": "^2.0.0",
         "acorn": "^8.5.0",
         "ansi-colors": "^4.1.1",
         "body-parser": "^1.14.1",
@@ -756,11 +755,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
-    },
-    "node_modules/@govuk-prototype-kit/step-by-step": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@govuk-prototype-kit/step-by-step/-/step-by-step-2.0.0.tgz",
-      "integrity": "sha512-OmkkDqi8sYoGZewePo6waCBCMYAQZtPMgTG3obhBsM6F6/Wj/aFqduX3FJ0P0PEysg3p8Yz29W/HKGObcqHqvg=="
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
@@ -12049,11 +12043,6 @@
           "dev": true
         }
       }
-    },
-    "@govuk-prototype-kit/step-by-step": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@govuk-prototype-kit/step-by-step/-/step-by-step-2.0.0.tgz",
-      "integrity": "sha512-OmkkDqi8sYoGZewePo6waCBCMYAQZtPMgTG3obhBsM6F6/Wj/aFqduX3FJ0P0PEysg3p8Yz29W/HKGObcqHqvg=="
     },
     "@hapi/hoek": {
       "version": "9.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "express-session": "^1.13.0",
         "fancy-log": "^1.3.3",
         "fs-extra": "^10.0.1",
-        "govuk-frontend": "^4.3.1",
         "inquirer": "^8.2.0",
         "lodash": "^4.17.21",
         "marked": "^4.0.10",
@@ -53,6 +52,9 @@
       },
       "engines": {
         "node": ">=12.0.0 <19.0.0"
+      },
+      "peerDependencies": {
+        "govuk-frontend": ">=3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5577,6 +5579,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.3.1.tgz",
       "integrity": "sha512-uD0KVFds7drOwLEvfp4zRBOXuHCxkWLYDQcYvlbG+2baZ9po2TGZz8WjfzhfueYjo9+Uwk+bM0NQT6g4cg/Q+A==",
+      "peer": true,
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -15726,7 +15729,8 @@
     "govuk-frontend": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.3.1.tgz",
-      "integrity": "sha512-uD0KVFds7drOwLEvfp4zRBOXuHCxkWLYDQcYvlbG+2baZ9po2TGZz8WjfzhfueYjo9+Uwk+bM0NQT6g4cg/Q+A=="
+      "integrity": "sha512-uD0KVFds7drOwLEvfp4zRBOXuHCxkWLYDQcYvlbG+2baZ9po2TGZz8WjfzhfueYjo9+Uwk+bM0NQT6g4cg/Q+A==",
+      "peer": true
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "express-session": "^1.13.0",
     "fancy-log": "^1.3.3",
     "fs-extra": "^10.0.1",
-    "govuk-frontend": "^4.3.1",
     "inquirer": "^8.2.0",
     "lodash": "^4.17.21",
     "marked": "^4.0.10",
@@ -84,6 +83,9 @@
     "start-server-and-test": "^1.14.0",
     "supertest": "^6.2.3",
     "wait-on": "^6.0.1"
+  },
+  "peerDependencies": {
+    "govuk-frontend": ">=3"
   },
   "standard": {
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "express-session": "^1.13.0",
     "fancy-log": "^1.3.3",
     "fs-extra": "^10.0.1",
-    "govuk-frontend": "^4.2.0",
+    "govuk-frontend": "^4.3.1",
     "inquirer": "^8.2.0",
     "lodash": "^4.17.21",
     "marked": "^4.0.10",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "test": "npm run test:unit && npm run test:integration && npm run lint"
   },
   "dependencies": {
-    "@govuk-prototype-kit/step-by-step": "^2.0.0",
     "acorn": "^8.5.0",
     "ansi-colors": "^4.1.1",
     "body-parser": "^1.14.1",


### PR DESCRIPTION
Closes #1737 

---

Note that I've put a fairly lax requirement on the version of govuk-frontend; we could tighten this up to be greater than version 3, less than version 5, and in future release another version when we've verified what changes we need to make (if any) to support v5. But right now I'm not expecting v5 to require changes to the kit itself, as we've made much of the plugin architecture loose such that the initialisation code required is in the plugin package, not the kit.

Alternatively we could change the version requirement to '*', so users can use any version of govuk-frontend, although I think we'd prefer they use the better colour scheme and new link styles I don't think there's any major impediment to using the kit with older versions of govuk-frontend.

Of course, installing a version that doesn't match the peer dependency requirement is still possible, npm will just give a warning, so it doesn't matter too much either way.