### PR TITLE
Update message about setting default port

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -92,7 +92,6 @@ exports.findAvailablePort = function (app, callback) {
           callback(port)
         } else {
           // User answers no - exit
-          console.log('\nYou can set a new default port in server.js, or by running the server with PORT=XXXX')
           console.log('\nExit by pressing \'ctrl + c\'')
           process.exit(0)
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,20 +1,20 @@
 // Core dependencies
-const https = require('https')
 const crypto = require('crypto')
 const fs = require('fs')
+const https = require('https')
+const path = require('path')
 
 // NPM dependencies
-const { marked } = require('marked')
-const path = require('path')
-const portScanner = require('portscanner')
 const inquirer = require('inquirer')
+const portScanner = require('portscanner')
+const { marked } = require('marked')
 
 // Local dependencies
 const config = require('./config').getConfig()
-const { appDir, tempDir } = require('./path-utils')
+const extensions = require('./extensions/extensions')
 const filters = require('./filters/api')
 const routes = require('./routes/api')
-const extensions = require('./extensions/extensions')
+const { appDir, tempDir } = require('./path-utils')
 
 // Tweak the Markdown renderer
 const defaultMarkedRenderer = marked.defaults.renderer || new marked.Renderer()


### PR DESCRIPTION
Default port can no longer be set by changing server.js, let's just remove this message. In future we should add something to the docs on setting port numbers, and then we can link users to that.