### PR TITLE
Stop showing messages from session-file-store about deleting expired sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - [#1847: Stop user's home path from being printed in migration script log](https://github.com/alphagov/govuk-prototype-kit/pull/1847)
+- [#1846: Stop showing messages from session-file-store about deleting expired sessions](https://github.com/alphagov/govuk-prototype-kit/pull/1846)
 - [#1841: Fix crashes when path to prototype contains spaces](https://github.com/alphagov/govuk-prototype-kit/pull/1841)
 
 ## 13.0.1

--- a/lib/sessionUtils.js
+++ b/lib/sessionUtils.js
@@ -6,6 +6,7 @@ const { get: getKeypath } = require('lodash')
 
 const { getConfig } = require('./config')
 const { projectDir, tempDir } = require('./path-utils')
+const { sessionFileStoreQuietLogFn } = require('./utils')
 
 // Add Nunjucks function called 'checked' to populate radios and checkboxes
 const addCheckedFunction = function (env) {
@@ -132,6 +133,10 @@ const getSessionMiddleware = () => {
 
   const fileStoreOptions = {
     path: path.join(tempDir, 'sessions')
+  }
+
+  if (config.isDevelopment) {
+    fileStoreOptions.logFn = sessionFileStoreQuietLogFn
   }
 
   if (config.isProduction) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -213,3 +213,12 @@ exports.requestHttpsJson = (url) => new Promise((resolve, reject) => {
     reject(e)
   })
 })
+
+exports.sessionFileStoreQuietLogFn = (message) => {
+  if (message.endsWith('Deleting expired sessions')) {
+    // session-file-store logs every time it prunes files for expired sessions,
+    // but this isn't useful for our users, so let's just swallow those messages
+    return
+  }
+  console.log(message)
+}

--- a/lib/utils.test.js
+++ b/lib/utils.test.js
@@ -1,0 +1,29 @@
+/* eslint-env jest */
+
+afterEach(() => {
+  jest.useRealTimers()
+  jest.restoreAllMocks()
+})
+
+describe('sessionFileStoreQuietLogFn', () => {
+  it('hides messages about deleting expired sessions', () => {
+    jest.spyOn(global.console, 'log').mockImplementation()
+
+    const session = require('express-session')
+    const SessionFileStore = require('session-file-store')(session)
+    const { sessionFileStoreQuietLogFn } = require('./utils')
+
+    jest.useFakeTimers({ doNotFake: ['performance'] })
+
+    const testStore = new SessionFileStore({
+      logFn: sessionFileStoreQuietLogFn,
+      reapInterval: 0.01
+    })
+
+    jest.runOnlyPendingTimers()
+
+    clearTimeout(testStore.options.reapIntervalObject)
+
+    expect(console.log).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
session-file-store logs every time it prunes files for expired sessions, but this isn't useful for our users, so let's just swallow those messages.

Closes #1812.