### PR TITLE
Allowing the user to opt-out of version control

### DIFF
--- a/__tests__/spec/sanity-checks.js
+++ b/__tests__/spec/sanity-checks.js
@@ -51,7 +51,7 @@ describe('The Prototype Kit', () => {
       return meaningfulLines.pop().trim()
     }
 
-    expect(getLastMeaningfulLineTrimmed(outputLines)).toBe('Created prototype kit')
+    expect(getLastMeaningfulLineTrimmed(outputLines)).toBe('Create prototype')
   })
 
   describe('index page', () => {

--- a/bin/cli
+++ b/bin/cli
@@ -15,7 +15,9 @@ const currentDirectory = process.cwd()
 const kitRoot = path.join(__dirname, '..')
 const kitVersion = require('../package.json').version
 
-const argv = parse(process.argv)
+const argv = parse(process.argv, {
+  booleans: ['no-version-control']
+})
 
 const npmrc = `
 audit=false
@@ -51,7 +53,7 @@ async function updatePackageJson (packageJsonPath) {
 }
 
 async function initialiseGitRepo () {
-  if (argv.options['version-control'] === 'none') {
+  if (argv.options['no-version-control']) {
     return
   }
   try {

--- a/bin/cli
+++ b/bin/cli
@@ -51,18 +51,23 @@ async function updatePackageJson (packageJsonPath) {
 }
 
 async function initialiseGitRepo () {
-  const presenceCheckOutput = []
-  const notPresentText = 'not present'
-  await exec(`which git || echo "${notPresentText}"`, {}, data => presenceCheckOutput.push(data))
-  if (presenceCheckOutput.join('').trim() === notPresentText) {
+  if (argv.options['version-control'] === 'none') {
+    return
+  }
+  try {
+    await exec('git init && git checkout -b main && git add -A .', {})
+  } catch (e) {
     return
   }
 
-  await exec('git init && git add -A .')
+  const failSilently = () => {}
 
-  const overrideParams = '-c "user.email=gov.uk-prototype@digital.cabinet-office.gov.uk" -c "user.name=GOV.UK Prototype Kit"'
-  const commitMessage = 'Created prototype kit'
-  await exec(`git commit -am "${commitMessage}" || git ${overrideParams} commit -am "${commitMessage}"`)
+  const commitMessage = 'Create prototype'
+  await exec(`git commit -am "${commitMessage}"`)
+    .catch(() =>
+      exec(`git -c "user.email=gov.uk-prototype@digital.cabinet-office.gov.uk" -c "user.name=GOV.UK Prototype Kit" commit -am "${commitMessage}"`)
+    )
+    .catch(failSilently)
 }
 
 function usage () {

--- a/bin/cli
+++ b/bin/cli
@@ -166,7 +166,9 @@ async function runCreate () {
 
   await npmInstall(installDirectory, [kitDependency, 'govuk-frontend'])
 
-  await spawn('npx', ['govuk-prototype-kit', 'init', '--', installDirectory], {
+  const additionalArgs = Object.keys(argv.options).map(name => `--${name}="${argv.options[name]}"`)
+
+  await spawn('npx', ['govuk-prototype-kit', 'init', '--', ...additionalArgs, installDirectory], {
     cwd: installDirectory,
     stdio: 'inherit'
   })
@@ -182,7 +184,7 @@ async function runInit () {
     return
   }
 
-  const installDirectory = process.argv[4]
+  const installDirectory = getInstallLocation()
 
   const copyFile = (fileName) => fs.copy(path.join(kitRoot, fileName), path.join(installDirectory, fileName))
 

--- a/bin/cli
+++ b/bin/cli
@@ -57,7 +57,7 @@ async function initialiseGitRepo () {
     return
   }
   try {
-    await exec('git init && git checkout -b main && git add -A .', {})
+    await exec('git init --initial-branch=main && git add -A .', {})
   } catch (e) {
     return
   }

--- a/bin/cli
+++ b/bin/cli
@@ -173,7 +173,7 @@ async function runCreate () {
 
   const additionalArgs = Object.keys(argv.options).map(name => `--${name}="${argv.options[name]}"`)
 
-  await spawn('npx', ['govuk-prototype-kit', 'init', '--', ...additionalArgs, installDirectory], {
+  await spawn('npx', ['govuk-prototype-kit', 'init', '--', installDirectory, ...additionalArgs], {
     cwd: installDirectory,
     stdio: 'inherit'
   })

--- a/bin/utils/argv-parser.js
+++ b/bin/utils/argv-parser.js
@@ -14,11 +14,18 @@ function parse (argvInput) {
     }
   }
 
+  const prepareArg = (arg) => {
+    if ((arg.startsWith('"') && arg.endsWith('"')) || (arg.startsWith('\'') && arg.endsWith('\''))) {
+      return arg.substring(1, arg.length - 1)
+    }
+    return arg
+  }
+
   args.forEach(arg => {
     if (arg.startsWith('-')) {
       if (arg.includes('=')) {
         const parts = arg.split('=')
-        options[processOptionName(parts[0])] = parts[1]
+        options[processOptionName(parts[0])] = prepareArg(parts[1])
         return
       }
       contextFromPrevious = {

--- a/bin/utils/argv-parser.js
+++ b/bin/utils/argv-parser.js
@@ -1,7 +1,8 @@
-function parse (argvInput) {
+function parse (argvInput, config = {}) {
   const args = [...argvInput].splice(2)
   const options = {}
   const paths = []
+  const booleanOptions = config.booleans || []
   let command
   let contextFromPrevious
 
@@ -23,6 +24,11 @@ function parse (argvInput) {
 
   args.forEach(arg => {
     if (arg.startsWith('-')) {
+      const processedArgName = processOptionName(arg)
+      if (booleanOptions.includes(processedArgName)) {
+        options[processedArgName] = true
+        return
+      }
       if (arg.includes('=')) {
         const parts = arg.split('=')
         options[processOptionName(parts[0])] = prepareArg(parts[1])

--- a/bin/utils/argv-parser.spec.js
+++ b/bin/utils/argv-parser.spec.js
@@ -168,4 +168,34 @@ describe('argv parser', () => {
       paths: ['/tmp/hello-world']
     })
   })
+  it('should support speech marks when using equals to set an option', () => {
+    const result = parser.parse(addStandardArgs([
+      '--version="this is a multi-word option"',
+      'create',
+      '/tmp/hello-world'
+    ]))
+
+    expect(result).toEqual({
+      command: 'create',
+      options: {
+        version: 'this is a multi-word option'
+      },
+      paths: ['/tmp/hello-world']
+    })
+  })
+  it('should support quote marks when using equals to set an option', () => {
+    const result = parser.parse(addStandardArgs([
+      '--version=\'this is a multi-word option\'',
+      'create',
+      '/tmp/hello-world'
+    ]))
+
+    expect(result).toEqual({
+      command: 'create',
+      options: {
+        version: 'this is a multi-word option'
+      },
+      paths: ['/tmp/hello-world']
+    })
+  })
 })

--- a/bin/utils/argv-parser.spec.js
+++ b/bin/utils/argv-parser.spec.js
@@ -198,4 +198,21 @@ describe('argv parser', () => {
       paths: ['/tmp/hello-world']
     })
   })
+  it.only('should allow a boolean option', () => {
+    const result = parser.parse(addStandardArgs([
+      'create',
+      '--no-version-control',
+      '/tmp/hello-world'
+    ]), {
+      booleans: ['no-version-control']
+    })
+
+    expect(result).toEqual({
+      command: 'create',
+      options: {
+        'no-version-control': true
+      },
+      paths: ['/tmp/hello-world']
+    })
+  })
 })

--- a/bin/utils/argv-parser.spec.js
+++ b/bin/utils/argv-parser.spec.js
@@ -198,7 +198,7 @@ describe('argv parser', () => {
       paths: ['/tmp/hello-world']
     })
   })
-  it.only('should allow a boolean option', () => {
+  it('should allow a boolean option', () => {
     const result = parser.parse(addStandardArgs([
       'create',
       '--no-version-control',

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,7 +1,6 @@
 
 // npm dependencies
 const { spawn: crossSpawn } = require('cross-spawn')
-const colors = require('ansi-colors')
 
 function exec (command, options = {}, stdout) {
   const errorOutput = []
@@ -25,10 +24,12 @@ function exec (command, options = {}, stdout) {
       if (code === 0) {
         resolve(true)
       } else {
+        const error = new Error(`Exit code was ${code}`)
+        error.code = code
         if (errorOutput.length > 0) {
-          console.error(colors.red(errorOutput.join('\n')))
+          error.errorOutput = errorOutput.join('\n')
         }
-        reject(new Error(`Exit code was ${code}`))
+        reject(error)
       }
     })
   })

--- a/lib/exec.test.js
+++ b/lib/exec.test.js
@@ -1,0 +1,63 @@
+const fs = require('fs')
+const path = require('path')
+
+const exec = require('./exec').exec
+
+describe('exec', () => {
+  it('should be able to create and delete files', async () => {
+    const fileName = 'this-is-a-test-file.txt'
+    const filePath = path.join(__dirname, fileName)
+
+    expect(fs.existsSync(filePath)).toBe(false)
+
+    await exec(`touch ${fileName}`, { cwd: __dirname })
+    expect(fs.existsSync(filePath)).toBe(true)
+
+    await exec(`rm ${fileName}`, { cwd: __dirname })
+    expect(fs.existsSync(filePath)).toBe(false)
+  })
+
+  it('should provide an output from stdout', async () => {
+    const outputParts = []
+
+    await exec('echo hello', {}, output => outputParts.push(output.toString()))
+
+    expect(outputParts[0].trim()).toEqual('hello')
+  })
+  // it('should error when a command fails', async () => {
+  //   let catchCalled = false
+  //
+  //   await exec('sadflkajsdfoiewflkjsadf')
+  //     .catch(() => {
+  //       catchCalled = true
+  //     })
+  //
+  //   expect(catchCalled).toBe(true)
+  // })
+  // it('should provide the error code and message', async () => {
+  //   let catchCalled = false
+  //
+  //   await exec('which asldfkj')
+  //     .catch((e) => {
+  //       catchCalled = true
+  //       expect(e.code).toBe(1)
+  //       expect(e.message).toBe('Exit code was 1')
+  //       expect(e.errorOutput).not.toBeDefined()
+  //     })
+  //
+  //   expect(catchCalled).toBe(true)
+  // })
+  // it('should provide the error code and message', async () => {
+  //   let catchCalled = false
+  //
+  //   await exec('echo >&2 "this is the error message"; exit 4')
+  //     .catch((e) => {
+  //       catchCalled = true
+  //       expect(e.code).toBe(4)
+  //       expect(e.message).toBe('Exit code was 4')
+  //       expect(e.errorOutput).toBe('this is the error message\n')
+  //     })
+  //
+  //   expect(catchCalled).toBe(true)
+  // })
+})

--- a/lib/exec.test.js
+++ b/lib/exec.test.js
@@ -1,7 +1,14 @@
 const fs = require('fs')
 const path = require('path')
+const os = require('os')
 
 const exec = require('./exec').exec
+
+const skipOnWindows = (fn) => {
+  if (os.platform() !== 'win32') {
+    fn()
+  }
+}
 
 describe('exec', () => {
   it('should be able to create and delete files', async () => {
@@ -24,40 +31,42 @@ describe('exec', () => {
 
     expect(outputParts[0].trim()).toEqual('hello')
   })
-  // it('should error when a command fails', async () => {
-  //   let catchCalled = false
-  //
-  //   await exec('sadflkajsdfoiewflkjsadf')
-  //     .catch(() => {
-  //       catchCalled = true
-  //     })
-  //
-  //   expect(catchCalled).toBe(true)
-  // })
-  // it('should provide the error code and message', async () => {
-  //   let catchCalled = false
-  //
-  //   await exec('which asldfkj')
-  //     .catch((e) => {
-  //       catchCalled = true
-  //       expect(e.code).toBe(1)
-  //       expect(e.message).toBe('Exit code was 1')
-  //       expect(e.errorOutput).not.toBeDefined()
-  //     })
-  //
-  //   expect(catchCalled).toBe(true)
-  // })
-  // it('should provide the error code and message', async () => {
-  //   let catchCalled = false
-  //
-  //   await exec('echo >&2 "this is the error message"; exit 4')
-  //     .catch((e) => {
-  //       catchCalled = true
-  //       expect(e.code).toBe(4)
-  //       expect(e.message).toBe('Exit code was 4')
-  //       expect(e.errorOutput).toBe('this is the error message\n')
-  //     })
-  //
-  //   expect(catchCalled).toBe(true)
-  // })
+  skipOnWindows(() => {
+    it('should error when a command fails', async () => {
+      let catchCalled = false
+
+      await exec('sadflkajsdfoiewflkjsadf')
+        .catch(() => {
+          catchCalled = true
+        })
+
+      expect(catchCalled).toBe(true)
+    })
+    it('should provide the error code and message', async () => {
+      let catchCalled = false
+
+      await exec('which asldfkj')
+        .catch((e) => {
+          catchCalled = true
+          expect(e.code).toBe(1)
+          expect(e.message).toBe('Exit code was 1')
+          expect(e.errorOutput).not.toBeDefined()
+        })
+
+      expect(catchCalled).toBe(true)
+    })
+    it('should provide the error code and message', async () => {
+      let catchCalled = false
+
+      await exec('echo >&2 "this is the error message"; exit 4')
+        .catch((e) => {
+          catchCalled = true
+          expect(e.code).toBe(4)
+          expect(e.message).toBe('Exit code was 4')
+          expect(e.errorOutput).toBe('this is the error message\n')
+        })
+
+      expect(catchCalled).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
The core of this update is to allow the user to opt-out of creating a git repo with the `--version-control=none` command.

To get to that I had to pass argv options through from `create` to `init`, I realised we weren't supporting quote marks and speech marks around options so I've added support for those and used it when passing options through to allow for multi-word options.  I added tests for this.

I also found it hard to deal with error messages when using `exec` while debugging so I added more details on errors from `exec`.  I added tests for this.

I tested with @joelanman on Windows and Mac with and without git, these tests showed up a scenario where the user had `git` but not `which` so I changed the code around to succeed in this circumstance.

We also found that it's quite easy to have an outdated name for your main branch as a default so each git repository we create has a main branch called "main".