### PR TITLE
Drop support for Node.js 12, 14

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false  # continue other tests if one test in matrix fails
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
         os: [macos-latest, windows-latest, ubuntu-latest]
 
     name: Test kit on Node v${{ matrix.node-version }} (${{ matrix.os }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Breaking changes
+- [#1753: Drop support for Node.js 12, 14](https://github.com/alphagov/govuk-prototype-kit/pull/1753)
 - [#1752: Move default user template to app/views/layouts/main.html](https://github.com/alphagov/govuk-prototype-kit/pull/1752)
 - [#1640: Fixing govuk frontend until they release update](https://github.com/alphagov/govuk-prototype-kit/pull/1640) We have made the plugin framework powerful enough to handle everything govuk-frontend needs but they haven't yet implemented their side of this, this change allows current and previous versions of govuk-frontend to work with the kit.  You'll need to import components before you can use them until govuk-frontend release a version which imports them automatically.  
 - [#1648: Change default session store to cookie store when in production mode](https://github.com/alphagov/govuk-prototype-kit/pull/1648) When hosted online the kit will now preserve user session data between server restarts by default.

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "wait-on": "^6.0.1"
       },
       "engines": {
-        "node": ">=12.0.0 <19.0.0"
+        "node": "^16.x || >= 18.x"
       },
       "peerDependencies": {
         "govuk-frontend": ">=3"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Rapidly create HTML prototypes of GOV.UK services",
   "version": "0.0.1-beta.3",
   "engines": {
-    "node": ">=12.0.0 <19.0.0"
+    "node": "^16.x || >= 18.x"
   },
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Node 12 has reached end of life (EOL), and Node 14 will reach end of life within the lifetime of GOV.UK Prototype Kit 13. Users shouldn't be using EOL versions of Node, as they do not receive security fixes. Let's stop supporting these versions, to reduce our maintenance burden. This commit removes them from the test matrix and the engines directive of the package.json.

Part of #1124.