### PR TITLE
Improve path validation of templated created pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#1847: Stop user's home path from being printed in migration script log](https://github.com/alphagov/govuk-prototype-kit/pull/1847)
 - [#1846: Stop showing messages from session-file-store about deleting expired sessions](https://github.com/alphagov/govuk-prototype-kit/pull/1846)
 - [#1841: Fix crashes when path to prototype contains spaces](https://github.com/alphagov/govuk-prototype-kit/pull/1841)
+- [#1848: Improve path validation of template created pages](https://github.com/alphagov/govuk-prototype-kit/pull/1848)
 
 ## 13.0.1
 

--- a/cypress/e2e/dev/6-management-tests/create-new-page-from-template.cypress.js
+++ b/cypress/e2e/dev/6-management-tests/create-new-page-from-template.cypress.js
@@ -73,6 +73,13 @@ describe('create new start page', () => {
   })
 
   describe('Invalid urls entered', () => {
+    const testError = (url, error) => () => {
+      url && cy.get('input').type(url)
+      cy.get('form').submit()
+      cy.get('.govuk-error-summary__list').should('contains.text', error)
+      cy.get('#chosen-url-error').should('contains.text', error)
+    }
+
     const errors = {
       exists: 'The chosen URL already exists',
       missing: 'The URL cannot be blank',
@@ -87,66 +94,22 @@ describe('create new start page', () => {
       cy.get(`a[href="${getTemplateLink('install', 'govuk-prototype-kit', '/lib/templates/start.html')}"]`).click()
     })
 
-    it('already exists', () => {
-      cy.get('input').type(startPagePath)
-      cy.get('form').submit()
-      cy.get('.govuk-error-summary__list').should('contains.text', errors.exists)
-      cy.get('#chosen-url-error').should('contains.text', errors.exists)
-    })
+    it('already exists', testError(startPagePath, errors.exists))
 
-    it('empty', () => {
-      cy.get('form').submit()
-      cy.get('.govuk-error-summary__list').should('contains.text', errors.missing)
-      cy.get('#chosen-url-error').should('contains.text', errors.missing)
-    })
+    it('empty', testError('', errors.missing))
 
-    it('empty (multiple spaces)', () => {
-      cy.get('input').type('         ')
-      cy.get('form').submit()
-      cy.get('.govuk-error-summary__list').should('contains.text', errors.missing)
-      cy.get('#chosen-url-error').should('contains.text', errors.missing)
-    })
+    it('empty (multiple spaces)', testError('         ', errors.missing))
 
-    it('single slash only', () => {
-      cy.get('input').type('/')
-      cy.get('form').submit()
-      cy.get('.govuk-error-summary__list').should('contains.text', errors.singleSlash)
-      cy.get('#chosen-url-error').should('contains.text', errors.singleSlash)
-    })
+    it('single slash only', testError('/', errors.singleSlash))
 
-    it('missing starting slash', () => {
-      cy.get('input').type('foo/bar')
-      cy.get('form').submit()
-      cy.get('.govuk-error-summary__list').should('contains.text', errors.slash)
-      cy.get('#chosen-url-error').should('contains.text', errors.slash)
-    })
+    it('missing starting slash', testError('foo/bar', errors.slash))
 
-    it('ends with a slash', () => {
-      cy.get('input').type('/foo/bar/')
-      cy.get('form').submit()
-      cy.get('.govuk-error-summary__list').should('contains.text', errors.endsWithSlash)
-      cy.get('#chosen-url-error').should('contains.text', errors.endsWithSlash)
-    })
+    it('ends with a slash', testError('/foo/bar/', errors.endsWithSlash))
 
-    it('invalid (contains a search parameter)', () => {
-      cy.get('input').type('/?param=true')
-      cy.get('form').submit()
-      cy.get('.govuk-error-summary__list').should('contains.text', errors.invalid)
-      cy.get('#chosen-url-error').should('contains.text', errors.invalid)
-    })
+    it('invalid (contains a search parameter)', testError('/?param=true', errors.invalid))
 
-    it('invalid (contains spaces in the url)', () => {
-      cy.get('input').type('/foo bar/baz bar')
-      cy.get('form').submit()
-      cy.get('.govuk-error-summary__list').should('contains.text', errors.invalid)
-      cy.get('#chosen-url-error').should('contains.text', errors.invalid)
-    })
+    it('invalid (contains spaces in the url)', testError('/foo bar/baz bar', errors.invalid))
 
-    it('invalid (random)', () => {
-      cy.get('input').type('/$$fr%%"pp')
-      cy.get('form').submit()
-      cy.get('.govuk-error-summary__list').should('contains.text', errors.invalid)
-      cy.get('#chosen-url-error').should('contains.text', errors.invalid)
-    })
+    it('invalid (random)', testError('/$$fr%%"pp', errors.invalid))
   })
 })

--- a/cypress/e2e/dev/6-management-tests/create-new-page-from-template.cypress.js
+++ b/cypress/e2e/dev/6-management-tests/create-new-page-from-template.cypress.js
@@ -97,6 +97,7 @@ describe('create new page', () => {
       missing: 'Enter a path',
       singleSlash: 'Path must not be a single forward slash (/)',
       endsWithSlash: 'Path must not end in a forward slash (/)',
+      multipleSlashes: 'must not include a slash followed by another slash (//)',
       slash: 'Path must begin with a forward slash (/)',
       invalid: 'Path must not include !$&\'()*+,;=:?#[]@.% or space'
     }
@@ -117,6 +118,8 @@ describe('create new page', () => {
     it('missing starting slash', testError('foo/bar', errors.slash))
 
     it('ends with a slash', testError('/foo/bar/', errors.endsWithSlash))
+
+    it('contains consecutive slashes', testError('//bar/foo', errors.multipleSlashes))
 
     it('invalid (contains a search parameter)', testError('/?param=true', errors.invalid))
 

--- a/cypress/e2e/dev/6-management-tests/create-new-page-from-template.cypress.js
+++ b/cypress/e2e/dev/6-management-tests/create-new-page-from-template.cypress.js
@@ -71,4 +71,82 @@ describe('create new start page', () => {
     cy.task('log', 'Confirm the view of the page exists where expected')
     cy.task('existsFile', { filename: startPageView })
   })
+
+  describe('Invalid urls entered', () => {
+    const errors = {
+      exists: 'The chosen URL already exists',
+      missing: 'The URL cannot be blank',
+      singleSlash: 'The URL cannot be a single forward slash (/)',
+      endsWithSlash: 'The URL cannot end in a forward slash (/)',
+      slash: 'The URL must begin with a forward slash (/)',
+      invalid: 'The URL entered is not a valid prototype url'
+    }
+
+    beforeEach(() => {
+      cy.visit(manageTemplatesPagePath)
+      cy.get(`a[href="${getTemplateLink('install', 'govuk-prototype-kit', '/lib/templates/start.html')}"]`).click()
+    })
+
+    it('already exists', () => {
+      cy.get('input').type(startPagePath)
+      cy.get('form').submit()
+      cy.get('.govuk-error-summary__list').should('contains.text', errors.exists)
+      cy.get('#chosen-url-error').should('contains.text', errors.exists)
+    })
+
+    it('empty', () => {
+      cy.get('form').submit()
+      cy.get('.govuk-error-summary__list').should('contains.text', errors.missing)
+      cy.get('#chosen-url-error').should('contains.text', errors.missing)
+    })
+
+    it('empty (multiple spaces)', () => {
+      cy.get('input').type('         ')
+      cy.get('form').submit()
+      cy.get('.govuk-error-summary__list').should('contains.text', errors.missing)
+      cy.get('#chosen-url-error').should('contains.text', errors.missing)
+    })
+
+    it('single slash only', () => {
+      cy.get('input').type('/')
+      cy.get('form').submit()
+      cy.get('.govuk-error-summary__list').should('contains.text', errors.singleSlash)
+      cy.get('#chosen-url-error').should('contains.text', errors.singleSlash)
+    })
+
+    it('missing starting slash', () => {
+      cy.get('input').type('foo/bar')
+      cy.get('form').submit()
+      cy.get('.govuk-error-summary__list').should('contains.text', errors.slash)
+      cy.get('#chosen-url-error').should('contains.text', errors.slash)
+    })
+
+    it('ends with a slash', () => {
+      cy.get('input').type('/foo/bar/')
+      cy.get('form').submit()
+      cy.get('.govuk-error-summary__list').should('contains.text', errors.endsWithSlash)
+      cy.get('#chosen-url-error').should('contains.text', errors.endsWithSlash)
+    })
+
+    it('invalid (contains a search parameter)', () => {
+      cy.get('input').type('/?param=true')
+      cy.get('form').submit()
+      cy.get('.govuk-error-summary__list').should('contains.text', errors.invalid)
+      cy.get('#chosen-url-error').should('contains.text', errors.invalid)
+    })
+
+    it('invalid (contains spaces in the url)', () => {
+      cy.get('input').type('/foo bar/baz bar')
+      cy.get('form').submit()
+      cy.get('.govuk-error-summary__list').should('contains.text', errors.invalid)
+      cy.get('#chosen-url-error').should('contains.text', errors.invalid)
+    })
+
+    it('invalid (random)', () => {
+      cy.get('input').type('/$$fr%%"pp')
+      cy.get('form').submit()
+      cy.get('.govuk-error-summary__list').should('contains.text', errors.invalid)
+      cy.get('#chosen-url-error').should('contains.text', errors.invalid)
+    })
+  })
 })

--- a/cypress/e2e/dev/6-management-tests/create-new-page-from-template.cypress.js
+++ b/cypress/e2e/dev/6-management-tests/create-new-page-from-template.cypress.js
@@ -7,10 +7,8 @@ const viewFolder = path.join(Cypress.env('projectFolder'), 'app', 'views')
 const startPageView = path.join(viewFolder, 'start.html')
 const startPagePath = '/start'
 
-const validUnicodePageView = path.join(viewFolder, '/^-café/£10©.html')
-const validUnicodePagePath = '/^-café/£10©'
-const validUnicodePageView = path.join(viewFolder, 'café.html')
-const validUnicodePagePath = '/café'
+const validUnicodePageView = path.join(viewFolder, 'brontë.html')
+const validUnicodePagePath = '/brontë'
 
 const manageTemplatesPagePath = '/manage-prototype/templates'
 

--- a/cypress/e2e/dev/6-management-tests/create-new-page-from-template.cypress.js
+++ b/cypress/e2e/dev/6-management-tests/create-new-page-from-template.cypress.js
@@ -93,12 +93,12 @@ describe('create new page', () => {
     }
 
     const errors = {
-      exists: 'The chosen URL already exists',
-      missing: 'The URL cannot be blank',
-      singleSlash: 'The URL cannot be a single forward slash (/)',
-      endsWithSlash: 'The URL cannot end in a forward slash (/)',
-      slash: 'The URL must begin with a forward slash (/)',
-      invalid: 'The URL entered is not a valid prototype url'
+      exists: 'Path already exists',
+      missing: 'Enter a path',
+      singleSlash: 'Path must not be a single forward slash (/)',
+      endsWithSlash: 'Path must not end in a forward slash (/)',
+      slash: 'Path must begin with a forward slash (/)',
+      invalid: 'Path must not include !$&\'()*+,;=:?#[]@.% or space'
     }
 
     beforeEach(() => {

--- a/lib/routes/prototype-admin-routes.js
+++ b/lib/routes/prototype-admin-routes.js
@@ -256,7 +256,11 @@ router.get('/templates/install', (req, res) => {
       templateName: templateConfig.name,
       error: ({
         exists: 'The chosen URL already exists',
-        slash: 'The URL must begin with a forward slash (/)'
+        missing: 'The URL cannot be blank',
+        singleSlash: 'The URL cannot be a single forward slash (/)',
+        endsWithSlash: 'The URL cannot end in a forward slash (/)',
+        slash: 'The URL must begin with a forward slash (/)',
+        invalid: 'The URL entered is not a valid prototype url'
       })[req.query.errorType],
       chosenUrl: req.query['chosen-url']
     })
@@ -269,7 +273,7 @@ router.post('/templates/install', async (req, res) => {
   const templateConfig = locateTemplateConfig(req)
   const templatePath = path.join(projectDir, 'node_modules', templateConfig.path)
 
-  const chosenUrl = req.body['chosen-url']
+  const chosenUrl = req.body['chosen-url'].trim()
 
   const installLocation = path.join(projectDir, 'app', 'views', `${chosenUrl}.html`)
 
@@ -283,13 +287,33 @@ router.post('/templates/install', async (req, res) => {
     res.redirect(url)
   }
 
+  if (!chosenUrl.length) {
+    renderError('missing')
+    return
+  }
+
+  if (chosenUrl === '/') {
+    renderError('singleSlash')
+    return
+  }
+
   if (chosenUrl[0] !== '/') {
     renderError('slash')
     return
   }
 
+  if (chosenUrl[chosenUrl.length - 1] === '/') {
+    renderError('endsWithSlash')
+    return
+  }
+
   if (await fse.exists(installLocation)) {
     renderError('exists')
+    return
+  }
+
+  if (!chosenUrl.match(/^(\/[a-zA-Z0-9-_]+)+(\.)?$/)) {
+    renderError('invalid')
     return
   }
 

--- a/lib/routes/prototype-admin-routes.js
+++ b/lib/routes/prototype-admin-routes.js
@@ -311,8 +311,7 @@ router.post('/templates/install', async (req, res) => {
     renderError('exists')
     return
   }
-
-  if (!chosenUrl.match(/^(\/[a-zA-Z0-9-_]+)?$/)) {
+  if (`!#$&'()*+,:;=?@[].% `.split('').some((char) => chosenUrl.includes(char))) {
     renderError('invalid')
     return
   }

--- a/lib/routes/prototype-admin-routes.js
+++ b/lib/routes/prototype-admin-routes.js
@@ -311,7 +311,9 @@ router.post('/templates/install', async (req, res) => {
     renderError('exists')
     return
   }
-  if (`!#$&'()*+,:;=?@[].% `.split('').some((char) => chosenUrl.includes(char))) {
+
+  // Don't allow URI reserved characters (per RFC 3986) in paths
+  if ("!$&'()*+,;=:?#[]@.% ".split('').some((char) => chosenUrl.includes(char))) {
     renderError('invalid')
     return
   }

--- a/lib/routes/prototype-admin-routes.js
+++ b/lib/routes/prototype-admin-routes.js
@@ -255,12 +255,12 @@ router.get('/templates/install', (req, res) => {
       links: managementLinks,
       templateName: templateConfig.name,
       error: ({
-        exists: 'The chosen URL already exists',
-        missing: 'The URL cannot be blank',
-        singleSlash: 'The URL cannot be a single forward slash (/)',
-        endsWithSlash: 'The URL cannot end in a forward slash (/)',
-        slash: 'The URL must begin with a forward slash (/)',
-        invalid: 'The URL entered is not a valid prototype url'
+        exists: 'Path already exists',
+        missing: 'Enter a path',
+        singleSlash: 'Path must not be a single forward slash (/)',
+        endsWithSlash: 'Path must not end in a forward slash (/)',
+        slash: 'Path must begin with a forward slash (/)',
+        invalid: 'Path must not include !$&\'()*+,;=:?#[]@.% or space'
       })[req.query.errorType],
       chosenUrl: req.query['chosen-url']
     })

--- a/lib/routes/prototype-admin-routes.js
+++ b/lib/routes/prototype-admin-routes.js
@@ -259,6 +259,7 @@ router.get('/templates/install', (req, res) => {
         missing: 'Enter a path',
         singleSlash: 'Path must not be a single forward slash (/)',
         endsWithSlash: 'Path must not end in a forward slash (/)',
+        multipleSlashes: 'must not include a slash followed by another slash (//)',
         slash: 'Path must begin with a forward slash (/)',
         invalid: 'Path must not include !$&\'()*+,;=:?#[]@.% or space'
       })[req.query.errorType],
@@ -304,6 +305,11 @@ router.post('/templates/install', async (req, res) => {
 
   if (chosenUrl[chosenUrl.length - 1] === '/') {
     renderError('endsWithSlash')
+    return
+  }
+
+  if (chosenUrl.indexOf('//') !== -1) {
+    renderError('multipleSlashes')
     return
   }
 

--- a/lib/routes/prototype-admin-routes.js
+++ b/lib/routes/prototype-admin-routes.js
@@ -273,7 +273,7 @@ router.post('/templates/install', async (req, res) => {
   const templateConfig = locateTemplateConfig(req)
   const templatePath = path.join(projectDir, 'node_modules', templateConfig.path)
 
-  const chosenUrl = req.body['chosen-url'].trim()
+  const chosenUrl = req.body['chosen-url'].trim().normalize()
 
   const installLocation = path.join(projectDir, 'app', 'views', `${chosenUrl}.html`)
 

--- a/lib/routes/prototype-admin-routes.js
+++ b/lib/routes/prototype-admin-routes.js
@@ -312,7 +312,7 @@ router.post('/templates/install', async (req, res) => {
     return
   }
 
-  if (!chosenUrl.match(/^(\/[a-zA-Z0-9-_]+)+(\.)?$/)) {
+  if (!chosenUrl.match(/^(\/[a-zA-Z0-9-_]+)?$/)) {
     renderError('invalid')
     return
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -156,7 +156,7 @@ function renderPath (path, res, next) {
 }
 
 exports.matchRoutes = function (req, res, next) {
-  var path = req.path
+  let path = decodeURI(req.path).normalize()
 
   // Remove the first slash, render won't work with it
   path = path.substr(1)

--- a/server.js
+++ b/server.js
@@ -164,7 +164,7 @@ app.get('/', async (req, res) => {
 
 // Catch 404 and forward to error handler
 app.use(function (req, res, next) {
-  var err = new Error(`Page not found: ${req.path}`)
+  const err = new Error(`Page not found: ${decodeURI(req.path)}`)
   err.status = 404
   next(err)
 })


### PR DESCRIPTION
See: [You can create a page from a template with no name](https://github.com/alphagov/govuk-prototype-kit/issues/1810)

Added validation and acceptance tests for:
- Path already exists
- Path not entered
- Path only containing spaces
- Path with only a single slash
- Path missing a starting slash
- Path ending in a slash
- Path containing consecutive slashes
- Path containing a search parameter
- Path containing spaces
- Path including invalid characters