### PR TITLE
Fix loading of front-end legacy assets

### DIFF
--- a/cypress/e2e/smoke/0-smoke-tests/index-page.cypress.js
+++ b/cypress/e2e/smoke/0-smoke-tests/index-page.cypress.js
@@ -2,3 +2,13 @@ specify('index page', () => {
   cy.visit('/')
   cy.contains('GOV.UK Prototype Kit')
 })
+
+specify('govuk-frontend fonts loaded', () => {
+  cy.visit('/')
+
+  const fontUrl = '/extension-assets/govuk-frontend/govuk/assets/fonts/bold-b542beb274-v2.woff2'
+
+  cy.task('log', `Requesting govuk-frontend font`)
+  cy.request(`/${fontUrl}`, { retryOnStatusCodeFailure: true })
+    .then(response => expect(response.status).to.eq(200))
+})

--- a/cypress/e2e/smoke/0-smoke-tests/index-page.cypress.js
+++ b/cypress/e2e/smoke/0-smoke-tests/index-page.cypress.js
@@ -8,7 +8,7 @@ specify('govuk-frontend fonts loaded', () => {
 
   const fontUrl = '/extension-assets/govuk-frontend/govuk/assets/fonts/bold-b542beb274-v2.woff2'
 
-  cy.task('log', `Requesting govuk-frontend font`)
+  cy.task('log', 'Requesting govuk-frontend font')
   cy.request(`/${fontUrl}`, { retryOnStatusCodeFailure: true })
     .then(response => expect(response.status).to.eq(200))
 })

--- a/lib/extensions/extensions.js
+++ b/lib/extensions/extensions.js
@@ -286,7 +286,7 @@ const self = module.exports = {
     .concat(additionalViews || []),
   legacyGovukFrontendFixesNeeded: () => {
     try {
-      const config = require('../../node_modules/govuk-frontend/govuk-prototype-kit.config.json')
+      const config = require(path.join(projectDir, 'node_modules/govuk-frontend/govuk-prototype-kit.config.json'))
       return !config.nunjucksMacros
     } catch (e) {
       return false


### PR DESCRIPTION
We found when testing v13 beta 2 (0.0.1-beta.2 on npm) that the GOV.UK Frontend fonts weren't working, even though the same code worked when creating a prototype linked to the local files.

This is because the check for whether the 'legacy' GOV.UK Frontend fixes are needed was using a hardcoded path into `node_modules`, which depends on how the node_modules folder is laid out. When installing the kit with a link to local files the `govuk-frontend` folder is at a different level. Making the path relative to the project dir fixes this.