### PR TITLE
Update domain from heroku to service.gov.uk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # GOV.UK Prototype Kit
 
-Go to the [GOV.UK Prototype Kit site](https://govuk-prototype-kit.herokuapp.com/docs) to download the latest version and read the documentation.
+Go to the [GOV.UK Prototype Kit site](https://prototype-kit.service.gov.uk/docs) to download the latest version and read the documentation.
 
 ## About the Prototype Kit
 
 The Prototype Kit provides a simple way to make interactive prototypes that look like pages on GOV.UK. These prototypes can be used to show ideas to people you work with, and to do user research.
 
-Read the [project principles](https://govuk-prototype-kit.herokuapp.com/docs/principles).
+Read the [project principles](https://prototype-kit.service.gov.uk/docs/principles).
 
 ## Make sure prototypes are password-protected
 
-If you publish your prototypes online, they **must** be protected by a [username and password](https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku). This is to prevent members of the public finding prototypes and thinking they are real services.
+If you publish your prototypes online, they **must** be protected by a [username and password](https://prototype-kit.service.gov.uk/docs/publishing-on-heroku). This is to prevent members of the public finding prototypes and thinking they are real services.
 
 You must protect user privacy at all times, even when using prototypes. Prototypes made with the kit look like GOV.UK, but do not have the same security provisions. Always make sure you are handling user data appropriately.
 
 ## Installation instructions
 
-- [Installation guide for new users (non technical)](https://govuk-prototype-kit.herokuapp.com/docs/install/introduction)
-- [Installation guide for developers (technical)](https://govuk-prototype-kit.herokuapp.com/docs/install/developer-install-instructions)
+- [Installation guide for new users (non technical)](https://prototype-kit.service.gov.uk/docs/install/introduction)
+- [Installation guide for developers (technical)](https://prototype-kit.service.gov.uk/docs/install/developer-install-instructions)
 
 ## Node version requirements
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Read the [project principles](https://prototype-kit.service.gov.uk/docs/principl
 
 ## Make sure prototypes are password-protected
 
-If you publish your prototypes online, they **must** be protected by a [username and password](https://prototype-kit.service.gov.uk/docs/publishing-on-heroku). This is to prevent members of the public finding prototypes and thinking they are real services.
+If you publish your prototypes online, they **must** be [protected by a password](https://prototype-kit.service.gov.uk/docs/publishing). This is to prevent members of the public finding prototypes and thinking they are real services.
 
 You must protect user privacy at all times, even when using prototypes. Prototypes made with the kit look like GOV.UK, but do not have the same security provisions. Always make sure you are handling user data appropriately.
 

--- a/internal_docs/releasing-from-a-support-branch.md
+++ b/internal_docs/releasing-from-a-support-branch.md
@@ -96,7 +96,7 @@ Write a brief summary with highlights from the release then send it to the follo
 - X-GOV #prototype-kit
 - GDS #govuk-design-system
 
-Include a link to the install page: https://govuk-prototype-kit.herokuapp.com/docs/install.
+Include a link to the install page: https://prototype-kit.service.gov.uk/docs/install.
 
 Include a link to the GitHub release page if there are actions for users that are not covered in the release notes.
 

--- a/internal_docs/releasing.md
+++ b/internal_docs/releasing.md
@@ -66,4 +66,4 @@ Write a brief summary with highlights from the release then send it to the follo
 - X-GOV #prototype-kit
 - GDS #govuk-design-system
 
-Make sure to send a link to the install page rather than the GitHub release page: https://govuk-prototype-kit.herokuapp.com/docs/install.
+Make sure to send a link to the install page rather than the GitHub release page: https://prototype-kit.service.gov.uk/docs/install.

--- a/lib/assets/sass/unbranded.scss
+++ b/lib/assets/sass/unbranded.scss
@@ -1,7 +1,7 @@
 // The unbranded stylesheet is used if you need to create pages in your
 // prototype without the GOV.UK branding.
 //
-// See https://govuk-prototype-kit.herokuapp.com/docs/templates/blank-unbranded
+// See https://prototype-kit.service.gov.uk/docs/templates/blank-unbranded
 
 // Override the default GOV.UK Frontend font stack
 $govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;

--- a/lib/middleware/authentication/authentication.js
+++ b/lib/middleware/authentication/authentication.js
@@ -59,7 +59,7 @@ function shouldUseAuth () {
 
 function showNoPasswordError (res) {
   console.error('Password is not set.')
-  return res.send('<h1>Error:</h1><p>Password not set. <a href="https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku#6-set-a-password">See guidance for setting a password</a>.</p>')
+  return res.send('<h1>Error:</h1><p>Password not set. <a href="https://prototype-kit.service.gov.uk/docs/publishing#setting-a-password">See guidance for setting a password</a>.</p>')
 }
 
 function sendUserToPasswordPage (req, res) {

--- a/lib/middleware/authentication/authentication.test.js
+++ b/lib/middleware/authentication/authentication.test.js
@@ -77,7 +77,7 @@ describe('authentication', () => {
 
       it('should return a user friendly error to the browser', () => {
         const errorDisplayedToUser = res.send.mock.calls[0][0]
-        expect(errorDisplayedToUser).toBe('<h1>Error:</h1><p>Password not set. <a href="https://govuk-prototype-kit.herokuapp.com/docs/publishing-on-heroku#6-set-a-password">See guidance for setting a password</a>.</p>')
+        expect(errorDisplayedToUser).toBe('<h1>Error:</h1><p>Password not set. <a href="https://prototype-kit.service.gov.uk/docs/publishing#setting-a-password">See guidance for setting a password</a>.</p>')
       })
     })
 

--- a/lib/migrator/index.js
+++ b/lib/migrator/index.js
@@ -1,6 +1,6 @@
 const logger = require('./logger')
 
-const supportPage = 'https://govuk-prototype-kit.herokuapp.com/docs/support'
+const supportPage = 'https://prototype-kit.service.gov.uk/docs/support'
 
 const {
   preflightChecks,

--- a/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/index.njk
+++ b/lib/nunjucks/govuk-prototype-kit/internal/views/manage-prototype/index.njk
@@ -19,7 +19,7 @@
           </p>
         {% endif %}
         <p>
-          <a href="https://govuk-prototype-kit.herokuapp.com/">Prototype Kit website</a>
+          <a href="https://prototype-kit.service.gov.uk/">Prototype Kit website</a>
           for guidance and tutorials
         </p>
       </div>

--- a/lib/usage-data-prompt.txt
+++ b/lib/usage-data-prompt.txt
@@ -4,6 +4,6 @@ Help us improve the GOV.UK Prototype Kit
 
 With your permission, the kit can send useful anonymous usage data
 for analysis to help the team improve the service. Read more here:
-https://govuk-prototype-kit.herokuapp.com/docs/usage-data
+https://prototype-kit.service.gov.uk/docs/usage-data
 
 Do you give permission for the kit to send anonymous usage data?

--- a/server.js
+++ b/server.js
@@ -160,7 +160,7 @@ app.post(/^\/([^.]+)$/, function (req, res) {
 
 // redirect old local docs to the docs site
 app.get('/docs/tutorials-and-examples', function (req, res) {
-  res.redirect('https://govuk-prototype-kit.herokuapp.com/docs')
+  res.redirect('https://prototype-kit.service.gov.uk/docs')
 })
 
 app.get('/', async (req, res) => {


### PR DESCRIPTION
update various references in code and documentation

leaves references in:

 - Changelog as it is a historical record and the redirects will catch it
 - migration scripts and tests where the reference needs to match old code