### PR TITLE
Increase manage prototype unit tests

### DIFF
--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -1,0 +1,574 @@
+
+// core dependencies
+const path = require('path')
+
+// npm dependencies
+const fse = require('fs-extra')
+const querystring = require('querystring')
+const templateRenderNunjucks = require('nunjucks')
+
+// local dependencies
+const config = require('./config').getConfig()
+const plugins = require('./plugins/plugins')
+const { exec } = require('./exec')
+const { requestHttpsJson, prototypeAppScripts } = require('./utils')
+const { projectDir, packageDir } = require('./utils/paths')
+
+const contextPath = '/manage-prototype'
+
+const appViews = plugins.getAppViews([
+  path.join(projectDir, 'node_modules'),
+  path.join(projectDir, 'app/views/')
+])
+
+const pkgPath = path.join(projectDir, 'package.json')
+
+const currentKitVersion = require(path.join(packageDir, 'package.json')).version
+const knownPlugins = require(path.join(packageDir, 'known-plugins.json'))
+const { preparePackageNameForDisplay } = require('./plugins/plugins')
+
+const latestReleaseVersions = knownPlugins.plugins.available
+  .reduce((releaseVersions, nextPlugin) => {
+    return { ...releaseVersions, [nextPlugin]: 0 }
+  }, { 'govuk-prototype-kit': currentKitVersion })
+
+async function lookupLatestPackageVersion (packageName) {
+  try {
+    const packageInfo = await requestHttpsJson(`https://registry.npmjs.org/${encodeURIComponent(packageName)}`)
+    latestReleaseVersions[packageName] = packageInfo['dist-tags'].latest
+  } catch (e) {
+    console.log('ignoring error', e.message)
+  }
+  return latestReleaseVersions[packageName]
+}
+
+async function updateLatestReleaseVersions () {
+  await Promise.all(Object.keys(latestReleaseVersions).map(lookupLatestPackageVersion))
+  return latestReleaseVersions
+}
+
+if (!config.isTest) {
+  updateLatestReleaseVersions()
+  setInterval(lookupLatestPackageVersion, 1000 * 60 * 20)
+}
+
+templateRenderNunjucks.configure(appViews, {
+  autoescape: true,
+  noCache: true,
+  watch: false // We are now setting this to `false` (it's by default false anyway) as having it set to `true` for production was making the tests hang
+})
+
+function getManagementView (filename) {
+  return ['views', 'manage-prototype', filename].join('/')
+}
+
+// Local dependencies
+const encryptPassword = require('./utils').encryptPassword
+
+const password = process.env.PASSWORD
+
+// Clear all data in session
+function getClearDataHandler (req, res) {
+  res.render(getManagementView('clear-data.njk'))
+}
+
+function postClearDataHandler (req, res) {
+  req.session.data = {}
+  res.render(getManagementView('clear-data-success.njk'))
+}
+
+// Render password page with a returnURL to redirect people to where they came from
+function getPasswordHandler (req, res) {
+  const returnURL = req.query.returnURL || '/'
+  const error = req.query.error
+  res.render(getManagementView('password.njk'), { returnURL, error })
+}
+
+// Check authentication password
+function postPasswordHandler (req, res) {
+  const submittedPassword = req.body.password
+  const providedUrl = req.body.returnURL
+  const processedRedirectUrl = (!providedUrl || providedUrl.startsWith('/manage-prototype/password')) ? '/' : providedUrl
+
+  if (submittedPassword === password) {
+    // see lib/middleware/authentication.js for explanation
+    res.cookie('authentication', encryptPassword(password), {
+      maxAge: 1000 * 60 * 60 * 24 * 30, // 30 days
+      sameSite: 'None', // Allows GET and POST requests from other domains
+      httpOnly: true,
+      secure: true
+    })
+    res.redirect(processedRedirectUrl)
+  } else {
+    res.redirect('/manage-prototype/password?error=wrong-password&returnURL=' + encodeURIComponent(processedRedirectUrl))
+  }
+}
+
+// Middleware to ensure the routes specified below will render the manage-prototype-not-available
+// view when the prototype is not running in development
+function developmentOnlyMiddleware (req, res, next) {
+  if (config.isDevelopment) {
+    next()
+  } else {
+    res.render(getManagementView('manage-prototype-not-available.njk'))
+  }
+}
+
+const managementLinks = [
+  {
+    text: 'Home',
+    url: contextPath
+  },
+  {
+    text: 'Templates',
+    url: '/manage-prototype/templates'
+  },
+  {
+    text: 'Plugins',
+    url: '/manage-prototype/plugins'
+  },
+  {
+    text: 'Go to prototype',
+    url: '/'
+  }
+]
+
+async function readFileIfExists (path) {
+  if (await fse.exists(path)) {
+    return await fse.readFile(path, 'utf8')
+  }
+}
+
+async function getHomeHandler (req, res) {
+  const pageName = 'Home'
+
+  const originalHomepage = await fse.readFile(path.join(packageDir, 'prototype-starter', 'app', 'views', 'index.html'), 'utf8')
+  const currentHomepage = await readFileIfExists(path.join(projectDir, 'app', 'views', 'index.html'))
+
+  res.render(getManagementView('index.njk'), {
+    currentUrl: req.originalUrl,
+    currentPage: pageName,
+    links: managementLinks,
+    kitUpgradeAvailable: latestReleaseVersions['govuk-prototype-kit'] !== currentKitVersion,
+    latestAvailableKit: latestReleaseVersions['govuk-prototype-kit'],
+    tasks: [
+      {
+        done: config.serviceName !== 'Service name goes here' && config.serviceName !== 'GOV.UK Prototype Kit',
+        html: 'Change the service name in the file <strong>app/config.json</strong>'
+      }, {
+        done: currentHomepage !== undefined && originalHomepage !== currentHomepage,
+        html: 'Edit the homepage in the file <strong>app/views/index.html</strong>'
+      }
+    ]
+
+  })
+}
+
+function exampleTemplateConfig (packageName, { name, path }) {
+  const queryString = `?package=${encodeURIComponent(packageName)}&template=${encodeURIComponent(path)}`
+  return {
+    name,
+    path: require('path').join(packageName, path),
+    installLink: `/manage-prototype/templates/install${queryString}`,
+    viewLink: `/manage-prototype/templates/view${queryString}`
+  }
+}
+
+function getPluginTemplates () {
+  const templates = plugins.getByType('templates')
+  const output = []
+  templates.forEach(({ packageName, item }) => {
+    const matchingPackages = output.filter(x => x.packageName === packageName)
+    if (item.type !== 'nunjucks') {
+      console.warn(`Omitting ${item.name} from ${packageName} because the type ${JSON.stringify(item.type)} isn't supported.  The only currently supported type is "nunjucks".`)
+      return
+    }
+    let packageDescription
+    if (matchingPackages.length > 0) {
+      packageDescription = matchingPackages[0]
+    } else {
+      packageDescription = {
+        packageName,
+        pluginDisplayName: plugins.preparePackageNameForDisplay(packageName),
+        templates: []
+      }
+      output.push(packageDescription)
+    }
+    packageDescription.templates.push(exampleTemplateConfig(packageName, item))
+  })
+  return output
+}
+
+function getTemplatesHandler (req, res) {
+  const pageName = 'Templates'
+  res.render(getManagementView('templates.njk'), {
+    currentPage: pageName,
+    links: managementLinks,
+    availableTemplates: getPluginTemplates()
+  })
+}
+
+function locateTemplateConfig (req) {
+  const debugOutput = []
+  const packageTemplates = getPluginTemplates().filter(({ packageName }) => packageName === req.query.package)
+  debugOutput.push(`packages ${JSON.stringify(packageTemplates.map(({ packageName }) => packageName), null, 2)}`)
+  if (packageTemplates.length > 0) {
+    const pathToMatch = [packageTemplates[0].packageName, req.query.template].join('')
+    debugOutput.push(`path to match ${pathToMatch}`)
+    const templates = packageTemplates[0].templates.filter(({ path }) => {
+      // switch backslashes for forward slashes in case of windows
+      path = path.split('\\').join('/')
+      debugOutput.push(`path ${path}`)
+      return path === pathToMatch
+    })
+    if (templates.length > 0) {
+      debugOutput.push('found')
+      return templates[0]
+    } else {
+      debugOutput.push('not found')
+    }
+  }
+}
+
+function getTemplatesViewHandler (req, res) {
+  const model = {
+    pluginConfig: plugins.getAppConfig({ scripts: prototypeAppScripts }),
+    serviceName: 'Service name goes here'
+  }
+  const templateConfig = locateTemplateConfig(req)
+
+  if (templateConfig) {
+    const renderPath = templateConfig.path
+    res.send(templateRenderNunjucks.render(renderPath, model))
+  } else {
+    res.status(404).send('Template not found.')
+  }
+}
+
+function getTemplatesInstallHandler (req, res) {
+  const templateConfig = locateTemplateConfig(req)
+
+  if (templateConfig) {
+    res.render(getManagementView('template-install.njk'), {
+      currentPage: 'Templates',
+      currentUrl: req.originalUrl,
+      links: managementLinks,
+      templateName: templateConfig.name,
+      error: ({
+        exists: 'Path already exists',
+        missing: 'Enter a path',
+        singleSlash: 'Path must not be a single forward slash (/)',
+        endsWithSlash: 'Path must not end in a forward slash (/)',
+        multipleSlashes: 'must not include a slash followed by another slash (//)',
+        slash: 'Path must begin with a forward slash (/)',
+        invalid: 'Path must not include !$&\'()*+,;=:?#[]@.% or space'
+      })[req.query.errorType],
+      chosenUrl: req.query['chosen-url']
+    })
+  } else {
+    res.status(404).send('Template not found.')
+  }
+}
+
+async function postTemplatesInstallHandler (req, res) {
+  const templateConfig = locateTemplateConfig(req)
+  const templatePath = path.join(projectDir, 'node_modules', templateConfig.path)
+
+  const chosenUrl = req.body['chosen-url'].trim().normalize()
+
+  const installLocation = path.join(projectDir, 'app', 'views', `${chosenUrl}.html`)
+
+  const renderError = (errorType) => {
+    const query = querystring.stringify({
+      ...req.query,
+      'chosen-url': req.body['chosen-url'],
+      errorType
+    })
+    const url = `${req.originalUrl.split('?')[0]}?${query}`
+    res.redirect(url)
+  }
+
+  if (!chosenUrl.length) {
+    renderError('missing')
+    return
+  }
+
+  if (chosenUrl === '/') {
+    renderError('singleSlash')
+    return
+  }
+
+  if (chosenUrl[0] !== '/') {
+    renderError('slash')
+    return
+  }
+
+  if (chosenUrl[chosenUrl.length - 1] === '/') {
+    renderError('endsWithSlash')
+    return
+  }
+
+  if (chosenUrl.indexOf('//') !== -1) {
+    renderError('multipleSlashes')
+    return
+  }
+
+  if (await fse.exists(installLocation)) {
+    renderError('exists')
+    return
+  }
+
+  // Don't allow URI reserved characters (per RFC 3986) in paths
+  if ("!$&'()*+,;=:?#[]@.% ".split('').some((char) => chosenUrl.includes(char))) {
+    renderError('invalid')
+    return
+  }
+
+  await fse.ensureDir(path.dirname(installLocation))
+  await fse.copy(templatePath, installLocation)
+
+  res.redirect(`/manage-prototype/templates/post-install?chosen-url=${encodeURIComponent(chosenUrl)}`)
+}
+
+function getTemplatesPostInstallHandler (req, res) {
+  const pageName = 'Templates'
+  const chosenUrl = req.query['chosen-url']
+
+  res.render(getManagementView('template-post-install.njk'), {
+    currentPage: pageName,
+    links: managementLinks,
+    url: chosenUrl,
+    filePath: path.join('app', 'views', `${chosenUrl}.html`)
+  })
+}
+
+function removeDuplicates (val, index, arr) {
+  return !arr.includes(val, index + 1)
+}
+
+async function getPluginDetails () {
+  const pkg = fse.readJsonSync(pkgPath)
+  const installed = plugins.listInstalledPlugins()
+  const all = await Promise.all(installed.concat(knownPlugins.plugins.available)
+    .filter(removeDuplicates)
+    .map(async (packageName) => {
+      // Only those plugins not referenced locally can be looked up
+      const reference = pkg.dependencies[packageName] || ''
+      const canLookUp = !reference.startsWith('file:')
+      return {
+        packageName,
+        latestVersion: canLookUp && await lookupLatestPackageVersion(packageName)
+      }
+    })
+    .map(async (packageDetails) => {
+      const pack = await packageDetails
+      Object.assign(pack, plugins.preparePackageNameForDisplay(pack.packageName), {
+        installLink: `${contextPath}/plugins/install?package=${encodeURIComponent(pack.packageName)}`,
+        installCommand: `npm install ${pack.packageName}`,
+        upgradeCommand: `npm install ${pack.packageName}@${pack.latestVersion}`,
+        uninstallCommand: `npm uninstall ${pack.packageName}`
+      })
+      if (installed.includes(pack.packageName)) {
+        pack.installedVersion = (await fse.readJson(path.join(projectDir, 'node_modules', pack.packageName, 'package.json'))).version
+        if (!['govuk-prototype-kit', 'govuk-frontend'].includes(pack.packageName)) {
+          pack.uninstallLink = `${contextPath}/plugins/uninstall?package=${encodeURIComponent(pack.packageName)}`
+        }
+      }
+      if (pack.latestVersion && pack.installedVersion && pack.installedVersion !== pack.latestVersion) {
+        pack.upgradeLink = `${contextPath}/plugins/upgrade?package=${encodeURIComponent(pack.packageName)}`
+      }
+      return pack
+    }))
+  return all
+}
+
+async function prepareForPluginPage () {
+  const all = await getPluginDetails()
+
+  const installedOut = {}
+  const availableOut = {}
+  const output = [installedOut, availableOut]
+
+  installedOut.name = 'Installed'
+  installedOut.plugins = []
+  availableOut.name = 'Available'
+  availableOut.plugins = []
+
+  all.forEach(packageInfo => {
+    if (packageInfo.installedVersion) {
+      installedOut.plugins.push(packageInfo)
+    } else {
+      availableOut.plugins.push(packageInfo)
+    }
+  })
+
+  return output
+}
+
+function getCommand (mode, chosenPlugin) {
+  switch (mode) {
+    case 'upgrade': return chosenPlugin.upgradeCommand
+    case 'install': return chosenPlugin.installCommand
+    case 'uninstall': return chosenPlugin.uninstallCommand
+  }
+}
+
+const verbs = {
+  upgrade: {
+    title: 'Upgrade',
+    para: 'upgrade',
+    status: 'upgraded',
+    progressive: 'upgrading'
+  },
+  install: {
+    title: 'Install',
+    para: 'install',
+    status: 'installed',
+    progressive: 'installing'
+  },
+  uninstall: {
+    title: 'Uninstall',
+    para: 'uninstall',
+    status: 'uninstalled',
+    progressive: 'uninstalling'
+  }
+}
+
+async function getPluginsHandler (req, res) {
+  const pageName = 'Plugins'
+  const model = {
+    currentPage: pageName,
+    links: managementLinks,
+    mode: req.query.mode
+  }
+
+  const isSuccessResult = !!req.query.package
+
+  if (isSuccessResult) {
+    model.successBanner = {
+      package: plugins.preparePackageNameForDisplay(req.query.package),
+      mode: req.query.mode,
+      verb: verbs[req.query.mode].status
+    }
+  }
+  model.groupsOfPlugins = await prepareForPluginPage()
+  res.render(getManagementView('plugins.njk'), model)
+}
+
+async function getPluginForRequest (req) {
+  const searchPackage = req.query.package || req.body.package
+  if (searchPackage) {
+    return (await getPluginDetails())
+      .filter(({ packageName }) => packageName === searchPackage)[0]
+  }
+}
+
+function modeIsComplete (mode, { installedVersion, latestVersion }) {
+  switch (mode) {
+    case 'upgrade': return installedVersion === latestVersion
+    case 'install': return !!installedVersion
+    case 'uninstall': return !installedVersion
+  }
+}
+
+async function getPluginsModeHandler (req, res) {
+  const isSameOrigin = req.headers['sec-fetch-site'] === 'same-origin'
+  const { mode } = req.params
+  const verb = verbs[mode]
+
+  if (!verb) {
+    res.status(404).send(`Page not found: ${req.path}`)
+    return
+  }
+
+  const chosenPlugin = await getPluginForRequest(req) || preparePackageNameForDisplay(req.query.package)
+
+  const pageName = `${verb.title} ${chosenPlugin.name}`
+
+  res.render(getManagementView('plugin-install-or-uninstall.njk'), {
+    currentPage: pageName,
+    currentUrl: req.originalUrl,
+    links: managementLinks,
+    chosenPlugin,
+    command: getCommand(mode, chosenPlugin),
+    verb,
+    isSameOrigin,
+    csrfToken: req.csrfToken()
+  })
+}
+
+const startTimestamp = Date.now()
+
+async function postPluginsStatusHandler (req, res) {
+  let status = 'processing'
+  try {
+    const chosenPlugin = await getPluginForRequest(req)
+    if (!chosenPlugin) {
+      status = 'error'
+    }
+  } catch (e) {
+    console.log(e)
+  }
+  res.json({ startTimestamp, status })
+}
+
+async function postPluginsModeMiddleware (req, res, next) {
+  // Redirect to the GET route of the same url when the post request is not an ajax request
+  if (req.headers['content-type'].indexOf('json') === -1) {
+    res.redirect(req.originalUrl)
+  } else {
+    next()
+  }
+}
+
+async function postPluginsModeHandler (req, res) {
+  const { mode } = req.params
+  const verb = verbs[mode]
+
+  if (!verb) {
+    res.json({ startTimestamp, status: 'error' })
+    return
+  }
+
+  let status = 'processing'
+  try {
+    const chosenPlugin = await getPluginForRequest(req)
+    if (!chosenPlugin) {
+      status = 'error'
+    } else if (modeIsComplete(mode, chosenPlugin)) {
+      status = 'completed'
+    } else {
+      const command = getCommand(mode, chosenPlugin)
+      exec(command, { cwd: projectDir }).finally(() => {
+        console.log(`Completed ${command}`)
+        // force the application to stop after a delay as nodemon restart does not always work on Windows when running acceptance tests
+        setTimeout(() => {
+          process.exit(1)
+        }, 6000)
+      })
+    }
+  } catch (e) {
+    console.log(e)
+  }
+  res.json({ startTimestamp, status })
+}
+
+module.exports = {
+  contextPath,
+  getClearDataHandler,
+  postClearDataHandler,
+  getPasswordHandler,
+  postPasswordHandler,
+  developmentOnlyMiddleware,
+  getHomeHandler,
+  getTemplatesHandler,
+  getTemplatesViewHandler,
+  getTemplatesInstallHandler,
+  postTemplatesInstallHandler,
+  getTemplatesPostInstallHandler,
+  getPluginsHandler,
+  getPluginsModeHandler,
+  postPluginsStatusHandler,
+  postPluginsModeMiddleware,
+  postPluginsModeHandler
+}

