### PR TITLE
Fix step by step plugin test

### DIFF
--- a/cypress/e2e/dev/6-management-tests/install-available-plugin.cypress.js
+++ b/cypress/e2e/dev/6-management-tests/install-available-plugin.cypress.js
@@ -2,7 +2,7 @@ const { waitForApplication, uninstallPlugin, installPlugin } = require('../../ut
 const managePluginsPagePath = '/manage-prototype/plugins'
 const plugin = '@govuk-prototype-kit/step-by-step'
 const version1 = '@1.0.0'
-const version2 = '@2.0.0'
+const version2 = '@2.1.0'
 const pluginName = 'Step By Step'
 
 const cleanup = () => {


### PR DESCRIPTION
The cypress test needs to be updated as the latest step by step version is now 2.1.0 