### PR TITLE
Create a git repository for new prototypes (when git is present)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#1860: Create a git repository for new prototypes (when git is present)](https://github.com/alphagov/govuk-prototype-kit/pull/1860)
 - [#1824: Add feature to manage plugins without using the command line](https://github.com/alphagov/govuk-prototype-kit/pull/1824)
 
 ### Fixes

--- a/__tests__/spec/sanity-checks.js
+++ b/__tests__/spec/sanity-checks.js
@@ -14,7 +14,7 @@ let app
 process.env.KIT_PROJECT_DIR = tmpDir
 
 const { packageDir, projectDir } = require('../../lib/path-utils')
-
+const { exec } = require('../../lib/exec')
 const createKitTimeout = parseInt(process.env.CREATE_KIT_TIMEOUT || '90000', 10)
 
 /**
@@ -36,6 +36,18 @@ describe('The Prototype Kit', () => {
       path.join(projectDir, '.tmp', 'public', 'stylesheets', 'application.css'),
       path.join(packageDir, 'lib', 'assets', 'sass', 'prototype.scss')
     )
+  })
+
+  it('should initialise git out of the box', async () => {
+    const outputLines = []
+    await exec('git log', { cwd: tmpDir }, (data) => outputLines.push(data.toString()))
+
+    function getLastMeaningfulLineTrimmed (outputLines) {
+      const meaningulLines = outputLines.join('').split('\n').filter(line => line !== '')
+      return meaningulLines.pop().trim()
+    }
+
+    expect(getLastMeaningfulLineTrimmed(outputLines)).toBe('Created prototype kit')
   })
 
   describe('index page', () => {

--- a/bin/cli
+++ b/bin/cli
@@ -3,7 +3,7 @@
 const fs = require('fs-extra')
 const path = require('path')
 
-const { spawn } = require('../lib/exec')
+const { spawn, exec } = require('../lib/exec')
 const { parse } = require('./utils/argvParser')
 const { prepareMigration, preflightChecks } = require('../lib/migrator')
 const { npmInstall, packageJsonFormat } = require('./utils')
@@ -47,6 +47,21 @@ async function updatePackageJson (packageJsonPath) {
   let newPackageJson = Object.assign({}, packageJson)
   newPackageJson = Object.assign(newPackageJson, await fs.readJson(packageJsonPath))
   await fs.writeJson(packageJsonPath, newPackageJson, packageJsonFormat)
+}
+
+async function initialiseGitRepo () {
+  const presenceCheckOutput = []
+  const notPresentText = 'not present'
+  await exec(`which git || echo "${notPresentText}"`, {}, data => presenceCheckOutput.push(data))
+  if (presenceCheckOutput.join('').trim() === notPresentText) {
+    return
+  }
+
+  await exec('git init && git add -A .')
+
+  const overrideParams = '-c "user.email=gov.uk-prototype@digital.cabinet-office.gov.uk" -c "user.name=GOV.UK Prototype Kit"'
+  const commitMessage = 'Created prototype kit'
+  await exec(`git commit -am "${commitMessage}" || git ${overrideParams} commit -am "${commitMessage}"`)
 }
 
 function usage () {
@@ -175,7 +190,7 @@ function warnIfNpmStart (argv, env) {
       fs.writeFile(path.join(installDirectory, '.npmrc'), npmrc, 'utf8'),
       copyFile('LICENCE.txt'),
       updatePackageJson(path.join(installDirectory, 'package.json'))
-    ])
+    ]).then(initialiseGitRepo)
   } else if (argv.command === 'dev') {
     require('../start')
   } else if (argv.command === 'start' || argv.command === 'serve') {


### PR DESCRIPTION
Ticket: https://github.com/alphagov/govuk-prototype-kit/issues/1670

This will make the initial commit as the current user if they have set up a email address etc. in git, if they haven't set that up it will be committed as the Prototype Kit with the team email address - this is mostly for CI but it would also be useful for a user who has just set up a new computer and hasn't set up git properly yet.

As each of the test clients have git installed I have manually tested on an Ubuntu VM without git.  It works.