--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -8,7 +8,7 @@ const querystring = require('querystring')
 const templateRenderNunjucks = require('nunjucks')
 
 // local dependencies
-const config = require('./config').getConfig()
+const config = require('./config')
 const plugins = require('./plugins/plugins')
 const { exec } = require('./exec')
 const { requestHttpsJson, prototypeAppScripts } = require('./utils')
@@ -24,10 +24,8 @@ const appViews = plugins.getAppViews([
 const pkgPath = path.join(projectDir, 'package.json')
 
 const currentKitVersion = require(path.join(packageDir, 'package.json')).version
-const knownPlugins = require(path.join(packageDir, 'known-plugins.json'))
-const { preparePackageNameForDisplay } = require('./plugins/plugins')
 
-const latestReleaseVersions = knownPlugins.plugins.available
+const latestReleaseVersions = plugins.getKnownPlugins().available
   .reduce((releaseVersions, nextPlugin) => {
     return { ...releaseVersions, [nextPlugin]: 0 }
   }, { 'govuk-prototype-kit': currentKitVersion })
@@ -47,7 +45,7 @@ async function updateLatestReleaseVersions () {
   return latestReleaseVersions
 }
 
-if (!config.isTest) {
+if (!config.getConfig().isTest) {
   updateLatestReleaseVersions()
   setInterval(lookupLatestPackageVersion, 1000 * 60 * 20)
 }
@@ -64,8 +62,6 @@ function getManagementView (filename) {
 
 // Local dependencies
 const encryptPassword = require('./utils').encryptPassword
-
-const password = process.env.PASSWORD
 
 // Clear all data in session
 function getClearDataHandler (req, res) {
@@ -86,6 +82,7 @@ function getPasswordHandler (req, res) {
 
 // Check authentication password
 function postPasswordHandler (req, res) {
+  const password = config.getConfig().password
   const submittedPassword = req.body.password
   const providedUrl = req.body.returnURL
   const processedRedirectUrl = (!providedUrl || providedUrl.startsWith('/manage-prototype/password')) ? '/' : providedUrl
@@ -107,7 +104,7 @@ function postPasswordHandler (req, res) {
 // Middleware to ensure the routes specified below will render the manage-prototype-not-available
 // view when the prototype is not running in development
 function developmentOnlyMiddleware (req, res, next) {
-  if (config.isDevelopment) {
+  if (config.getConfig().isDevelopment) {
     next()
   } else {
     res.render(getManagementView('manage-prototype-not-available.njk'))
@@ -141,11 +138,12 @@ async function readFileIfExists (path) {
 
 async function getHomeHandler (req, res) {
   const pageName = 'Home'
+  const { serviceName } = config.getConfig()
 
   const originalHomepage = await fse.readFile(path.join(packageDir, 'prototype-starter', 'app', 'views', 'index.html'), 'utf8')
   const currentHomepage = await readFileIfExists(path.join(projectDir, 'app', 'views', 'index.html'))
 
-  res.render(getManagementView('index.njk'), {
+  const viewData = {
     currentUrl: req.originalUrl,
     currentPage: pageName,
     links: managementLinks,
@@ -153,15 +151,16 @@ async function getHomeHandler (req, res) {
     latestAvailableKit: latestReleaseVersions['govuk-prototype-kit'],
     tasks: [
       {
-        done: config.serviceName !== 'Service name goes here' && config.serviceName !== 'GOV.UK Prototype Kit',
+        done: serviceName !== 'Service name goes here' && serviceName !== 'GOV.UK Prototype Kit',
         html: 'Change the service name in the file <strong>app/config.json</strong>'
       }, {
         done: currentHomepage !== undefined && originalHomepage !== currentHomepage,
         html: 'Edit the homepage in the file <strong>app/views/index.html</strong>'
       }
     ]
+  }
 
-  })
+  res.render(getManagementView('index.njk'), viewData)
 }
 
 function exampleTemplateConfig (packageName, { name, path }) {
@@ -238,8 +237,7 @@ function getTemplatesViewHandler (req, res) {
   const templateConfig = locateTemplateConfig(req)
 
   if (templateConfig) {
-    const renderPath = templateConfig.path
-    res.send(templateRenderNunjucks.render(renderPath, model))
+    res.send(templateRenderNunjucks.render(templateConfig.path, model))
   } else {
     res.status(404).send('Template not found.')
   }
@@ -313,14 +311,14 @@ async function postTemplatesInstallHandler (req, res) {
     return
   }
 
-  if (await fse.exists(installLocation)) {
-    renderError('exists')
-    return
-  }
-
   // Don't allow URI reserved characters (per RFC 3986) in paths
   if ("!$&'()*+,;=:?#[]@.% ".split('').some((char) => chosenUrl.includes(char))) {
     renderError('invalid')
+    return
+  }
+
+  if (await fse.exists(installLocation)) {
+    renderError('exists')
     return
   }
 
@@ -349,7 +347,7 @@ function removeDuplicates (val, index, arr) {
 async function getPluginDetails () {
   const pkg = fse.readJsonSync(pkgPath)
   const installed = plugins.listInstalledPlugins()
-  const all = await Promise.all(installed.concat(knownPlugins.plugins.available)
+  const all = await Promise.all(installed.concat(plugins.getKnownPlugins().available)
     .filter(removeDuplicates)
     .map(async (packageName) => {
       // Only those plugins not referenced locally can be looked up
@@ -481,7 +479,7 @@ async function getPluginsModeHandler (req, res) {
     return
   }
 
-  const chosenPlugin = await getPluginForRequest(req) || preparePackageNameForDisplay(req.query.package)
+  const chosenPlugin = await getPluginForRequest(req) || plugins.preparePackageNameForDisplay(req.query.package)
 
   const pageName = `${verb.title} ${chosenPlugin.name}`
 

--- a/lib/manage-prototype-handlers.test.js
+++ b/lib/manage-prototype-handlers.test.js
@@ -1,0 +1,492 @@
+/* eslint-env jest */
+
+// core dependencies
+const path = require('path')
+
+// npm dependencies
+const fse = require('fs-extra')
+const nunjucks = require('nunjucks')
+
+// local dependencies
+const config = require('./config')
+const utils = require('./utils')
+const exec = require('./exec')
+const plugins = require('./plugins/plugins')
+
+const {
+  getPasswordHandler,
+  getClearDataHandler,
+  getHomeHandler,
+  postClearDataHandler,
+  postPasswordHandler,
+  developmentOnlyMiddleware,
+  getTemplatesHandler,
+  getTemplatesViewHandler,
+  getTemplatesInstallHandler,
+  postTemplatesInstallHandler,
+  getTemplatesPostInstallHandler,
+  getPluginsHandler,
+  postPluginsStatusHandler,
+  postPluginsModeMiddleware,
+  getPluginsModeHandler,
+  postPluginsModeHandler
+} = require('./manage-prototype-handlers')
+const { projectDir } = require('./utils/paths')
+
+// mocked dependencies
+jest.mock('fs-extra', () => {
+  return {
+    readFile: jest.fn().mockResolvedValue(''),
+    copy: jest.fn(),
+    ensureDir: jest.fn().mockResolvedValue(true),
+    exists: jest.fn().mockResolvedValue(true),
+    existsSync: jest.fn().mockReturnValue(true),
+    pathExistsSync: jest.fn().mockReturnValue(true),
+    readJsonSync: jest.fn().mockReturnValue({})
+  }
+})
+jest.mock('nunjucks', () => {
+  return {
+    render: jest.fn(),
+    configure: jest.fn()
+  }
+})
+jest.mock('./utils', () => {
+  return {
+    encryptPassword: jest.fn().mockReturnValue('encrypted password'),
+    requestHttpsJson: jest.fn()
+  }
+})
+jest.mock('./plugins/plugins', () => {
+  return {
+    getAppViews: jest.fn(),
+    getAppConfig: jest.fn(),
+    getByType: jest.fn(),
+    listInstalledPlugins: jest.fn(),
+    getKnownPlugins: jest.fn().mockReturnValue({ available: [] }),
+    preparePackageNameForDisplay: jest.fn()
+  }
+})
+jest.mock('./exec', () => {
+  return {
+    exec: jest.fn().mockReturnValue({ finally: jest.fn() })
+  }
+})
+
+describe('manage-prototype-handlers', () => {
+  let req, res, next
+
+  beforeEach(() => {
+    fse.exists.mockResolvedValue(true)
+    fse.readJsonSync.mockReturnValue({})
+    req = {
+      headers: {},
+      originalUrl: '/current-url'
+    }
+    res = {
+      render: jest.fn(),
+      redirect: jest.fn()
+    }
+    next = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('getClearDataHandler', () => {
+    getClearDataHandler(req, res)
+    expect(res.render).toHaveBeenCalledWith(
+      'views/manage-prototype/clear-data.njk'
+    )
+  })
+
+  it('postClearDataHandler', () => {
+    req.session = {
+      data: { hasData: true }
+    }
+    postClearDataHandler(req, res)
+    expect(req.session.data).toEqual({})
+    expect(res.render).toHaveBeenCalledWith(
+      'views/manage-prototype/clear-data-success.njk'
+    )
+  })
+
+  it('getPasswordHandler', () => {
+    req.query = {
+      returnUrl: '/'
+    }
+    getPasswordHandler(req, res)
+    expect(res.render).toHaveBeenCalledWith(
+      'views/manage-prototype/password.njk',
+      { error: undefined, returnURL: '/' }
+    )
+  })
+
+  describe('postPasswordHandler', () => {
+    beforeEach(() => {
+      jest.spyOn(config, 'getConfig').mockImplementation(() => ({ password: 'password' }))
+    })
+
+    it('correct password', () => {
+      req.body = {
+        password: 'password'
+      }
+      res.cookie = jest.fn()
+      postPasswordHandler(req, res)
+      expect(res.cookie).toHaveBeenCalled()
+      expect(res.redirect).toHaveBeenCalledWith('/')
+    })
+
+    it('incorrect password', async () => {
+      req.body = {
+        password: 'xxxxx'
+      }
+      res.cookie = jest.fn()
+      postPasswordHandler(req, res)
+      expect(res.cookie).not.toHaveBeenCalled()
+      expect(res.redirect).toHaveBeenCalledWith(
+        '/manage-prototype/password?error=wrong-password&returnURL=%2F'
+      )
+    })
+  })
+
+  it('getHomeHandler', async () => {
+    await getHomeHandler(req, res)
+    expect(res.render).toHaveBeenCalledWith(
+      'views/manage-prototype/index.njk',
+      expect.objectContaining({ currentPage: 'Home' })
+    )
+  })
+
+  describe('developmentOnlyMiddleware', () => {
+    it('in production', () => {
+      developmentOnlyMiddleware(req, res, next)
+      expect(res.render).toHaveBeenCalledWith(
+        'views/manage-prototype/manage-prototype-not-available.njk'
+      )
+    })
+
+    it('in development', () => {
+      jest.spyOn(config, 'getConfig').mockImplementation(() => ({ isDevelopment: true }))
+      developmentOnlyMiddleware(req, res, next)
+      expect(next).toHaveBeenCalled()
+    })
+  })
+
+  describe('templates handlers', () => {
+    const packageName = 'test-package'
+    const pluginDisplayName = { name: 'Test Package' }
+    const templatePath = '/template'
+    const encodedTemplatePath = encodeURIComponent(templatePath)
+    const view = 'Test View'
+    const chosenUrl = '/chosen-url'
+    let mockSend
+
+    beforeEach(() => {
+      mockSend = jest.fn()
+      res.status = jest.fn().mockReturnValue({ send: mockSend })
+      req.query = {
+        package: packageName,
+        template: templatePath
+      }
+      res.send = mockSend
+      plugins.getByType.mockReturnValue([{
+        packageName,
+        item: {
+          type: 'nunjucks',
+          name: packageName,
+          path: templatePath
+        }
+      }])
+      plugins.preparePackageNameForDisplay.mockReturnValue(pluginDisplayName)
+      nunjucks.render.mockReturnValue(view)
+    })
+
+    it('getTemplatesHandler', async () => {
+      await getTemplatesHandler(req, res)
+      expect(res.render).toHaveBeenCalledWith(
+        'views/manage-prototype/templates.njk',
+        expect.objectContaining({
+          currentPage: 'Templates',
+          availableTemplates: [{
+            packageName,
+            pluginDisplayName,
+            templates: [{
+              installLink: `/manage-prototype/templates/install?package=${packageName}&template=${encodedTemplatePath}`,
+              name: packageName,
+              path: path.join(`${packageName}${templatePath}`),
+              viewLink: `/manage-prototype/templates/view?package=${packageName}&template=${encodedTemplatePath}`
+            }]
+          }]
+        })
+      )
+    })
+
+    describe('getTemplatesViewHandler', () => {
+      it('template found', async () => {
+        await getTemplatesViewHandler(req, res)
+        expect(res.status).not.toHaveBeenCalled()
+        expect(mockSend).toHaveBeenCalledWith(view)
+      })
+
+      it('template not found', async () => {
+        plugins.getByType.mockReturnValue([])
+        await getTemplatesViewHandler(req, res)
+        expect(res.status).toHaveBeenCalledWith(404)
+        expect(mockSend).toHaveBeenCalledWith('Template not found.')
+      })
+    })
+
+    describe('getTemplatesInstallHandler', () => {
+      describe('template found', () => {
+        beforeEach(() => {
+          req.query['chosen-url'] = chosenUrl
+        })
+
+        async function testGetTemplatesInstallHandler (error) {
+          await getTemplatesInstallHandler(req, res)
+          expect(res.status).not.toHaveBeenCalled()
+          expect(res.render).toHaveBeenCalledWith(
+            'views/manage-prototype/template-install.njk',
+            expect.objectContaining({
+              currentPage: 'Templates',
+              chosenUrl,
+              currentUrl: req.originalUrl,
+              error,
+              templateName: packageName
+            })
+          )
+        }
+
+        it('no errors', async () => {
+          await testGetTemplatesInstallHandler()
+        })
+
+        Object.entries({
+          exists: 'Path already exists',
+          missing: 'Enter a path',
+          singleSlash: 'Path must not be a single forward slash (/)',
+          endsWithSlash: 'Path must not end in a forward slash (/)',
+          multipleSlashes: 'must not include a slash followed by another slash (//)',
+          slash: 'Path must begin with a forward slash (/)',
+          invalid: 'Path must not include !$&\'()*+,;=:?#[]@.% or space'
+        }).forEach(([errorType, errorMessage]) => {
+          it(`error type is ${errorType}`, async () => {
+            req.query.errorType = errorType
+            await testGetTemplatesInstallHandler(errorMessage)
+          })
+        })
+      })
+
+      it('template not found', async () => {
+        plugins.getByType.mockReturnValue([])
+        await getTemplatesInstallHandler(req, res)
+        expect(res.status).toHaveBeenCalledWith(404)
+        expect(mockSend).toHaveBeenCalledWith('Template not found.')
+      })
+
+      describe('postTemplatesInstallHandler', () => {
+        it('chosen url success', async () => {
+          req.body = {
+            'chosen-url': chosenUrl
+          }
+          fse.exists.mockResolvedValue(false)
+          await postTemplatesInstallHandler(req, res)
+          expect(res.redirect).toHaveBeenCalledWith(
+            `/manage-prototype/templates/post-install?chosen-url=${encodeURIComponent(chosenUrl)}`
+          )
+        })
+
+        describe('chosen url failures', () => {
+          const testPostTemplatesInstallHandler = ([errorType, chosenUrl]) => {
+            it(`error type is ${errorType} when chosen url is "${chosenUrl}"`, async () => {
+              req.body = {
+                'chosen-url': chosenUrl
+              }
+              await postTemplatesInstallHandler(req, res)
+              expect(res.redirect).toHaveBeenCalledWith(
+                `${req.originalUrl}?package=${packageName}&template=${encodedTemplatePath}&chosen-url=${encodeURIComponent(chosenUrl)}&errorType=${errorType}`
+              )
+            })
+          }
+          // Test each type of error
+          Object.entries({
+            exists: '/exists',
+            missing: '',
+            singleSlash: '/',
+            endsWithSlash: '/slash-at-end/',
+            multipleSlashes: '//multiple-slashes',
+            slash: 'no-forward-slash'
+          }).forEach(testPostTemplatesInstallHandler)
+
+          // Test each invalid character
+          "!$&'()*+,;=:?#[]@.% "
+            .split('')
+            .map(invalidCharacter => ['invalid', `/${invalidCharacter}/abc`])
+            .forEach(testPostTemplatesInstallHandler)
+        })
+      })
+    })
+
+    it('getTemplatesPostInstallHandler', async () => {
+      req.query['chosen-url'] = chosenUrl
+      await getTemplatesPostInstallHandler(req, res)
+      expect(res.render).toHaveBeenCalledWith(
+        'views/manage-prototype/template-post-install.njk',
+        expect.objectContaining({
+          currentPage: 'Templates',
+          filePath: path.join(`app/views${chosenUrl}.html`)
+        })
+      )
+    })
+  })
+
+  describe('plugins handlers', () => {
+    const csrfToken = 'CSRF-TOKEN'
+    const packageName = 'test-package'
+    const pluginVersion = '1.0.0'
+    const pluginDisplayName = { name: 'Test Package' }
+    const availablePlugin = {
+      installCommand: `npm install ${packageName}`,
+      installLink: `/manage-prototype/plugins/install?package=${packageName}`,
+      latestVersion: pluginVersion,
+      name: pluginDisplayName.name,
+      packageName,
+      uninstallCommand: `npm uninstall ${packageName}`,
+      upgradeCommand: `npm install ${packageName}@${pluginVersion}`
+    }
+
+    beforeEach(() => {
+      plugins.listInstalledPlugins.mockReturnValue([])
+      plugins.preparePackageNameForDisplay.mockReturnValue(pluginDisplayName)
+      plugins.getKnownPlugins.mockReturnValue({ available: [packageName] })
+      utils.requestHttpsJson.mockResolvedValue({
+        'dist-tags': {
+          latest: pluginVersion
+        }
+      })
+      fse.readJsonSync.mockReturnValue({
+        dependencies: {}
+      })
+      res.json = jest.fn().mockReturnValue({})
+    })
+
+    it('getPluginsHandler', async () => {
+      req.query = {
+        mode: 'install'
+      }
+      await getPluginsHandler(req, res)
+      expect(res.render).toHaveBeenCalledWith(
+        'views/manage-prototype/plugins.njk',
+        expect.objectContaining({
+          currentPage: 'Plugins',
+          groupsOfPlugins: [
+            { name: 'Installed', plugins: [] },
+            { name: 'Available', plugins: [availablePlugin] }
+          ]
+        })
+      )
+    })
+
+    it('getPluginsModeHandler', async () => {
+      req.params = {
+        mode: 'install'
+      }
+      req.query = {
+        package: packageName
+      }
+      req.csrfToken = jest.fn().mockReturnValue(csrfToken)
+      await getPluginsModeHandler(req, res)
+      expect(res.render).toHaveBeenCalledWith(
+        'views/manage-prototype/plugin-install-or-uninstall.njk',
+        expect.objectContaining({
+          chosenPlugin: availablePlugin,
+          command: `npm install ${packageName}`,
+          csrfToken,
+          currentPage: `Install ${pluginDisplayName.name}`,
+          currentUrl: req.originalUrl,
+          isSameOrigin: false
+        })
+      )
+    })
+
+    describe('postPluginsStatusHandler', () => {
+      it('is processing', async () => {
+        req.query = {
+          package: packageName
+        }
+        await postPluginsStatusHandler(req, res)
+        expect(res.json).toHaveBeenCalledWith(
+          expect.objectContaining({
+            status: 'processing'
+          })
+        )
+      })
+
+      it('is in error', async () => {
+        req.query = {
+          package: 'invalid-package'
+        }
+        await postPluginsStatusHandler(req, res)
+        expect(res.json).toHaveBeenCalledWith(
+          expect.objectContaining({
+            status: 'error'
+          })
+        )
+      })
+    })
+
+    describe('postPluginsModeMiddleware', () => {
+      it('with AJAX', async () => {
+        req.headers['content-type'] = 'application/json'
+        await postPluginsModeMiddleware(req, res, next)
+        expect(next).toHaveBeenCalled()
+      })
+
+      it('without AJAX', async () => {
+        req.headers['content-type'] = 'document/html'
+        await postPluginsModeMiddleware(req, res, next)
+        expect(res.redirect).toHaveBeenCalledWith(req.originalUrl)
+      })
+    })
+
+    describe('postPluginsModeHandler', () => {
+      beforeEach(() => {
+        req.params = {
+          mode: 'install'
+        }
+        req.query = {}
+        req.body = {
+          package: packageName
+        }
+      })
+
+      it('processing', async () => {
+        await postPluginsModeHandler(req, res)
+        expect(exec.exec).toHaveBeenCalledWith(
+          availablePlugin.installCommand,
+          { cwd: projectDir }
+        )
+        expect(res.json).toHaveBeenCalledWith(
+          expect.objectContaining({
+            status: 'processing'
+          })
+        )
+      })
+
+      it('error', async () => {
+        req.body = {
+          package: 'invalid-package'
+        }
+        await postPluginsModeHandler(req, res)
+        expect(exec.exec).not.toHaveBeenCalled()
+        expect(res.json).toHaveBeenCalledWith(
+          expect.objectContaining({
+            status: 'error'
+          })
+        )
+      })
+    })
+  })
+})

--- a/lib/manage-prototype-routes.js
+++ b/lib/manage-prototype-routes.js
@@ -1,566 +1,70 @@
-
-// core dependencies
-const path = require('path')
-
 // npm dependencies
 const csrf = require('csurf')
-const fse = require('fs-extra')
-const querystring = require('querystring')
-const templateRenderNunjucks = require('nunjucks')
-
-// local dependencies
-const config = require('./config').getConfig()
-const plugins = require('./plugins/plugins')
-const { exec } = require('./exec')
-const { requestHttpsJson, prototypeAppScripts } = require('./utils')
-const { projectDir, packageDir } = require('./utils/paths')
-
-const contextPath = '/manage-prototype'
-
-const router = require('../index').requests.setupRouter(contextPath)
-const redirectingRouter = require('../index').requests.setupRouter('/manage-prototype')
 
 const csrfProtection = csrf({ cookie: false })
 
-const appViews = plugins.getAppViews([
-  path.join(projectDir, 'node_modules'),
-  path.join(projectDir, 'app/views/')
-])
+const {
+  contextPath,
+  getClearDataHandler,
+  postClearDataHandler,
+  getPasswordHandler,
+  postPasswordHandler,
+  developmentOnlyMiddleware,
+  getHomeHandler,
+  getTemplatesHandler,
+  getTemplatesViewHandler,
+  getTemplatesInstallHandler,
+  postTemplatesInstallHandler,
+  getTemplatesPostInstallHandler,
+  getPluginsHandler,
+  getPluginsModeHandler,
+  postPluginsModeMiddleware,
+  postPluginsModeHandler,
+  postPluginsStatusHandler
+} = require('./manage-prototype-handlers')
 
-const pkgPath = path.join(projectDir, 'package.json')
-
-const currentKitVersion = require(path.join(packageDir, 'package.json')).version
-const knownPlugins = require(path.join(packageDir, 'known-plugins.json'))
-const { preparePackageNameForDisplay } = require('./plugins/plugins')
-
-const latestReleaseVersions = knownPlugins.plugins.available
-  .reduce((releaseVersions, nextPlugin) => {
-    return { ...releaseVersions, [nextPlugin]: 0 }
-  }, { 'govuk-prototype-kit': currentKitVersion })
-
-async function lookupLatestPackageVersion (packageName) {
-  try {
-    const packageInfo = await requestHttpsJson(`https://registry.npmjs.org/${encodeURIComponent(packageName)}`)
-    latestReleaseVersions[packageName] = packageInfo['dist-tags'].latest
-  } catch (e) {
-    console.log('ignoring error', e.message)
-  }
-  return latestReleaseVersions[packageName]
-}
-
-async function updateLatestReleaseVersions () {
-  await Promise.all(Object.keys(latestReleaseVersions).map(lookupLatestPackageVersion))
-  return latestReleaseVersions
-}
-
-if (!config.isTest) {
-  updateLatestReleaseVersions()
-  setInterval(lookupLatestPackageVersion, 1000 * 60 * 20)
-}
-
-templateRenderNunjucks.configure(appViews, {
-  autoescape: true,
-  noCache: true,
-  watch: false // We are now setting this to `false` (it's by default false anyway) as having it set to `true` for production was making the tests hang
-})
-
-function getManagementView (filename) {
-  return ['views', 'manage-prototype', filename].join('/')
-}
+const router = require('../index').requests.setupRouter(contextPath)
+const redirectingRouter = require('../index').requests.setupRouter('/manage-prototype')
 
 redirectingRouter.use((req, res) => {
   res.redirect(req.originalUrl.replace('/manage-prototype', contextPath))
 })
 
-// Local dependencies
-const encryptPassword = require('./utils').encryptPassword
-
-const password = process.env.PASSWORD
-
 // Clear all data in session
-router.get('/clear-data', (req, res) => {
-  res.render(getManagementView('clear-data.njk'))
-})
+router.get('/clear-data', getClearDataHandler)
 
-router.post('/clear-data', (req, res) => {
-  req.session.data = {}
-  res.render(getManagementView('clear-data-success.njk'))
-})
+router.post('/clear-data', postClearDataHandler)
 
 // Render password page with a returnURL to redirect people to where they came from
-router.get('/password', (req, res) => {
-  const returnURL = req.query.returnURL || '/'
-  const error = req.query.error
-  res.render(getManagementView('password.njk'), { returnURL, error })
-})
+router.get('/password', getPasswordHandler)
 
 // Check authentication password
-router.post('/password', (req, res) => {
-  const submittedPassword = req.body.password
-  const providedUrl = req.body.returnURL
-  const processedRedirectUrl = (!providedUrl || providedUrl.startsWith('/manage-prototype/password')) ? '/' : providedUrl
-
-  if (submittedPassword === password) {
-    // see lib/middleware/authentication.js for explanation
-    res.cookie('authentication', encryptPassword(password), {
-      maxAge: 1000 * 60 * 60 * 24 * 30, // 30 days
-      sameSite: 'None', // Allows GET and POST requests from other domains
-      httpOnly: true,
-      secure: true
-    })
-    res.redirect(processedRedirectUrl)
-  } else {
-    res.redirect('/manage-prototype/password?error=wrong-password&returnURL=' + encodeURIComponent(processedRedirectUrl))
-  }
-})
+router.post('/password', postPasswordHandler)
 
 // Middleware to ensure the routes specified below will render the manage-prototype-not-available
 // view when the prototype is not running in development
-router.use((req, res, next) => {
-  if (config.isDevelopment) {
-    next()
-  } else {
-    res.render(getManagementView('manage-prototype-not-available.njk'))
-  }
-})
+router.use(developmentOnlyMiddleware)
 
-const managementLinks = [
-  {
-    text: 'Home',
-    url: contextPath
-  },
-  {
-    text: 'Templates',
-    url: '/manage-prototype/templates'
-  },
-  {
-    text: 'Plugins',
-    url: '/manage-prototype/plugins'
-  },
-  {
-    text: 'Go to prototype',
-    url: '/'
-  }
-]
+router.get('/', getHomeHandler)
 
-async function readFileIfExists (path) {
-  if (await fse.exists(path)) {
-    return await fse.readFile(path, 'utf8')
-  }
-}
+router.get('/templates', getTemplatesHandler)
 
-router.get('/', async (req, res) => {
-  const pageName = 'Home'
+router.get('/templates/view', getTemplatesViewHandler)
 
-  const originalHomepage = await fse.readFile(path.join(packageDir, 'prototype-starter', 'app', 'views', 'index.html'), 'utf8')
-  const currentHomepage = await readFileIfExists(path.join(projectDir, 'app', 'views', 'index.html'))
+router.get('/templates/install', getTemplatesInstallHandler)
 
-  res.render(getManagementView('index.njk'), {
-    currentUrl: req.originalUrl,
-    currentPage: pageName,
-    links: managementLinks,
-    kitUpgradeAvailable: latestReleaseVersions['govuk-prototype-kit'] !== currentKitVersion,
-    latestAvailableKit: latestReleaseVersions['govuk-prototype-kit'],
-    tasks: [
-      {
-        done: config.serviceName !== 'Service name goes here' && config.serviceName !== 'GOV.UK Prototype Kit',
-        html: 'Change the service name in the file <strong>app/config.json</strong>'
-      }, {
-        done: currentHomepage !== undefined && originalHomepage !== currentHomepage,
-        html: 'Edit the homepage in the file <strong>app/views/index.html</strong>'
-      }
-    ]
+router.post('/templates/install', postTemplatesInstallHandler)
 
-  })
-})
+router.get('/templates/post-install', getTemplatesPostInstallHandler)
 
-function exampleTemplateConfig (packageName, { name, path }) {
-  const queryString = `?package=${encodeURIComponent(packageName)}&template=${encodeURIComponent(path)}`
-  return {
-    name,
-    path: require('path').join(packageName, path),
-    installLink: `/manage-prototype/templates/install${queryString}`,
-    viewLink: `/manage-prototype/templates/view${queryString}`
-  }
-}
+router.get('/plugins', getPluginsHandler)
 
-function getPluginTemplates () {
-  const templates = plugins.getByType('templates')
-  const output = []
-  templates.forEach(({ packageName, item }) => {
-    const matchingPackages = output.filter(x => x.packageName === packageName)
-    if (item.type !== 'nunjucks') {
-      console.warn(`Omitting ${item.name} from ${packageName} because the type ${JSON.stringify(item.type)} isn't supported.  The only currently supported type is "nunjucks".`)
-      return
-    }
-    let packageDescription
-    if (matchingPackages.length > 0) {
-      packageDescription = matchingPackages[0]
-    } else {
-      packageDescription = {
-        packageName,
-        pluginDisplayName: plugins.preparePackageNameForDisplay(packageName),
-        templates: []
-      }
-      output.push(packageDescription)
-    }
-    packageDescription.templates.push(exampleTemplateConfig(packageName, item))
-  })
-  return output
-}
+router.get('/plugins/:mode', csrfProtection, getPluginsModeHandler)
 
-router.get('/templates', (req, res) => {
-  const pageName = 'Templates'
-  res.render(getManagementView('templates.njk'), {
-    currentPage: pageName,
-    links: managementLinks,
-    availableTemplates: getPluginTemplates()
-  })
-})
+router.post('/plugins/status', postPluginsStatusHandler)
 
-function locateTemplateConfig (req) {
-  const debugOutput = []
-  const packageTemplates = getPluginTemplates().filter(({ packageName }) => packageName === req.query.package)
-  debugOutput.push(`packages ${JSON.stringify(packageTemplates.map(({ packageName }) => packageName), null, 2)}`)
-  if (packageTemplates.length > 0) {
-    const pathToMatch = [packageTemplates[0].packageName, req.query.template].join('')
-    debugOutput.push(`path to match ${pathToMatch}`)
-    const templates = packageTemplates[0].templates.filter(({ path }) => {
-      // switch backslashes for forward slashes in case of windows
-      path = path.split('\\').join('/')
-      debugOutput.push(`path ${path}`)
-      return path === pathToMatch
-    })
-    if (templates.length > 0) {
-      debugOutput.push('found')
-      return templates[0]
-    } else {
-      debugOutput.push('not found')
-    }
-  }
-}
+router.post('/plugins/:mode', postPluginsModeMiddleware)
 
-router.get('/templates/view', (req, res) => {
-  const model = {
-    pluginConfig: plugins.getAppConfig({ scripts: prototypeAppScripts }),
-    serviceName: 'Service name goes here'
-  }
-  const templateConfig = locateTemplateConfig(req)
-
-  if (templateConfig) {
-    const renderPath = templateConfig.path
-    res.send(templateRenderNunjucks.render(renderPath, model))
-  } else {
-    res.status(404).send('Template not found.')
-  }
-})
-
-router.get('/templates/install', (req, res) => {
-  const templateConfig = locateTemplateConfig(req)
-
-  if (templateConfig) {
-    res.render(getManagementView('template-install.njk'), {
-      currentPage: 'Templates',
-      currentUrl: req.originalUrl,
-      links: managementLinks,
-      templateName: templateConfig.name,
-      error: ({
-        exists: 'Path already exists',
-        missing: 'Enter a path',
-        singleSlash: 'Path must not be a single forward slash (/)',
-        endsWithSlash: 'Path must not end in a forward slash (/)',
-        multipleSlashes: 'must not include a slash followed by another slash (//)',
-        slash: 'Path must begin with a forward slash (/)',
-        invalid: 'Path must not include !$&\'()*+,;=:?#[]@.% or space'
-      })[req.query.errorType],
-      chosenUrl: req.query['chosen-url']
-    })
-  } else {
-    res.status(404).send('Template not found.')
-  }
-})
-
-router.post('/templates/install', async (req, res) => {
-  const templateConfig = locateTemplateConfig(req)
-  const templatePath = path.join(projectDir, 'node_modules', templateConfig.path)
-
-  const chosenUrl = req.body['chosen-url'].trim().normalize()
-
-  const installLocation = path.join(projectDir, 'app', 'views', `${chosenUrl}.html`)
-
-  const renderError = (errorType) => {
-    const query = querystring.stringify({
-      ...req.query,
-      'chosen-url': req.body['chosen-url'],
-      errorType
-    })
-    const url = `${req.originalUrl.split('?')[0]}?${query}`
-    res.redirect(url)
-  }
-
-  if (!chosenUrl.length) {
-    renderError('missing')
-    return
-  }
-
-  if (chosenUrl === '/') {
-    renderError('singleSlash')
-    return
-  }
-
-  if (chosenUrl[0] !== '/') {
-    renderError('slash')
-    return
-  }
-
-  if (chosenUrl[chosenUrl.length - 1] === '/') {
-    renderError('endsWithSlash')
-    return
-  }
-
-  if (chosenUrl.indexOf('//') !== -1) {
-    renderError('multipleSlashes')
-    return
-  }
-
-  if (await fse.exists(installLocation)) {
-    renderError('exists')
-    return
-  }
-
-  // Don't allow URI reserved characters (per RFC 3986) in paths
-  if ("!$&'()*+,;=:?#[]@.% ".split('').some((char) => chosenUrl.includes(char))) {
-    renderError('invalid')
-    return
-  }
-
-  await fse.ensureDir(path.dirname(installLocation))
-  await fse.copy(templatePath, installLocation)
-
-  res.redirect(`/manage-prototype/templates/post-install?chosen-url=${encodeURIComponent(chosenUrl)}`)
-})
-
-router.get('/templates/post-install', (req, res) => {
-  const pageName = 'Templates'
-  const chosenUrl = req.query['chosen-url']
-
-  res.render(getManagementView('template-post-install.njk'), {
-    currentPage: pageName,
-    links: managementLinks,
-    url: chosenUrl,
-    filePath: path.join('app', 'views', `${chosenUrl}.html`)
-  })
-})
-
-function removeDuplicates (val, index, arr) {
-  return !arr.includes(val, index + 1)
-}
-
-async function getPluginDetails () {
-  const pkg = fse.readJsonSync(pkgPath)
-  const installed = plugins.listInstalledPlugins()
-  const all = await Promise.all(installed.concat(knownPlugins.plugins.available)
-    .filter(removeDuplicates)
-    .map(async (packageName) => {
-      // Only those plugins not referenced locally can be looked up
-      const reference = pkg.dependencies[packageName] || ''
-      const canLookUp = !reference.startsWith('file:')
-      return {
-        packageName,
-        latestVersion: canLookUp && await lookupLatestPackageVersion(packageName)
-      }
-    })
-    .map(async (packageDetails) => {
-      const pack = await packageDetails
-      Object.assign(pack, plugins.preparePackageNameForDisplay(pack.packageName), {
-        installLink: `${contextPath}/plugins/install?package=${encodeURIComponent(pack.packageName)}`,
-        installCommand: `npm install ${pack.packageName}`,
-        upgradeCommand: `npm install ${pack.packageName}@${pack.latestVersion}`,
-        uninstallCommand: `npm uninstall ${pack.packageName}`
-      })
-      if (installed.includes(pack.packageName)) {
-        pack.installedVersion = (await fse.readJson(path.join(projectDir, 'node_modules', pack.packageName, 'package.json'))).version
-        if (!['govuk-prototype-kit', 'govuk-frontend'].includes(pack.packageName)) {
-          pack.uninstallLink = `${contextPath}/plugins/uninstall?package=${encodeURIComponent(pack.packageName)}`
-        }
-      }
-      if (pack.latestVersion && pack.installedVersion && pack.installedVersion !== pack.latestVersion) {
-        pack.upgradeLink = `${contextPath}/plugins/upgrade?package=${encodeURIComponent(pack.packageName)}`
-      }
-      return pack
-    }))
-  return all
-}
-
-async function prepareForPluginPage () {
-  const all = await getPluginDetails()
-
-  const installedOut = {}
-  const availableOut = {}
-  const output = [installedOut, availableOut]
-
-  installedOut.name = 'Installed'
-  installedOut.plugins = []
-  availableOut.name = 'Available'
-  availableOut.plugins = []
-
-  all.forEach(packageInfo => {
-    if (packageInfo.installedVersion) {
-      installedOut.plugins.push(packageInfo)
-    } else {
-      availableOut.plugins.push(packageInfo)
-    }
-  })
-
-  return output
-}
-
-function getCommand (mode, chosenPlugin) {
-  switch (mode) {
-    case 'upgrade': return chosenPlugin.upgradeCommand
-    case 'install': return chosenPlugin.installCommand
-    case 'uninstall': return chosenPlugin.uninstallCommand
-  }
-}
-
-const verbs = {
-  upgrade: {
-    title: 'Upgrade',
-    para: 'upgrade',
-    status: 'upgraded',
-    progressive: 'upgrading'
-  },
-  install: {
-    title: 'Install',
-    para: 'install',
-    status: 'installed',
-    progressive: 'installing'
-  },
-  uninstall: {
-    title: 'Uninstall',
-    para: 'uninstall',
-    status: 'uninstalled',
-    progressive: 'uninstalling'
-  }
-}
-
-router.get('/plugins', async (req, res) => {
-  const pageName = 'Plugins'
-  const model = {
-    currentPage: pageName,
-    links: managementLinks,
-    mode: req.query.mode
-  }
-
-  const isSuccessResult = !!req.query.package
-
-  if (isSuccessResult) {
-    model.successBanner = {
-      package: plugins.preparePackageNameForDisplay(req.query.package),
-      mode: req.query.mode,
-      verb: verbs[req.query.mode].status
-    }
-  }
-  model.groupsOfPlugins = await prepareForPluginPage()
-  res.render(getManagementView('plugins.njk'), model)
-})
-
-async function getPluginForRequest (req) {
-  const searchPackage = req.query.package || req.body.package
-  if (searchPackage) {
-    return (await getPluginDetails())
-      .filter(({ packageName }) => packageName === searchPackage)[0]
-  }
-}
-
-function modeIsComplete (mode, { installedVersion, latestVersion }) {
-  switch (mode) {
-    case 'upgrade': return installedVersion === latestVersion
-    case 'install': return !!installedVersion
-    case 'uninstall': return !installedVersion
-  }
-}
-
-router.get('/plugins/:mode', csrfProtection, async (req, res) => {
-  const isSameOrigin = req.headers['sec-fetch-site'] === 'same-origin'
-  const { mode } = req.params
-  const verb = verbs[mode]
-
-  if (!verb) {
-    res.status(404).send(`Page not found: ${req.path}`)
-    return
-  }
-
-  const chosenPlugin = await getPluginForRequest(req) || preparePackageNameForDisplay(req.query.package)
-
-  const pageName = `${verb.title} ${chosenPlugin.name}`
-
-  res.render(getManagementView('plugin-install-or-uninstall.njk'), {
-    currentPage: pageName,
-    currentUrl: req.originalUrl,
-    links: managementLinks,
-    chosenPlugin,
-    command: getCommand(mode, chosenPlugin),
-    verb,
-    isSameOrigin,
-    csrfToken: req.csrfToken()
-  })
-})
-
-const startTimestamp = Date.now()
-
-router.post('/plugins/status', async (req, res) => {
-  let status = 'processing'
-  try {
-    const chosenPlugin = await getPluginForRequest(req)
-    if (!chosenPlugin) {
-      status = 'error'
-    }
-  } catch (e) {
-    console.log(e)
-  }
-  res.json({ startTimestamp, status })
-})
-
-router.post('/plugins/:mode', async (req, res, next) => {
-  // Redirect to the GET route of the same url when the post request is not an ajax request
-  if (req.headers['content-type'].indexOf('json') === -1) {
-    res.redirect(req.originalUrl)
-  } else {
-    next()
-  }
-})
-
-router.post('/plugins/:mode', csrfProtection, async (req, res) => {
-  const { mode } = req.params
-  const verb = verbs[mode]
-
-  if (!verb) {
-    res.json({ startTimestamp, status: 'error' })
-    return
-  }
-
-  let status = 'processing'
-  try {
-    const chosenPlugin = await getPluginForRequest(req)
-    if (!chosenPlugin) {
-      status = 'error'
-    } else if (modeIsComplete(mode, chosenPlugin)) {
-      status = 'completed'
-    } else {
-      const command = getCommand(mode, chosenPlugin)
-      exec(command, { cwd: projectDir }).finally(() => {
-        console.log(`Completed ${command}`)
-        // force the application to stop after a delay as nodemon restart does not always work on Windows when running acceptance tests
-        setTimeout(() => {
-          process.exit(1)
-        }, 6000)
-      })
-    }
-  } catch (e) {
-    console.log(e)
-  }
-  res.json({ startTimestamp, status })
-})
+router.post('/plugins/:mode', csrfProtection, postPluginsModeHandler)
 
 module.exports = router

--- a/lib/plugins/plugins.js
+++ b/lib/plugins/plugins.js
@@ -44,7 +44,8 @@ const fse = require('fs-extra')
 
 // local dependencies
 const appConfig = require('../config')
-const { projectDir, shadowNunjucksDir } = require('../utils/paths')
+const { projectDir, packageDir, shadowNunjucksDir } = require('../utils/paths')
+const knownPlugins = require(path.join(packageDir, 'known-plugins.json'))
 
 const pkgPath = path.join(projectDir, 'package.json')
 
@@ -91,6 +92,10 @@ function throwIfBadFilepath (subject) {
 
 // Check for `basePlugins` in config.js. If it's not there, default to `govuk-frontend`
 const getBasePlugins = () => appConfig.getConfig().basePlugins
+
+function getKnownPlugins () {
+  return knownPlugins.plugins
+}
 
 // Get all npm dependencies
 // Get basePlugins in the order defined in `basePlugins` in config.js
@@ -305,6 +310,7 @@ function legacyGovukFrontendFixesNeeded () {
 const self = module.exports = {
   preparePackageNameForDisplay,
   listInstalledPlugins,
+  getKnownPlugins,
   getByType,
   getPublicUrls,
   getFileSystemPaths,


### PR DESCRIPTION
To make unit tests easier to write, the handlers for each route have been moved into a separate manage-prototype-handlers.js file and unit tests have been written to test these handlers .