### PR TITLE
Make acceptance tests more realistic

### DIFF
--- a/.github/workflows/test-acceptance.yaml
+++ b/.github/workflows/test-acceptance.yaml
@@ -42,6 +42,19 @@ jobs:
 
     - run: npm ci
 
+    - run: npm run test:acceptance:smoke
+      env:
+        CYPRESS_REQUEST_TIMEOUT: 20000
+        CYPRESS_DEFAULT_COMMAND_TIMEOUT: 40000
+        CYPRESS_PAGE_LOAD_TIMEOUT: 120000
+        CYPRESS_RETRIES: 3
+
+    - if: ${{ failure() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: cypress-screenshots-smoke-${{ runner.os }}-${{ matrix.node-version }}
+        path: cypress/screenshots/
+
     - run: npm run test:acceptance:prod
       env:
         CYPRESS_REQUEST_TIMEOUT: 20000

--- a/__tests__/util/index.js
+++ b/__tests__/util/index.js
@@ -66,7 +66,7 @@ async function mkPrototype (prototypePath, {
       err.code = 'EEXIST'
       throw err
     } else {
-      fs.remove(prototypePath)
+      await fs.remove(prototypePath)
     }
   }
 

--- a/cypress/e2e/smoke/0-smoke-tests/index-page.cypress.js
+++ b/cypress/e2e/smoke/0-smoke-tests/index-page.cypress.js
@@ -3,7 +3,7 @@ specify('index page', () => {
   cy.contains('GOV.UK Prototype Kit')
 })
 
-specify('govuk-frontend fonts loaded', () => {
+specify('GOV.UK Frontend fonts loaded', () => {
   cy.visit('/')
 
   const fontUrl = '/extension-assets/govuk-frontend/govuk/assets/fonts/bold-b542beb274-v2.woff2'
@@ -11,4 +11,9 @@ specify('govuk-frontend fonts loaded', () => {
   cy.task('log', 'Requesting govuk-frontend font')
   cy.request(`/${fontUrl}`, { retryOnStatusCodeFailure: true })
     .then(response => expect(response.status).to.eq(200))
+
+  cy.task('log', 'Check page has loaded fonts successfully')
+  cy.document()
+    .invoke('fonts.check', '16px GDS Transport')
+    .should('be.true')
 })

--- a/cypress/scripts/run-starter-prototype.js
+++ b/cypress/scripts/run-starter-prototype.js
@@ -9,6 +9,7 @@ const testDir = path.resolve(process.env.KIT_TEST_DIR || defaultKitPath)
 
 ;(async () => {
   await mkPrototype(testDir, { overwrite: true, allowTracking: false })
+
   const fooLocation = path.join(__dirname, '..', 'fixtures', 'extensions', 'extension-foo')
   const barLocation = path.join(__dirname, '..', 'fixtures', 'extensions', 'extension-bar')
   const bazLocation = path.join(__dirname, '..', 'fixtures', 'extensions', 'extension-baz')

--- a/cypress/scripts/run-starter-prototype.js
+++ b/cypress/scripts/run-starter-prototype.js
@@ -1,23 +1,18 @@
 const os = require('os')
 const path = require('path')
 
-const { mkPrototype, startPrototype, installExtensions, npmInstall } = require('../../__tests__/util')
+const { mkPrototype, startPrototype, installExtensions } = require('../../__tests__/util')
 
 const defaultKitPath = path.join(os.tmpdir(), 'cypress/temp/test-project')
 
 const testDir = path.resolve(process.env.KIT_TEST_DIR || defaultKitPath)
 
 ;(async () => {
-  await mkPrototype(testDir, { overwrite: true, allowTracking: false })
+  await mkPrototype(testDir, { overwrite: true, allowTracking: false, npmInstallLinks: true })
 
   const fooLocation = path.join(__dirname, '..', 'fixtures', 'extensions', 'extension-foo')
   const barLocation = path.join(__dirname, '..', 'fixtures', 'extensions', 'extension-bar')
-  const bazLocation = path.join(__dirname, '..', 'fixtures', 'extensions', 'extension-baz')
-  await Promise.all([
-    npmInstall(fooLocation),
-    npmInstall(barLocation),
-    npmInstall(bazLocation)
-  ])
+
   await installExtensions(testDir, [
     '@govuk-prototype-kit/step-by-step@1',
     `"file:${fooLocation}"`,

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:heroku": "start-server-and-test start:package:heroku 3000 cypress:e2e:smoke",
     "test:acceptance:dev": "cross-env KIT_TEST_DIR=tmp/test-prototype-package start-server-and-test start:package 3000 cypress:e2e:dev",
     "test:acceptance:prod": "cross-env KIT_TEST_DIR=tmp/test-prototype-package start-server-and-test start:package:prodtest 3000 cypress:e2e:prod",
+    "test:acceptance:smoke": "cross-env KIT_TEST_DIR=tmp/test-prototype-package start-server-and-test start:package 3000 cypress:e2e:smoke",
     "test:acceptance:open": "cross-env KIT_TEST_DIR=tmp/test-prototype-package start-server-and-test start:package 3000 cypress:open",
     "test:unit": "jest --detectOpenHandles lib bin",
     "test:integration": "cross-env CREATE_KIT_TIMEOUT=90000 IS_INTEGRATION_TEST=true jest --detectOpenHandles --testTimeout=60000 __tests__",


### PR DESCRIPTION
Changes Cypress tests so they run against a prototype that is setup similar to how users will have the kit installed.

Because we're using `--version local` for tests, npm is installing a folder, and by default will just create a symlink to that folder, rather than installing the package and all dependencies [[1]]. This means the `node_modules` folder is laid out differently to how it would be for real users, which can cause issues (see ticket #1741 for example). We can change the behaviour however by setting the `install-links` config variable to true [[2]]. This PR adds a line to set this in the Cypress server start script, meaning that the test prototype is installed in a more representative fashion.

As a result we can also improve the tests for checking whether the GOV.UK Frontend fonts have loaded, so that they would have caught #1741.

[1]: https://docs.npmjs.com/cli/v8/commands/npm-install
[2]: https://docs.npmjs.com/cli/v8/using-npm/config#install-links