### PR TITLE
Migration will now report head and script failures

### DIFF
--- a/lib/migrator/migrationSteps.js
+++ b/lib/migrator/migrationSteps.js
@@ -199,18 +199,17 @@ module.exports.upgradeIfUnchanged = (filePaths, starterFilePath, additionalStep)
 
   const reporter = await addReporter(`Overwrite ${filePath}`)
 
-  if (!matchFound) {
-    await reporter(false)
-    return false
-  }
-
   let result = false
   try {
-    await copyFileFromStarter(starterFilePath || filePath, filePath)
+    if (matchFound) {
+      await copyFileFromStarter(starterFilePath || filePath, filePath)
+    } else {
+      await reporter(false)
+    }
     if (additionalStep) {
       result = await additionalStep()
     } else {
-      result = true
+      result = matchFound
     }
   } catch (e) {
     await verboseLog(e.message)

--- a/lib/migrator/migrationSteps.spec.js
+++ b/lib/migrator/migrationSteps.spec.js
@@ -51,6 +51,7 @@ describe('migration steps', () => {
   beforeEach(() => {
     fileHelpers.replaceStartOfFile.mockResolvedValue(true)
     fileHelpers.getFileAsLines.mockResolvedValue(true)
+    fileHelpers.matchAgainstOldVersions.mockResolvedValue(true)
   })
 
   afterEach(() => {
@@ -280,6 +281,29 @@ describe('migration steps', () => {
     expect(reporter.addReporter).toHaveBeenCalledWith(`Overwrite ${layout}`)
 
     expect(mockReporter).toHaveBeenCalledTimes(1)
+    expect(mockReporter).toHaveBeenCalledWith(true)
+  })
+
+  it('report if changed layout', async () => {
+    const layout = 'app/views/layout.html'
+    const additionalStep = jest.fn().mockResolvedValue(true)
+
+    fileHelpers.matchAgainstOldVersions.mockReturnValue(false)
+
+    const result = await upgradeIfUnchanged([layout], layout, additionalStep)
+
+    expect(result).toBeTruthy()
+
+    expect(fileHelpers.matchAgainstOldVersions).toHaveBeenCalledTimes(1)
+    expect(fileHelpers.matchAgainstOldVersions).toHaveBeenCalledWith(layout)
+
+    expect(additionalStep).toHaveBeenCalledTimes(1)
+    expect(additionalStep).toHaveBeenCalled()
+
+    expect(reporter.addReporter).toHaveBeenCalledTimes(1)
+    expect(reporter.addReporter).toHaveBeenCalledWith(`Overwrite ${layout}`)
+
+    expect(mockReporter).toHaveBeenCalledTimes(2)
     expect(mockReporter).toHaveBeenCalledWith(true)
   })
 


### PR DESCRIPTION
See: [Migration script does not always migrate app/views/includes/{head, scripts}.html](https://github.com/alphagov/govuk-prototype-kit/issues/1817)