### PR TITLE
Fix upgrade bug on test plugins

### DIFF
--- a/lib/routes/prototype-admin-routes.js
+++ b/lib/routes/prototype-admin-routes.js
@@ -18,6 +18,8 @@ const appViews = extensions.getAppViews([
   path.join(projectDir, 'app/views/')
 ])
 
+const pkgPath = path.join(projectDir, 'package.json')
+
 const currentKitVersion = require(path.join(packageDir, 'package.json')).version
 const knownPlugins = require(path.join(packageDir, 'known-plugins.json'))
 
@@ -312,13 +314,19 @@ router.get('/templates/post-install', (req, res) => {
 const removeDuplicates = (val, index, arr) => !arr.includes(val, index + 1)
 
 async function getPluginDetails () {
+  const pkg = fse.readJsonSync(pkgPath)
   const installed = extensions.listInstalledExtensions()
   const all = await Promise.all(installed.concat(knownPlugins.plugins.available)
     .filter(removeDuplicates)
-    .map(async (packageName) => ({
-      packageName,
-      latestVersion: await lookupLatestPackageVersion(packageName)
-    }))
+    .map(async (packageName) => {
+      // Only those plugins not referenced locally can be looked up
+      const reference = pkg.dependencies[packageName] || ''
+      const canLookUp = !reference.startsWith('file:')
+      return {
+        packageName,
+        latestVersion: canLookUp && await lookupLatestPackageVersion(packageName)
+      }
+    })
     .map(async (packageDetails) => {
       const pack = await packageDetails
       Object.assign(pack, extensions.preparePackageNameForDisplay(pack.packageName), {

--- a/lib/routes/prototype-admin-routes.js
+++ b/lib/routes/prototype-admin-routes.js
@@ -334,7 +334,7 @@ async function getPluginDetails () {
         }
       } else {
       }
-      if (pack.installedVersion && pack.installedVersion !== pack.latestVersion) {
+      if (pack.latestVersion && pack.installedVersion && pack.installedVersion !== pack.latestVersion) {
         pack.upgradeLink = `${contextPath}/plugins/install?package=${encodeURIComponent(pack.packageName)}&mode=upgrade`
       }
       return pack


### PR DESCRIPTION
Any plugin with a dependency reference starting with 'file:' will have the upgrade option in the manage plugins page omitted.