### PR TITLE
Split require lines in starter files

### DIFF
--- a/__tests__/spec/migrate.js
+++ b/__tests__/spec/migrate.js
@@ -48,10 +48,11 @@ describe('migrate test prototype', () => {
     const routesFileContents = fs.readFileSync(path.join(appDirectory, 'routes.js'), 'utf8')
 
     expect(routesFileContents).toEqual(
-      'const router = require(\'govuk-prototype-kit\').requests.setupRouter()' +
-      '\n\n' +
-      '// Add your routes here' +
-      '\n\n\n'
+      'const govukPrototypeKit = require(\'govuk-prototype-kit\')\n' +
+      'const router = govukPrototypeKit.requests.setupRouter()\n' +
+      '\n' +
+      '// Add your routes here\n' +
+      '\n\n'
     )
   })
 
@@ -59,7 +60,8 @@ describe('migrate test prototype', () => {
     const filtersFileContents = fs.readFileSync(path.join(appDirectory, 'filters.js'), 'utf8')
 
     expect(filtersFileContents).toEqual(
-      'const addFilter = require(\'govuk-prototype-kit\').views.addFilter' + '\n'
+      'const govukPrototypeKit = require(\'govuk-prototype-kit\')\n' +
+      'const addFilter = govukPrototypeKit.views.addFilter' + '\n'
     )
   })
 

--- a/prototype-starter/app/filters.js
+++ b/prototype-starter/app/filters.js
@@ -1,1 +1,2 @@
-const addFilter = require('govuk-prototype-kit').views.addFilter
+const govukPrototypeKit = require('govuk-prototype-kit')
+const addFilter = govukPrototypeKit.views.addFilter

--- a/prototype-starter/app/routes.js
+++ b/prototype-starter/app/routes.js
@@ -1,3 +1,4 @@
-const router = require('govuk-prototype-kit').requests.setupRouter()
+const govukPrototypeKit = require('govuk-prototype-kit')
+const router = govukPrototypeKit.requests.setupRouter()
 
 // Add your routes here


### PR DESCRIPTION
Something I discussed with @nataliecarey a while back but forgot about, not urgent but nice to have.

This splits the `require` lines in the starter files in 2 - one to get `govuk-prototype-kit` and another for whatever the relevant file needs (eg `router`).

This means `govukPrototypeKit` is available for users which seems flexible and future proof