### PR TITLE
Remove sass includes with patterns

### DIFF
--- a/lib/migrator/fileHelpers.js
+++ b/lib/migrator/fileHelpers.js
@@ -135,6 +135,7 @@ const matchAgainstOldVersions = async (filePath) => {
 
 module.exports = {
   getFileAsLines,
+  writeFileLinesToFile,
   replaceStartOfFile,
   removeLineFromFile,
   deleteFile,

--- a/lib/migrator/index.js
+++ b/lib/migrator/index.js
@@ -1,7 +1,3 @@
-const {
-  deleteDirectoryIfEmpty
-} = require('./fileHelpers')
-
 const logger = require('./logger')
 
 const {
@@ -11,10 +7,12 @@ const {
   prepareSass,
   deleteUnusedFiles,
   deleteUnusedDirectories,
-  upgradeIfUnchanged
+  deleteEmptyDirectories,
+  upgradeIfUnchanged,
+  deleteIfUnchanged,
+  removeOldPatternIncludesFromSassFile
 } = require('./migrationSteps')
 
-const { addReporter } = require('./reporter')
 const fs = require('fs-extra')
 const path = require('path')
 const { spawn } = require('../exec')
@@ -72,6 +70,14 @@ const filesToDeleteIfUnchanged = [
   'app/assets/images/unbranded.ico',
   'app/assets/javascripts/auto-store-data.js',
   'app/assets/javascripts/jquery-1.11.3.js',
+  'app/assets/sass/unbranded-ie8.scss',
+  'app/assets/sass/unbranded.scss',
+  'app/views/includes/breadcrumb_examples.html',
+  'app/views/includes/cookie-banner.html',
+  'app/views/layout_unbranded.html'
+]
+
+const patternsToDeleteIfUnchanged = [
   'app/assets/sass/patterns/_contents-list.scss',
   'app/assets/sass/patterns/_check-your-answers.scss',
   'app/assets/sass/patterns/_mainstream-guide.scss',
@@ -81,12 +87,7 @@ const filesToDeleteIfUnchanged = [
   'app/assets/sass/patterns/_step-by-step-related.scss',
   'app/assets/sass/patterns/_step-by-step-nav.scss',
   'app/assets/sass/patterns/_step-by-step-navigation.scss',
-  'app/assets/sass/patterns/_task-list.scss',
-  'app/assets/sass/unbranded-ie8.scss',
-  'app/assets/sass/unbranded.scss',
-  'app/views/includes/breadcrumb_examples.html',
-  'app/views/includes/cookie-banner.html',
-  'app/views/layout_unbranded.html'
+  'app/assets/sass/patterns/_task-list.scss'
 ]
 
 const prepareMigration = async (kitDependency, projectDirectory) => {
@@ -113,38 +114,38 @@ const prepareMigration = async (kitDependency, projectDirectory) => {
     })
 }
 
+// Special case app/views/layout.html, as it has moved in prototype
+// starter files, but we don't want to move for existing users
+const upgradeLayoutIfUnchanged = async () => {
+  await upgradeIfUnchanged(
+    ['app/views/layout.html'],
+    'app/views/layouts/main.html',
+    () => deleteIfUnchanged([
+      'app/views/includes/head.html',
+      'app/views/includes/scripts.html'
+    ]))
+}
+
 const migrate = async () => {
   await logger.setup()
 
   try {
     await Promise.all([
+      migrateConfig('app/config.js'),
       prepareAppRoutes('app/routes.js'),
       prepareSass('app/assets/sass/application.scss'),
       deleteUnusedFiles(filesToDelete),
       deleteUnusedDirectories(directoriesToDelete),
-      upgradeIfUnchanged([
-        ...filesToUpdateIfUnchanged.map(filePath => ({ filePath, action: 'copyFromKitStarter' })),
-        ...filesToDeleteIfUnchanged.map(filePath => ({ filePath, action: 'delete' }))
-      ]),
-      upgradeIfUnchanged([
-        // Special case app/views/layout.html, as it has moved in prototype
-        // starter files, but we don't want to move for existing users
-        { filePath: 'app/views/layout.html', starterFilePath: 'app/views/layouts/main.html', action: 'copyFromKitStarter' }
-      ])
+      upgradeIfUnchanged(filesToUpdateIfUnchanged),
+      upgradeLayoutIfUnchanged(),
+      deleteIfUnchanged(filesToDeleteIfUnchanged),
+      deleteIfUnchanged(patternsToDeleteIfUnchanged)
     ])
 
-    await Promise.all(directoriesToDeleteIfEmpty.map(async (dirPath) => {
-      const reporter = await addReporter(`Remove empty directory ${dirPath}`)
-      // Only report if a directory is empty
-      if (await deleteDirectoryIfEmpty(dirPath)) {
-        await reporter(true)
-      } else {
-        await logger.log(`Skipped deleting ${dirPath}`)
-      }
-    }))
-
-    // migrate config last so that it will indicate the migration is complete
-    await migrateConfig('app/config.js')
+    await Promise.all([
+      await removeOldPatternIncludesFromSassFile(patternsToDeleteIfUnchanged, 'app/assets/sass/application.scss'),
+      await deleteEmptyDirectories(directoriesToDeleteIfEmpty)
+    ])
   } catch (e) {
     await logger.log(e.message)
     await logger.log(e.stack)

--- a/lib/migrator/migrationSteps.js
+++ b/lib/migrator/migrationSteps.js
@@ -3,6 +3,7 @@ const lodash = require('lodash')
 const fse = require('fs-extra')
 const { appDir, projectDir, packageDir } = require('../path-utils')
 const config = require('../config')
+const logger = require('./logger')
 const { addReporter, reportSuccess, reportFailure } = require('./reporter')
 const {
   getFileAsLines,
@@ -13,7 +14,9 @@ const {
   matchAgainstOldVersions,
   copyFileFromStarter,
   verboseLog,
-  handleNotFound
+  handleNotFound,
+  deleteDirectoryIfEmpty,
+  writeFileLinesToFile
 } = require('./fileHelpers')
 
 // Allows mocking of getOldConfig
@@ -105,6 +108,20 @@ module.exports.prepareSass = async (sassFile) => {
   await reporter(result)
 }
 
+module.exports.removeOldPatternIncludesFromSassFile = async (patterns, sassFile) => {
+  const reporter = await addReporter('Remove old pattern includes from application SCSS file')
+  const deletedPatterns = (await Promise.all(patterns.map(async file => await fse.pathExistsSync(file) ? undefined : file)))
+    .filter((file) => file)
+    .map((file) => `@import "patterns/${file.substring(file.indexOf('/_') + 2, file.indexOf('.scss'))}";`)
+  const filePath = path.join(projectDir, sassFile)
+  const originalContent = await getFileAsLines(filePath)
+  const updatedContent = originalContent.filter((line) => {
+    return !deletedPatterns.includes(line.trim())
+  })
+  const succeeded = await writeFileLinesToFile(filePath, updatedContent)
+  await reporter(succeeded)
+}
+
 module.exports.deleteUnusedFiles = async (filesToDelete) => {
   const reporter = await addReporter('Deleted files that are no longer needed')
   const results = await Promise.all(filesToDelete.map(file =>
@@ -123,44 +140,45 @@ module.exports.deleteUnusedDirectories = async (directoriesToDelete) => {
   await reporter(allSucceeded)
 }
 
-module.exports.upgradeIfUnchanged = (configs) => Promise.all(configs.map(async config => {
-  const matchFound = await matchAgainstOldVersions(config.filePath)
+module.exports.deleteEmptyDirectories = (directoriesToDelete) => Promise.all(directoriesToDelete.map(async (dirPath) => {
+  const reporter = await addReporter(`Remove empty directory ${dirPath}`)
+  // Only report if a directory is empty
+  if (await deleteDirectoryIfEmpty(dirPath)) {
+    await reporter(true)
+  } else {
+    await logger.log(`Skipped deleting ${dirPath}`)
+  }
+}))
 
-  if (config.action === 'copyFromKitStarter') {
-    const reporter = await addReporter(`Overwrite ${config.filePath}`)
+module.exports.deleteIfUnchanged = (filePaths) => Promise.all(filePaths.map(async filePath => {
+  const matchFound = await matchAgainstOldVersions(filePath)
 
-    if (!matchFound) {
-      await reporter(false)
-      return
-    }
-    try {
-      await copyFileFromStarter(config.starterFilePath || config.filePath, config.filePath)
-      if (config.filePath === 'app/views/layout.html') {
-        await module.exports.upgradeIfUnchanged([
-          {
-            filePath: 'app/views/includes/head.html',
-            action: 'delete'
-          },
-          {
-            filePath: 'app/views/includes/scripts.html',
-            action: 'delete'
-          }
-        ])
-      }
-    } catch (e) {
-      await verboseLog(e.message)
-      await verboseLog(e.stack)
-      await reporter(false)
-      return
+  const reporter = await addReporter(`Delete ${filePath}`)
+  if (matchFound) {
+    const result = await deleteFile(path.join(projectDir, filePath)).catch(handleNotFound(false))
+    await reporter(result)
+  } else if (matchFound === false) {
+    await reporter(false)
+  }
+}))
+
+module.exports.upgradeIfUnchanged = (filePaths, starterFilePath, additionalStep) => Promise.all(filePaths.map(async filePath => {
+  const matchFound = await matchAgainstOldVersions(filePath)
+
+  const reporter = await addReporter(`Overwrite ${filePath}`)
+
+  if (!matchFound) {
+    await reporter(false)
+  }
+  try {
+    await copyFileFromStarter(starterFilePath || filePath, filePath)
+    if (additionalStep) {
+      await additionalStep()
     }
     await reporter(true)
-  } else if (config.action === 'delete') {
-    const reporter = await addReporter(`Delete ${config.filePath}`)
-    if (matchFound) {
-      const result = await deleteFile(path.join(projectDir, config.filePath)).catch(handleNotFound(false))
-      await reporter(result)
-    } else if (matchFound === false) {
-      await reporter(false)
-    }
+  } catch (e) {
+    await verboseLog(e.message)
+    await verboseLog(e.stack)
+    await reporter(false)
   }
 }))

--- a/lib/migrator/migrationSteps.spec.js
+++ b/lib/migrator/migrationSteps.spec.js
@@ -15,7 +15,8 @@ jest.mock('./reporter', () => {
 
 jest.mock('./fileHelpers', () => {
   return {
-    getFileAsLines: jest.fn().mockResolvedValue(['8.1.1']),
+    getFileAsLines: jest.fn().mockResolvedValue(true),
+    writeFileLinesToFile: jest.fn().mockResolvedValue(true),
     deleteFile: jest.fn().mockResolvedValue(true),
     replaceStartOfFile: jest.fn().mockResolvedValue(true),
     removeLineFromFile: jest.fn().mockResolvedValue(true),
@@ -33,7 +34,7 @@ const config = require('./../config')
 const { projectDir, starterDir, appDir } = require('../path-utils')
 
 const migrationSteps = require('./migrationSteps')
-const { preflightChecks } = require('./migrationSteps')
+const { preflightChecks, deleteIfUnchanged, removeOldPatternIncludesFromSassFile } = require('./migrationSteps')
 const { migrateConfig, prepareAppRoutes, prepareSass, deleteUnusedFiles, deleteUnusedDirectories, upgradeIfUnchanged } = migrationSteps
 
 describe('migration steps', () => {
@@ -41,6 +42,7 @@ describe('migration steps', () => {
 
   beforeEach(() => {
     fileHelpers.replaceStartOfFile.mockResolvedValue(true)
+    fileHelpers.getFileAsLines.mockResolvedValue(true)
   })
 
   afterEach(() => {
@@ -49,6 +51,10 @@ describe('migration steps', () => {
 
   describe('preflight checks', () => {
     const filesToCheck = ['foo', 'bar', 'foo/bar']
+
+    beforeEach(() => {
+      fileHelpers.getFileAsLines.mockResolvedValue(['8.1.1'])
+    })
 
     const testPreflightChecks = async (state) => {
       fse.pathExists = jest.fn().mockImplementation(async (path) => state && !path.includes('v6'))
@@ -170,6 +176,45 @@ describe('migration steps', () => {
     expect(mockReporter).toHaveBeenCalledWith(true)
   })
 
+  it('remove old pattern includes from sass', async () => {
+    const sassFile = 'foo-bar.scss'
+
+    const deletedPatterns = [
+      'app/assets/sass/patterns/_foo.scss',
+      'app/assets/sass/patterns/_baz.scss'
+    ]
+
+    const patternsToDelete = [
+      'app/assets/sass/patterns/_foo.scss',
+      'app/assets/sass/patterns/_bar.scss',
+      'app/assets/sass/patterns/_baz.scss'
+    ]
+
+    const originalSassContent = `
+      @import "patterns/foo";
+      @import "patterns/bar";
+      @import "patterns/baz";
+    `
+
+    const updatedSassContent = `
+      @import "patterns/bar";
+    `
+
+    fileHelpers.getFileAsLines.mockReturnValue(originalSassContent.split('\n'))
+    fse.pathExistsSync = jest.fn().mockImplementation(async (path) => !deletedPatterns.includes(path))
+
+    await removeOldPatternIncludesFromSassFile(patternsToDelete, sassFile)
+
+    expect(fileHelpers.getFileAsLines).toHaveBeenCalledTimes(1)
+    expect(fileHelpers.getFileAsLines).toHaveBeenCalledWith(path.join(projectDir, sassFile))
+
+    expect(fileHelpers.writeFileLinesToFile).toHaveBeenCalledTimes(1)
+    expect(fileHelpers.writeFileLinesToFile).toHaveBeenCalledWith(path.join(projectDir, sassFile), updatedSassContent.split('\n'))
+
+    expect(mockReporter).toHaveBeenCalledTimes(1)
+    expect(mockReporter).toHaveBeenCalledWith(true)
+  })
+
   it('delete unused files', async () => {
     const filesToDelete = ['foo', 'bar']
     await deleteUnusedFiles(filesToDelete)
@@ -196,39 +241,27 @@ describe('migration steps', () => {
 
   it('upgrade if unchanged layout', async () => {
     const layout = 'app/views/layout.html'
-    const head = 'app/views/includes/head.html'
-    const scripts = 'app/views/includes/scripts.html'
+    const additionalStep = jest.fn().mockResolvedValue(true)
 
-    await upgradeIfUnchanged([
-      { filePath: layout, action: 'copyFromKitStarter' }
-    ])
+    await upgradeIfUnchanged([layout], layout, additionalStep)
 
-    expect(fileHelpers.matchAgainstOldVersions).toHaveBeenCalledTimes(3)
-    expect(fileHelpers.matchAgainstOldVersions).toHaveBeenNthCalledWith(1, layout)
-    expect(fileHelpers.matchAgainstOldVersions).toHaveBeenNthCalledWith(2, head)
-    expect(fileHelpers.matchAgainstOldVersions).toHaveBeenNthCalledWith(3, scripts)
+    expect(fileHelpers.matchAgainstOldVersions).toHaveBeenCalledTimes(1)
+    expect(fileHelpers.matchAgainstOldVersions).toHaveBeenCalledWith(layout)
 
-    expect(reporter.addReporter).toHaveBeenCalledTimes(3)
-    expect(reporter.addReporter).toHaveBeenNthCalledWith(1, `Overwrite ${layout}`)
-    expect(reporter.addReporter).toHaveBeenNthCalledWith(2, `Delete ${head}`)
-    expect(reporter.addReporter).toHaveBeenNthCalledWith(3, `Delete ${scripts}`)
+    expect(additionalStep).toHaveBeenCalledTimes(1)
+    expect(additionalStep).toHaveBeenCalled()
 
-    expect(fileHelpers.deleteFile).toHaveBeenCalledTimes(2)
-    expect(fileHelpers.deleteFile).toHaveBeenNthCalledWith(1, path.join(projectDir, head))
-    expect(fileHelpers.deleteFile).toHaveBeenNthCalledWith(2, path.join(projectDir, scripts))
+    expect(reporter.addReporter).toHaveBeenCalledTimes(1)
+    expect(reporter.addReporter).toHaveBeenCalledWith(`Overwrite ${layout}`)
 
-    expect(mockReporter).toHaveBeenCalledTimes(3)
-    expect(mockReporter).toHaveBeenNthCalledWith(1, true)
-    expect(mockReporter).toHaveBeenNthCalledWith(2, true)
-    expect(mockReporter).toHaveBeenNthCalledWith(3, true)
+    expect(mockReporter).toHaveBeenCalledTimes(1)
+    expect(mockReporter).toHaveBeenCalledWith(true)
   })
 
-  it('upgrade if unchanged unbranded layout', async () => {
+  it('delete if unchanged unbranded layout', async () => {
     const unbrandedLayout = 'app/views/layout_unbranded.html'
 
-    await upgradeIfUnchanged([
-      { filePath: unbrandedLayout, action: 'delete' }
-    ])
+    await deleteIfUnchanged([unbrandedLayout])
 
     expect(fileHelpers.matchAgainstOldVersions).toHaveBeenCalledTimes(1)
     expect(fileHelpers.matchAgainstOldVersions).toHaveBeenCalledWith(unbrandedLayout)


### PR DESCRIPTION
- Split up the updateIfUnchanged migration step to make it easy to maintain and simplify tests to match.
- Add deleteIfUnchanged step to simplify steps.
- Add deleteEmptyDirectories step so that functionality can be moved into migrationSteps file with the other steps.