### PR TITLE
Bump govuk-frontend from 4.4.0 to 4.4.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5719,9 +5719,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.0.tgz",
-      "integrity": "sha512-3Hg4GePCdlynd7F6a3YPOEJx0lDPPP6iBv1S893tv3+efYGWLGvsSFdCG0uob8Xc1O7ckL19dSsFpFhBWUkTNA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.1.tgz",
+      "integrity": "sha512-Jm1LUWiH9vy47b6HSH/ksSb4ueBrtTTgyLBk+3X2qqAmmFUc1AXWLSYHid07YYu1tvn9RnodWk5Bac5Ywqk6tA==",
       "peer": true,
       "engines": {
         "node": ">= 4.2.0"
@@ -15959,9 +15959,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.0.tgz",
-      "integrity": "sha512-3Hg4GePCdlynd7F6a3YPOEJx0lDPPP6iBv1S893tv3+efYGWLGvsSFdCG0uob8Xc1O7ckL19dSsFpFhBWUkTNA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.1.tgz",
+      "integrity": "sha512-Jm1LUWiH9vy47b6HSH/ksSb4ueBrtTTgyLBk+3X2qqAmmFUc1AXWLSYHid07YYu1tvn9RnodWk5Bac5Ywqk6tA==",
       "peer": true
     },
     "graceful-fs": {


### PR DESCRIPTION
This PR bumps the version of GOV.UK Frontend used in local development.

Note that this release includes an important accessibility fix.

- [Release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v4.4.1)
- [Changelog](https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md)
- [Commits](alphagov/govuk-frontend@v4.4.0...v4.4.1)