### PR TITLE
Test password page

### DIFF
--- a/.github/workflows/test-acceptance.yaml
+++ b/.github/workflows/test-acceptance.yaml
@@ -61,6 +61,10 @@ jobs:
         CYPRESS_DEFAULT_COMMAND_TIMEOUT: 40000
         CYPRESS_PAGE_LOAD_TIMEOUT: 120000
         CYPRESS_RETRIES: 3
+        CYPRESS_PASSWORD: password
+        PASSWORD: password
+        USE_AUTH: true
+        NODE_ENV: production
 
     - if: ${{ failure() }}
       uses: actions/upload-artifact@v3

--- a/.github/workflows/test-acceptance.yaml
+++ b/.github/workflows/test-acceptance.yaml
@@ -61,7 +61,6 @@ jobs:
         CYPRESS_DEFAULT_COMMAND_TIMEOUT: 40000
         CYPRESS_PAGE_LOAD_TIMEOUT: 120000
         CYPRESS_RETRIES: 3
-        CYPRESS_PASSWORD: password
         PASSWORD: password
         USE_AUTH: true
         NODE_ENV: production

--- a/cypress/e2e/prod/1-home-page-tests/home-page-in-production.cypress.js
+++ b/cypress/e2e/prod/1-home-page-tests/home-page-in-production.cypress.js
@@ -1,12 +1,13 @@
-const { waitForApplication } = require('../../utils')
+const { authenticate } = require('../../utils')
 
 describe('home page in production', () => {
   before(() => {
-    waitForApplication()
+    cy.task('waitUntilAppRestarts')
   })
 
   it('should load as expected', () => {
     cy.visit('/')
+    authenticate()
     cy.get('h1').should('contains.text', 'Service name goes here')
   })
 })

