### PR TITLE
Stop user's home path from being printed in migration script log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- [Stop user's home path from being printed in migration script log](https://github.com/alphagov/govuk-prototype-kit/pull/1847)
 - [Fix crashes when path to prototype contains spaces](https://github.com/alphagov/govuk-prototype-kit/pull/1841)
 
 ## 13.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Fixes
 
-- [Stop user's home path from being printed in migration script log](https://github.com/alphagov/govuk-prototype-kit/pull/1847)
-- [Fix crashes when path to prototype contains spaces](https://github.com/alphagov/govuk-prototype-kit/pull/1841)
+- [#1847: Stop user's home path from being printed in migration script log](https://github.com/alphagov/govuk-prototype-kit/pull/1847)
+- [#1841: Fix crashes when path to prototype contains spaces](https://github.com/alphagov/govuk-prototype-kit/pull/1841)
 
 ## 13.0.1
 

--- a/lib/migrator/fileHelpers.js
+++ b/lib/migrator/fileHelpers.js
@@ -1,8 +1,10 @@
 const path = require('path')
-const { packageDir, projectDir } = require('../path-utils')
 const fs = require('fs').promises
+
 const fse = require('fs-extra')
-const { log } = require('./logger')
+
+const { packageDir, projectDir } = require('../path-utils')
+const { log, sanitisePaths } = require('./logger')
 
 const verboseLog = async function () {
   await log(...arguments)
@@ -64,15 +66,16 @@ const replaceStartOfFile = async ({ filePath, lineToFind, replacement }) => {
 }
 
 const removeLineFromFile = async ({ filePath, lineToRemove }) => {
+  const prettyFilePath = path.relative(projectDir, filePath)
   const linesToRemove = Array.isArray(lineToRemove) ? lineToRemove : [lineToRemove]
   const fileLines = await getFileAsLines(filePath)
   await verboseLog(fileLines)
   const updatedFileLines = fileLines.filter(line => !linesToRemove.includes(line))
   if (updatedFileLines.length !== fileLines.length) {
-    await verboseLog(`Found [${lineToRemove}] in [${filePath}, removing`)
+    await verboseLog(`Found [${lineToRemove}] in [${prettyFilePath}], removing`)
     return writeFileLinesToFile(filePath, updatedFileLines)
   }
-  await verboseLog(`Could not found [${lineToRemove}] in [${filePath}, aborting`)
+  await verboseLog(`Could not found [${lineToRemove}] in [${prettyFilePath}], aborting`)
   return false
 }
 
@@ -102,7 +105,9 @@ const deleteDirectoryIfEmpty = async (partialPath) => {
 const copyFileFromStarter = async (starterPath, newPath) => {
   const src = path.join(packageDir, 'prototype-starter', starterPath)
   const dest = path.join(projectDir, newPath || starterPath)
-  await verboseLog(`Copying from [${path.relative(projectDir, src)}] to [${path.relative(projectDir, dest)}]`)
+  const prettySrc = src.startsWith(projectDir) ? path.relative(projectDir, src) : sanitisePaths(src)
+  const prettyDest = path.relative(projectDir, dest)
+  await verboseLog(`Copying from [${prettySrc}] to [${prettyDest}]`)
   return fse.copy(src, dest)
     .then(successOutput)
     .catch(async e => {

--- a/lib/migrator/fileHelpers.js
+++ b/lib/migrator/fileHelpers.js
@@ -49,16 +49,17 @@ const handleNotFound = resultIfFileNotFound => e => {
 }
 
 const replaceStartOfFile = async ({ filePath, lineToFind, replacement }) => {
+  const prettyFilePath = path.relative(projectDir, filePath)
   const fileLines = await getFileAsLines(filePath)
   const replacementLineNumber = fileLines.indexOf(lineToFind)
   if (replacementLineNumber > -1) {
-    await verboseLog(`Found [${lineToFind}] in [${filePath}, replacing`)
+    await verboseLog(`Found [${lineToFind}] in [${prettyFilePath}], replacing`)
     const linesFromOldFile = fileLines.splice(replacementLineNumber + 1)
     await verboseLog('Keeping these lines from old file', linesFromOldFile)
     const updatedFileLines = [replacement, ...linesFromOldFile]
     return writeFileLinesToFile(filePath, updatedFileLines)
   }
-  await verboseLog(`Could not found [${lineToFind}] in [${filePath}, aborting`)
+  await verboseLog(`Could not found [${lineToFind}] in [${prettyFilePath}], aborting`)
   return false
 }
 
@@ -101,7 +102,7 @@ const deleteDirectoryIfEmpty = async (partialPath) => {
 const copyFileFromStarter = async (starterPath, newPath) => {
   const src = path.join(packageDir, 'prototype-starter', starterPath)
   const dest = path.join(projectDir, newPath || starterPath)
-  await verboseLog(`copying from [${src}] to [${dest}]`)
+  await verboseLog(`Copying from [${path.relative(projectDir, src)}] to [${path.relative(projectDir, dest)}]`)
   return fse.copy(src, dest)
     .then(successOutput)
     .catch(async e => {

--- a/lib/migrator/index.js
+++ b/lib/migrator/index.js
@@ -58,9 +58,9 @@ const directoriesToDelete = [
 ]
 
 const directoriesToDeleteIfEmpty = [
-  '/app/assets/sass/patterns',
-  '/app/assets/images',
-  '/app/views/includes'
+  'app/assets/sass/patterns',
+  'app/assets/images',
+  'app/views/includes'
 ]
 
 const filesToUpdateIfUnchanged = [

--- a/lib/migrator/logger.js
+++ b/lib/migrator/logger.js
@@ -1,4 +1,6 @@
+const os = require('os')
 const path = require('path')
+
 const { projectDir } = require('../path-utils')
 const fs = require('fs').promises
 
@@ -7,15 +9,19 @@ const packageVersion = require('../../package.json').version
 const migrateLogFilePath = path.join(projectDir, 'migrate.log')
 let migrateLogFileHandle
 
+function sanitisePaths (str) {
+  return str.replaceAll(os.homedir(), '~')
+}
+
 async function setup () {
   if (!migrateLogFileHandle) {
     migrateLogFileHandle = await fs.open(migrateLogFilePath, 'a')
 
     // log some information useful for debugging
     await module.exports.log(new Date().toISOString())
-    await module.exports.log('cwd: ' + process.cwd())
+    await module.exports.log('cwd: ' + sanitisePaths(process.cwd()))
     await module.exports.log(`package: govuk-prototype-kit@${packageVersion}`)
-    await module.exports.log('argv: ' + process.argv.join(' '))
+    await module.exports.log('argv: ' + sanitisePaths(process.argv.join(' ')))
   }
 }
 
@@ -31,6 +37,7 @@ async function log (message) {
 
 module.exports = {
   log,
+  sanitisePaths,
   setup,
   teardown
 }

--- a/lib/migrator/logger.test.js
+++ b/lib/migrator/logger.test.js
@@ -1,0 +1,20 @@
+/* eslint-env jest */
+
+describe('sanitisePaths', () => {
+  const os = require('os')
+  const path = require('path')
+
+  const { sanitisePaths } = require('./logger')
+
+  it('replaces occurences of home directory with ~', () => {
+    expect(
+      sanitisePaths(path.join(os.homedir(), 'path', 'to', 'folder'))
+    ).toEqual(path.join('~', 'path', 'to', 'folder'))
+  })
+
+  it('replaces all occurences in a string', () => {
+    expect(
+      sanitisePaths(process.argv.join(' '))
+    ).not.toContain(os.homedir())
+  })
+})

--- a/lib/migrator/migrationSteps.js
+++ b/lib/migrator/migrationSteps.js
@@ -131,7 +131,7 @@ module.exports.deleteUnusedFiles = async (filesToDelete) => {
       // Do not report files that don't exist
       return true
     }
-    const reporter = await addReporter(`Delete ${filePath}`)
+    const reporter = await addReporter(`Delete ${file}`)
     const result = await deleteFile(path.join(projectDir, file))
     await reporter(result)
     return result


### PR DESCRIPTION
This PR makes the logging of paths by the migration script more consistent, closing #1816.

It also works to ensure that the user's home path won't end up in `migrate.log`, so their computer username is now less likely to leak.