### PR TITLE
Fix heading sizes in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - [#1821: Always delete IE8 Sass files when migrating existing prototype](https://github.com/alphagov/govuk-prototype-kit/pull/1821)
+- [#1818: Fix heading sizes in templates](https://github.com/alphagov/govuk-prototype-kit/pull/1818)
 - [#1814: Stop express complaining if error occurs after res has been sent](https://github.com/alphagov/govuk-prototype-kit/pull/1814)
 - [#1804: Fix previewing templates with JavaScript in management pages](https://github.com/alphagov/govuk-prototype-kit/pull/1804)
 - [#1803: Stop installing dev dependencies when creating prototype](https://github.com/alphagov/govuk-prototype-kit/pull/1803)

--- a/lib/templates/content.html
+++ b/lib/templates/content.html
@@ -13,7 +13,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">
+      <h1 class="govuk-heading-l">
         Heading goes here
       </h1>
 

--- a/lib/templates/question.html
+++ b/lib/templates/question.html
@@ -13,7 +13,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">Heading or question goes here</h1>
+      <h1 class="govuk-heading-l">
+        Heading or question goes here
+      </h1>
 
       <form class="form" action="/url/of/next/page" method="post">
 


### PR DESCRIPTION
closes #1187 

Headings in services should generally be `govuk-heading-l`.

Changed:

 - question page
 - content page

The others seem ok at XL