### PR TITLE
Report fewer failures in migration script

### DIFF
--- a/__tests__/fixtures/test-v11-prototype/app/assets/sass/application.scss
+++ b/__tests__/fixtures/test-v11-prototype/app/assets/sass/application.scss
@@ -17,3 +17,7 @@ $govuk-assets-path: '/govuk/assets/';
 
 // Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you
 
+.my-style {
+  font-size: large;
+}
+

--- a/__tests__/spec/migrate.js
+++ b/__tests__/spec/migrate.js
@@ -30,7 +30,7 @@ describe('migrate test prototype', () => {
       env: process.env,
       stdio: 'ignore'
     })
-  }, 120000)
+  }, 240000)
 
   it('config.js to config.json', () => {
     const config = fse.readJsonSync(path.join(appDirectory, 'config.json'))
@@ -78,7 +78,11 @@ describe('migrate test prototype', () => {
 
     expect(sassFileContents).toEqual(
       '// Add extra styles here' +
-      '\n\n\n'
+      '\n\n\n' +
+      '.my-style {\n' +
+      '  font-size: large;\n' +
+      '}\n' +
+      '\n'
     )
   })
 

--- a/lib/migrator/index.js
+++ b/lib/migrator/index.js
@@ -3,6 +3,7 @@ const {
 } = require('./fileHelpers')
 
 const logger = require('./logger')
+
 const {
   preflightChecks,
   migrateConfig,
@@ -71,7 +72,6 @@ const filesToDeleteIfUnchanged = [
   'app/assets/images/unbranded.ico',
   'app/assets/javascripts/auto-store-data.js',
   'app/assets/javascripts/jquery-1.11.3.js',
-  'app/assets/sass/application.scss',
   'app/assets/sass/patterns/_contents-list.scss',
   'app/assets/sass/patterns/_check-your-answers.scss',
   'app/assets/sass/patterns/_mainstream-guide.scss',
@@ -135,8 +135,14 @@ const migrate = async () => {
 
     await Promise.all(directoriesToDeleteIfEmpty.map(async (dirPath) => {
       const reporter = await addReporter(`Remove empty directory ${dirPath}`)
-      const result = await deleteDirectoryIfEmpty(dirPath)
-      await reporter(result)
+      // Only report if a directory is empty
+      try {
+        if (await deleteDirectoryIfEmpty(dirPath)) {
+          await reporter(true)
+        }
+      } catch (e) {
+        await reporter(false)
+      }
     }))
 
     // migrate config last so that it will indicate the migration is complete

--- a/lib/migrator/index.js
+++ b/lib/migrator/index.js
@@ -136,12 +136,10 @@ const migrate = async () => {
     await Promise.all(directoriesToDeleteIfEmpty.map(async (dirPath) => {
       const reporter = await addReporter(`Remove empty directory ${dirPath}`)
       // Only report if a directory is empty
-      try {
-        if (await deleteDirectoryIfEmpty(dirPath)) {
-          await reporter(true)
-        }
-      } catch (e) {
-        await reporter(false)
+      if (await deleteDirectoryIfEmpty(dirPath)) {
+        await reporter(true)
+      } else {
+        await logger.log(`Skipped deleting ${dirPath}`)
       }
     }))
 

--- a/lib/migrator/migrationSteps.js
+++ b/lib/migrator/migrationSteps.js
@@ -62,7 +62,7 @@ module.exports.migrateConfig = async (oldConfigPath) => {
     }, {})
 
     await fse.writeJsonSync(newConfigPath, newConfig, { encoding: 'utf8' })
-    await deleteFile(oldConfigPath).catch(handleNotFound(false))
+    await deleteFile(oldConfigPath)
 
     return reporter(true)
   } catch (e) {

--- a/lib/migrator/migrationSteps.spec.js
+++ b/lib/migrator/migrationSteps.spec.js
@@ -157,7 +157,7 @@ describe('migration steps', () => {
     await prepareSass(sass)
 
     expect(fse.readFile).toHaveBeenCalledTimes(1)
-    expect(fse.readFile).toHaveBeenNthCalledWith(1, path.join(starterDir, sass), 'utf8')
+    expect(fse.readFile).toHaveBeenCalledWith(path.join(starterDir, sass), 'utf8')
 
     expect(fileHelpers.replaceStartOfFile).toHaveBeenCalledTimes(1)
     expect(fileHelpers.replaceStartOfFile).toHaveBeenCalledWith({


### PR DESCRIPTION
Also tidy, tests and add code to the test application.scss after the line to designate user code, to prove the code is retained when the top of the file is removed.