### PR TITLE
Remove @hmcts/frontend from available plugins list

### DIFF
--- a/known-plugins.json
+++ b/known-plugins.json
@@ -1,0 +1,11 @@
+{
+  "plugins": {
+    "available": [
+      "govuk-frontend",
+      "@govuk-prototype-kit/step-by-step",
+      "@hmcts/frontend",
+      "hmrc-frontend",
+      "jquery"
+    ]
+  }
+}

--- a/known-plugins.json
+++ b/known-plugins.json
@@ -3,7 +3,6 @@
     "available": [
       "govuk-frontend",
       "@govuk-prototype-kit/step-by-step",
-      "@hmcts/frontend",
       "hmrc-frontend",
       "jquery"
     ]

--- a/lib/routes/prototype-admin-routes.js
+++ b/lib/routes/prototype-admin-routes.js
@@ -318,13 +318,9 @@ const removeDuplicates = (val, index, arr) => !arr.includes(val, index + 1)
 
 async function getPluginDetails () {
   const installed = extensions.listInstalledExtensions()
-  const available = [
-    'govuk-frontend',
-    '@govuk-prototype-kit/step-by-step',
-    '@hmcts/frontend',
-    'hmrc-frontend',
-    'jquery'
-  ] // todo - load from docs.
+  const available = (
+    await fse.readJson(path.join(packageDir, 'known-plugins.json'))
+  ).plugins.available
   const all = await Promise.all(installed.concat(available)
     .filter(removeDuplicates)
     .map(async (packageName) => ({

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "LICENCE.txt",
     "README.md",
     "govuk-prototype-kit.config.json",
+    "known-plugins.json",
     "index.js",
     "listen-on-port.js",
     "server.js",


### PR DESCRIPTION
HMCTS Frontend hasn't been updated for 2 years [[1]], and is archived on GitHub [[2]]. We probably don't want to point users towards it.

[1]: https://www.npmjs.com/package/@hmcts/frontend
[2]: https://github.com/hmcts/frontend