--- a/cypress/e2e/prod/2-management-tests/management-not-available.cypress.js
+++ b/cypress/e2e/prod/2-management-tests/management-not-available.cypress.js
@@ -1,42 +1,49 @@
-const { waitForApplication } = require('../../utils')
+const { authenticate } = require('../../utils')
 
 describe('management not available', () => {
   before(() => {
-    waitForApplication()
+    cy.task('waitUntilAppRestarts')
   })
 
   it('when attempting to visit "/manage-prototype" page', () => {
     cy.visit('/manage-prototype')
+    authenticate()
     cy.get('h1').should('contain.text', 'How to manage your prototype')
   })
 
   it('when attempting to visit "/manage-prototype/templates" page', () => {
     cy.visit('/manage-prototype/templates')
+    authenticate()
     cy.get('h1').should('contain.text', 'How to manage your prototype')
   })
 
   it('when attempting to visit "/manage-prototype/plugins" page', () => {
     cy.visit('/manage-prototype/plugins')
+    authenticate()
     cy.get('h1').should('contain.text', 'How to manage your prototype')
   })
 
   it('when attempting to visit "/manage-prototype/foo" page', () => {
     cy.visit('/manage-prototype/foo')
+    authenticate()
     cy.get('h1').should('contain.text', 'How to manage your prototype')
   })
 
   it('manage prototype link should not exist on the home page', () => {
     cy.visit('/')
+    authenticate()
     cy.get('main a[href="/manage-prototype"]').should('not.exist')
   })
 
   it('manage prototype link should not exist in the footer', () => {
     cy.visit('/')
+    authenticate()
     cy.get('footer a[href="/manage-prototype"]').should('not.exist')
   })
 
   it('clear data link should exist in the footer and work correctly', () => {
     cy.visit('/')
+    authenticate()
     cy.get('footer a[href="/manage-prototype/clear-data"]').should('contain.text', 'Clear data').click()
     cy.get('h1').should('contain.text', 'Clear session data')
   })

--- a/cypress/e2e/prod/2-management-tests/password-page.cypress.js
+++ b/cypress/e2e/prod/2-management-tests/password-page.cypress.js
@@ -13,7 +13,7 @@ describe('password page', () => {
     cy.url().then(passwordUrl => {
       const urlObject = new URL(passwordUrl)
       expect(passwordUrl).equal(`${urlObject.origin + passwordPath}?${returnURLQuery}`)
-      cy.get('input#password').type(Cypress.env('PASSWORD'))
+      cy.get('input#password').type(Cypress.env('password'))
       cy.get('form').submit()
       cy.url().should('eq', urlObject.origin + homePath)
     })

--- a/cypress/e2e/prod/2-management-tests/password-page.cypress.js
+++ b/cypress/e2e/prod/2-management-tests/password-page.cypress.js
@@ -1,0 +1,34 @@
+const homePath = '/index'
+const passwordPath = '/manage-prototype/password'
+const errorQuery = 'error=wrong-password'
+const returnURLQuery = `returnURL=${encodeURIComponent(homePath)}`
+
+describe('password page', () => {
+  before(() => {
+    cy.task('waitUntilAppRestarts')
+  })
+
+  it('valid password', () => {
+    cy.visit(homePath)
+    cy.url().then(passwordUrl => {
+      const urlObject = new URL(passwordUrl)
+      expect(passwordUrl).equal(`${urlObject.origin + passwordPath}?${returnURLQuery}`)
+      cy.get('input#password').type(Cypress.env('PASSWORD'))
+      cy.get('form').submit()
+      cy.url().should('eq', urlObject.origin + homePath)
+    })
+  })
+
+  it('invalid password', () => {
+    cy.visit(homePath)
+    cy.url().then(passwordUrl => {
+      const urlObject = new URL(passwordUrl)
+      expect(passwordUrl).equal(`${urlObject.origin + passwordPath}?${returnURLQuery}`)
+      cy.get('input#password').type('invalid')
+      cy.get('form').submit()
+      cy.get('.govuk-error-summary__list').should('contains.text', 'The password is not correct')
+      cy.get('#password-error').should('contains.text', 'The password is not correct')
+      cy.url().should('eq', `${urlObject.origin + passwordPath}?${errorQuery}&${returnURLQuery}`)
+    })
+  })
+})

--- a/cypress/e2e/utils.js
+++ b/cypress/e2e/utils.js
@@ -1,6 +1,15 @@
 const { urlencode } = require('nunjucks/src/filters')
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
+const authenticate = () => {
+  const password = Cypress.env('PASSWORD')
+  if (password) {
+    cy.task('log', `Authenticating with ${password}`)
+    cy.get('input#password').type(password)
+    cy.get('form').submit()
+  }
+}
+
 const waitForApplication = async (path = '/index') => {
   cy.task('log', `Waiting for app to restart and load ${path} page`)
   cy.task('waitUntilAppRestarts')
@@ -46,6 +55,7 @@ function installPlugin (plugin, version = '') {
 }
 
 module.exports = {
+  authenticate,
   sleep,
   waitForApplication,
   getTemplateLink,

--- a/cypress/e2e/utils.js
+++ b/cypress/e2e/utils.js
@@ -2,7 +2,7 @@ const { urlencode } = require('nunjucks/src/filters')
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
 const authenticate = () => {
-  const password = Cypress.env('PASSWORD')
+  const password = Cypress.env('password')
   if (password) {
     cy.task('log', `Authenticating with ${password}`)
     cy.get('input#password').type(password)

--- a/cypress/events/index.js
+++ b/cypress/events/index.js
@@ -53,6 +53,7 @@ module.exports = function setupNodeEvents (on, config) {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
 
+  config.env.password = process.env.PASSWORD
   config.env.projectFolder = path.resolve(process.env.KIT_TEST_DIR || process.cwd())
   config.env.tempFolder = path.join(__dirname, '..', 'temp')
 


### PR DESCRIPTION
See: [Add tests for passwprd page](https://github.com/alphagov/govuk-prototype-kit/issues/1609)
- Update git workflow env variables for production tests to force authentication page
- Add cypress authenticate utility function to authenticate using the password page
- Update cypress prod tests to call cypress authenticate utility function
- Add a valid password test
- Add an invalid password test