### PR TITLE
Always delete IE8 Sass files when migrating existing prototype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- [#1821: Always delete IE8 Sass files when migrating existing prototype](https://github.com/alphagov/govuk-prototype-kit/pull/1821)
 - [#1814: Stop express complaining if error occurs after res has been sent](https://github.com/alphagov/govuk-prototype-kit/pull/1814)
 - [#1804: Fix previewing templates with JavaScript in management pages](https://github.com/alphagov/govuk-prototype-kit/pull/1804)
 - [#1803: Stop installing dev dependencies when creating prototype](https://github.com/alphagov/govuk-prototype-kit/pull/1803)

--- a/lib/migrator/index.js
+++ b/lib/migrator/index.js
@@ -40,7 +40,9 @@ const filesToDelete = [
   'start.js',
   'gulpfile.js',
   'VERSION.txt',
-  'Procfile'
+  'Procfile',
+  'app/assets/sass/application-ie8.scss',
+  'app/assets/sass/unbranded-ie8.scss'
 ]
 
 const directoriesToDelete = [
@@ -72,7 +74,6 @@ const filesToDeleteIfUnchanged = [
   'app/assets/images/unbranded.ico',
   'app/assets/javascripts/auto-store-data.js',
   'app/assets/javascripts/jquery-1.11.3.js',
-  'app/assets/sass/unbranded-ie8.scss',
   'app/assets/sass/unbranded.scss',
   'app/views/includes/breadcrumb_examples.html',
   'app/views/includes/cookie-banner.html',

--- a/lib/migrator/known-old-versions/app-assets-sass-application-ie8.scss/v7.0.0.scss
+++ b/lib/migrator/known-old-versions/app-assets-sass-application-ie8.scss/v7.0.0.scss
@@ -1,3 +1,0 @@
-$govuk-is-ie8: true;
-
-@import "application";

--- a/lib/migrator/known-old-versions/app-assets-sass-unbranded-ie8.scss/v9.5.0.scss
+++ b/lib/migrator/known-old-versions/app-assets-sass-unbranded-ie8.scss/v9.5.0.scss
@@ -1,3 +1,0 @@
-$govuk-is-ie8: true;
-
-@import "unbranded";


### PR DESCRIPTION
Version 13 does not support IE8, so there is never any value in keeping the IE8 Sass files. This PR changes the migration script so that those files are always deleted.