### PR TITLE
Simplify Cypress before and after hooks

### DIFF
--- a/cypress/e2e/dev/1-watch-files/watch-config.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-config.cypress.js
@@ -5,8 +5,8 @@ const path = require('path')
 // local dependencies
 const { waitForApplication } = require('../../utils')
 
-const appConfig = path.join(Cypress.env('projectFolder'), 'app', 'config.json')
-const backupAppConfig = path.join(Cypress.env('tempFolder'), 'temp-config.json')
+const appConfigPath = path.join('app', 'config.json')
+const appConfig = path.join(Cypress.env('projectFolder'), appConfigPath)
 
 const originalText = 'Service name goes here'
 const newText = 'Cypress test'
@@ -16,19 +16,13 @@ const serverNameQuery = 'a.govuk-header__link.govuk-header__service-name, a.govu
 describe('watch config file', () => {
   describe(`service name in config file ${appConfig} should be changed and restored`, () => {
     before(() => {
+      // Restore config.json from prototype starter
+      cy.task('copyFromStarterFiles', { filename: appConfigPath })
       waitForApplication()
-      // backup config.json
-      cy.task('copyFile', { source: appConfig, target: backupAppConfig })
-      waitForApplication()
-    })
-
-    after(() => {
-      // restore config.json
-      cy.task('copyFile', { source: backupAppConfig, target: appConfig })
-      cy.task('deleteFile', { filename: backupAppConfig })
     })
 
     it('The service name should change to "cypress test"', () => {
+      cy.visit('/')
       cy.get(serverNameQuery).should('contains.text', originalText)
       cy.task('replaceTextInFile', { filename: appConfig, originalText, newText })
       waitForApplication()

--- a/cypress/e2e/dev/1-watch-files/watch-custom-styles.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-custom-styles.cypress.js
@@ -16,25 +16,18 @@ const pageFixtureName = `${pageFixture}.html`
 const pageFixturePath = path.join(Cypress.config('fixturesFolder'), 'views', pageFixtureName)
 const pageAppPath = path.join(Cypress.env('projectFolder'), 'app', 'views', pageFixtureName)
 
-function cleanUp () {
-  cy.task('deleteFile', { filename: path.join(Cypress.env('projectFolder'), customStylesPublicPath) })
-  cy.task('deleteFile', { filename: customStylesAppPath })
-  cy.task('deleteFile', { filename: pageAppPath })
-}
-
 describe('watch custom sass files', () => {
   describe(`sass file ${customStylesFixtureName} should be created and linked within ${pageFixturePath} and accessible from the browser as /${customStylesPublicPath}`, () => {
     beforeEach(() => {
+      cy.task('deleteFile', { filename: path.join(Cypress.env('projectFolder'), customStylesPublicPath) })
+      cy.task('deleteFile', { filename: customStylesAppPath })
+      cy.task('deleteFile', { filename: pageAppPath })
       waitForApplication()
-      cleanUp()
-      waitForApplication()
-    })
-
-    afterEach(() => {
-      cleanUp()
     })
 
     it('The colour of the paragraph should be changed to green', () => {
+      cy.visit('/')
+
       // FIXME: the expected behaviour is that it shouldn't make a difference
       // whether the stylesheet exists or not, but currently for Browsersync to
       // update the page properly the stylesheet has to be created first, so we

--- a/cypress/e2e/dev/1-watch-files/watch-images.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-images.cypress.js
@@ -15,21 +15,12 @@ const pageFixtureName = `${pageFixture}.html`
 const pageFixturePath = path.join(Cypress.config('fixturesFolder'), 'views', pageFixtureName)
 const pageAppPath = path.join(Cypress.env('projectFolder'), 'app', 'views', pageFixtureName)
 
-function cleanUp () {
-  cy.task('deleteFile', { filename: path.join(appImages, imageFile) })
-  cy.task('deleteFile', { filename: path.join(Cypress.env('projectFolder'), publicImages, imageFile) })
-  cy.task('deleteFile', { filename: pageAppPath })
-}
-
 describe('watch image files', () => {
   before(() => {
+    cy.task('deleteFile', { filename: path.join(appImages, imageFile) })
+    cy.task('deleteFile', { filename: path.join(Cypress.env('projectFolder'), publicImages, imageFile) })
+    cy.task('deleteFile', { filename: pageAppPath })
     waitForApplication()
-    cleanUp()
-    waitForApplication()
-  })
-
-  afterEach(() => {
-    cleanUp()
   })
 
   it(`image created in ${appImages} should be copied to ${publicImages} and accessible from the browser`, () => {

--- a/cypress/e2e/dev/1-watch-files/watch-javascripts.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-javascripts.cypress.js
@@ -5,20 +5,14 @@ const path = require('path')
 // local dependencies
 const { waitForApplication } = require('../../utils')
 
-const appJs = path.join(Cypress.env('projectFolder'), 'app', 'assets', 'javascripts', 'application.js')
-const backupAppJs = path.join(Cypress.env('tempFolder'), 'temp-application.js')
+const appJsPath = path.join('app', 'assets', 'javascripts', 'application.js')
+const appJs = path.join(Cypress.env('projectFolder'), appJsPath)
 
 describe('watch application.js', () => {
   before(() => {
+    // Restore application.js from prototype starter
+    cy.task('copyFromStarterFiles', { filename: appJsPath })
     waitForApplication()
-
-    // backup application.js
-    cy.task('copyFile', { source: appJs, target: backupAppJs })
-  })
-
-  after(() => {
-    // restore files
-    cy.task('copyFile', { source: backupAppJs, target: appJs })
   })
 
   it('changes to application.js should be reflected in browser', (done) => {

--- a/cypress/e2e/dev/1-watch-files/watch-routes.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-routes.cypress.js
@@ -5,22 +5,17 @@ const path = require('path')
 // local dependencies
 const { waitForApplication } = require('../../utils')
 
+const appRoutesPath = path.join('app', 'routes.js')
+
 const routesFixture = path.join(Cypress.config('fixturesFolder'), 'routes.js')
-const appRoutes = path.join(Cypress.env('projectFolder'), 'app', 'routes.js')
-const backupRoutes = path.join(Cypress.env('tempFolder'), 'temp-routes.js')
+const appRoutes = path.join(Cypress.env('projectFolder'), appRoutesPath)
 const pagePath = '/cypress-test'
 
 describe('watch route file', () => {
   before(() => {
+    // Restore routes file from prototype starter
+    cy.task('copyFromStarterFiles', { filename: appRoutesPath })
     waitForApplication()
-    // backup routes
-    cy.task('copyFile', { source: appRoutes, target: backupRoutes })
-    waitForApplication()
-  })
-
-  after(() => {
-    // delete backup routes
-    cy.task('deleteFile', { filename: backupRoutes })
   })
 
   it(`add and remove ${pagePath} route`, () => {
@@ -39,8 +34,8 @@ describe('watch route file', () => {
     cy.get('h1')
       .should('contains.text', 'CYPRESS TEST PAGE')
 
-    cy.task('log', `Restore ${appRoutes}`)
-    cy.task('copyFile', { source: backupRoutes, target: appRoutes })
+    cy.task('log', `Restore ${appRoutesPath}`)
+    cy.task('copyFromStarterFiles', { filename: appRoutesPath })
 
     waitForApplication()
 

--- a/cypress/e2e/dev/1-watch-files/watch-styles.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-styles.cypress.js
@@ -5,12 +5,14 @@ const path = require('path')
 // local dependencies
 const { waitForApplication } = require('../../utils')
 
-const appStyles = path.join(Cypress.env('projectFolder'), 'app', 'assets', 'sass')
-const appStylesheet = path.join(appStyles, 'application.scss')
+const appStylesPath = path.join('app', 'assets', 'sass')
+const appStylesheetPath = path.join(appStylesPath, 'application.scss')
+const appStylesFolder = path.join(Cypress.env('projectFolder'), appStylesPath)
+const appStylesheet = path.join(Cypress.env('projectFolder'), appStylesheetPath)
+
 const cypressTestStyles = 'cypress-test'
-const cypressTestStylePattern = `${appStyles}/patterns/_${cypressTestStyles}.scss`
+const cypressTestStylePattern = path.join(appStylesFolder, 'patterns', `_${cypressTestStyles}.scss`)
 const publicStylesheet = 'public/stylesheets/application.css'
-const backupAppStylesheet = path.join(Cypress.env('tempFolder'), 'temp-application.scss')
 
 const RED = 'rgb(255, 0, 0)'
 const BLACK = 'rgb(11, 12, 12)'
@@ -22,20 +24,11 @@ describe('watch sass files', () => {
     `
 
     before(() => {
-      waitForApplication()
-      // backup application.scss
-      cy.task('copyFile', { source: appStylesheet, target: backupAppStylesheet })
-      waitForApplication()
-    })
-
-    after(() => {
-      // restore files
-      cy.task('copyFile', { source: backupAppStylesheet, target: appStylesheet })
-
       cy.task('deleteFile', { filename: cypressTestStylePattern })
 
-      cy.get('.govuk-header').should('have.css', 'background-color', BLACK)
-      cy.task('deleteFile', { filename: backupAppStylesheet })
+      // Restore application.scss from prototype starter
+      cy.task('copyFromStarterFiles', { filename: appStylesheetPath })
+      waitForApplication()
     })
 
     it('The colour of the header should be changed to red then back to black', () => {

--- a/cypress/e2e/dev/1-watch-files/watch-views.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-views.cypress.js
@@ -11,13 +11,8 @@ const pagePath = '/start'
 
 describe('watching start page', () => {
   before(() => {
-    waitForApplication()
     cy.task('deleteFile', { filename: appView })
     waitForApplication()
-  })
-
-  after(() => {
-    cy.task('deleteFile', { filename: appView })
   })
 
   it('Add and remove the start page', () => {

--- a/cypress/e2e/dev/2-page-component-tests/checkboxes.cypress.js
+++ b/cypress/e2e/dev/2-page-component-tests/checkboxes.cypress.js
@@ -12,16 +12,9 @@ const pagePath = '/checkbox-test'
 
 describe('checkbox tests', () => {
   before(() => {
-    waitForApplication()
-    cy.task('deleteFile', { filename: appView })
     cy.task('log', `Copy ${templatesView} to ${appView}`)
     cy.task('copyFile', { source: templatesView, target: appView })
     waitForApplication()
-  })
-
-  after(() => {
-    waitForApplication()
-    cy.task('deleteFile', { filename: appView })
   })
 
   const loadTestView = async () => {

--- a/cypress/e2e/dev/3-link-page-tests/branching-journey.cypress.js
+++ b/cypress/e2e/dev/3-link-page-tests/branching-journey.cypress.js
@@ -1,7 +1,7 @@
 
 // local dependencies
 const { waitForApplication } = require('../../utils')
-const { setUpPages, setUpBranchingPages, cleanUpPages, cleanUpBranchingPages, backUpRoutes, restoreRoutes } = require('./link-page-utils')
+const { setUpPages, setUpBranchingPages, cleanUpPages, cleanUpBranchingPages, restoreRoutes } = require('./link-page-utils')
 
 const jugglingBallsPath = '/juggling-balls'
 
@@ -10,19 +10,12 @@ const ineligibleHowManyBalls = '1 or 2'
 
 describe('Branching journey', async () => {
   before(() => {
-    waitForApplication()
-    cleanUpPages()
-    cleanUpBranchingPages()
-    backUpRoutes()
-    setUpPages()
-    setUpBranchingPages()
-    waitForApplication()
-  })
-
-  after(() => {
     cleanUpPages()
     cleanUpBranchingPages()
     restoreRoutes()
+    setUpPages()
+    setUpBranchingPages()
+    waitForApplication()
   })
 
   it('eligible journey', () => {

--- a/cypress/e2e/dev/3-link-page-tests/change-answers.cypress.js
+++ b/cypress/e2e/dev/3-link-page-tests/change-answers.cypress.js
@@ -1,7 +1,7 @@
 
 // local dependencies
 const { waitForApplication } = require('../../utils')
-const { setUpPages, setUpData, cleanUpPages, clearUpData } = require('./link-page-utils')
+const { setUpPages, setUpData, cleanUpPages } = require('./link-page-utils')
 
 const checkAnswersPath = '/check-answers'
 
@@ -13,16 +13,10 @@ const defaultMostImpressiveTrick = 'None - I cannot do tricks'
 
 describe('Change answers', async () => {
   before(() => {
-    waitForApplication()
     cleanUpPages()
     setUpPages()
     setUpData()
     waitForApplication()
-  })
-
-  after(() => {
-    clearUpData()
-    cleanUpPages()
   })
 
   it('Change juggling balls journey', () => {

--- a/cypress/e2e/dev/3-link-page-tests/link-index-to-start.cypress.js
+++ b/cypress/e2e/dev/3-link-page-tests/link-index-to-start.cypress.js
@@ -3,11 +3,13 @@
 const path = require('path')
 
 // local dependencies
-const { waitForApplication, copyFile, deleteFile } = require('../../utils')
+const { waitForApplication, copyFile } = require('../../utils')
 
-const appViews = path.join(Cypress.env('projectFolder'), 'app', 'views')
-const indexView = path.join(appViews, 'index.html')
-const startView = path.join(appViews, 'start.html')
+const appViewsPath = path.join('app', 'views')
+const indexViewPath = path.join(appViewsPath, 'index.html')
+
+const indexView = path.join(Cypress.env('projectFolder'), indexViewPath)
+const startView = path.join(Cypress.env('projectFolder'), appViewsPath, 'start.html')
 const templateStartView = path.join(Cypress.config('fixturesFolder'), 'views', 'start.html')
 
 const commentText = '{% include "govuk-prototype-kit/includes/homepage-bottom.njk" %}'
@@ -18,23 +20,14 @@ const linkText = `<a href="/start">${startText}</a>`
 
 describe('Link index page to start page', async () => {
   before(() => {
-    waitForApplication()
     copyFile(templateStartView, startView)
+    cy.task('copyFromStarterFiles', { filename: indexViewPath })
     cy.task('replaceTextInFile', {
       filename: indexView,
       originalText: commentText,
       newText: linkText
     })
     waitForApplication()
-  })
-
-  after(() => {
-    cy.task('replaceTextInFile', {
-      filename: indexView,
-      originalText: linkText,
-      newText: commentText
-    })
-    deleteFile(startView)
   })
 
   it('click start link', () => {

--- a/cypress/e2e/dev/3-link-page-tests/link-page-utils.js
+++ b/cypress/e2e/dev/3-link-page-tests/link-page-utils.js
@@ -29,8 +29,8 @@ const checkAnswersView = path.join(appViews, 'check-answers.html')
 const confirmationView = path.join(appViews, 'confirmation.html')
 const ineligibleView = path.join(appViews, 'ineligible.html')
 
-const appRoutes = path.join(Cypress.env('projectFolder'), 'app', 'routes.js')
-const backedUpRoutes = path.join(Cypress.env('tempFolder'), 'temp-routes.js')
+const appRoutesPath = path.join('app', 'routes.js')
+const appRoutes = path.join(Cypress.env('projectFolder'), appRoutesPath)
 
 const appDataFile = path.join(Cypress.env('projectFolder'), 'app', 'data', 'session-data-defaults.js')
 
@@ -113,13 +113,8 @@ const cleanUpBranchingPages = () => {
   deleteFile(ineligibleView)
 }
 
-const backUpRoutes = () => {
-  copyFile(appRoutes, backedUpRoutes)
-}
-
 const restoreRoutes = () => {
-  copyFile(backedUpRoutes, appRoutes)
-  deleteFile(backedUpRoutes)
+  cy.task('copyFromStarterFiles', { filename: appRoutesPath })
 }
 
 module.exports = {
@@ -129,6 +124,5 @@ module.exports = {
   cleanUpPages,
   cleanUpBranchingPages,
   clearUpData,
-  backUpRoutes,
   restoreRoutes
 }

--- a/cypress/e2e/dev/3-link-page-tests/simple-journey.cypress.js
+++ b/cypress/e2e/dev/3-link-page-tests/simple-journey.cypress.js
@@ -10,21 +10,16 @@ const mostImpressiveTrick = 'Standing on my head'
 
 describe('Question journey', async () => {
   before(() => {
-    waitForApplication()
     cleanUpPages()
     setUpPages()
     waitForApplication()
-  })
-
-  after(() => {
-    cleanUpPages()
   })
 
   it('Happy path journey', () => {
     // Visit start page and click start
     cy.task('log', 'The start page should be displayed')
     cy.visit(startPath)
-    cy.get('h1').should('contains.text', 'Service name goes here')
+    cy.get('body').should('contains.text', 'Start now')
     cy.get('a.govuk-button--start').click()
 
     // On Juggling balls page, click continue

--- a/cypress/e2e/dev/4-step-by-step-tests/step-by-step-journey.cypress.js
+++ b/cypress/e2e/dev/4-step-by-step-tests/step-by-step-journey.cypress.js
@@ -3,7 +3,7 @@
 const path = require('path')
 
 // local dependencies
-const { copyFile, deleteFile, waitForApplication } = require('../../utils')
+const { copyFile, waitForApplication } = require('../../utils')
 const {
   assertHidden,
   assertVisible,
@@ -35,13 +35,8 @@ stepByStepTestData.forEach(({ name, heading, title1, title2 }) => {
 
   describe(`${name} journey`, async () => {
     before(() => {
-      waitForApplication()
       copyFile(stepByStepTemplateView, stepByStepView)
       waitForApplication()
-    })
-
-    after(() => {
-      deleteFile(stepByStepView)
     })
 
     const loadPage = async () => {

--- a/cypress/e2e/dev/5-plugin-tests/install-plugin-test.cypress.js
+++ b/cypress/e2e/dev/5-plugin-tests/install-plugin-test.cypress.js
@@ -3,7 +3,7 @@
 const path = require('path')
 
 // local dependencies
-const { waitForApplication, installPlugin, uninstallPlugin, deleteFile, createFile } = require('../../utils')
+const { waitForApplication, installPlugin, uninstallPlugin, createFile } = require('../../utils')
 
 const appViews = path.join(Cypress.env('projectFolder'), 'app', 'views')
 const pluginBazView = path.join(appViews, 'plugin-baz.html')
@@ -30,26 +30,15 @@ const pluginBazViewMarkup = `
 {% endblock %}
 `
 
-const cleanup = () => {
-  deleteFile(pluginBazView)
-  uninstallPlugin('plugin-baz')
-}
-
 describe('Single Plugin Test', async () => {
   before(() => {
-    waitForApplication()
-    cleanup()
+    uninstallPlugin('plugin-baz')
     cy.task('notExistsFile', { filename: pluginPackageJson, timeout: 15000 })
     cy.wait(5000)
     createFile(pluginBazView, { data: pluginBazViewMarkup })
-    cy.task('createFile', { filename: pluginBazView, data: pluginBazViewMarkup })
     installPlugin(`file:${pluginLocation}`)
     cy.task('existsFile', { filename: pluginPackageJson, timeout: 15000 })
     cy.wait(5000)
-  })
-
-  after(() => {
-    cleanup()
   })
 
   it('Loads plugin-baz view correctly', () => {

--- a/cypress/e2e/dev/5-plugin-tests/multi-combined-plugin-test.cypress.js
+++ b/cypress/e2e/dev/5-plugin-tests/multi-combined-plugin-test.cypress.js
@@ -35,13 +35,8 @@ const pluginFooBarCombinedViewMarkup = `
 
 describe('Multiple Plugin test', async () => {
   before(() => {
-    waitForApplication()
     cy.task('createFile', { filename: pluginFooBarView, data: pluginFooBarCombinedViewMarkup })
-  })
-
-  after(() => {
-    // clean up
-    cy.task('deleteFile', { filename: pluginFooBarView })
+    waitForApplication()
   })
 
   describe('Plugin Bar', () => {

--- a/cypress/e2e/dev/5-plugin-tests/multi-plugin-test.cypress.js
+++ b/cypress/e2e/dev/5-plugin-tests/multi-plugin-test.cypress.js
@@ -34,13 +34,8 @@ const pluginFooBarSeparatedViewMarkup = `
 
 describe('Plugins test', async () => {
   before(() => {
-    waitForApplication()
     cy.task('createFile', { filename: pluginFooBarView, data: pluginFooBarSeparatedViewMarkup })
-  })
-
-  after(() => {
-    // clean up
-    cy.task('deleteFile', { filename: pluginFooBarView })
+    waitForApplication()
   })
 
   describe('Plugin Bar', () => {

--- a/cypress/e2e/dev/5-plugin-tests/single-plugin-test.cypress.js
+++ b/cypress/e2e/dev/5-plugin-tests/single-plugin-test.cypress.js
@@ -30,13 +30,8 @@ const pluginFooViewMarkup = `
 
 describe('Single Plugin Test', async () => {
   before(() => {
-    waitForApplication()
     cy.task('createFile', { filename: pluginFooView, data: pluginFooViewMarkup })
-  })
-
-  after(() => {
-    // clean up
-    cy.task('deleteFile', { filename: pluginFooView })
+    waitForApplication()
   })
 
   it('Loads plugin-foo view correctly', () => {

--- a/cypress/e2e/dev/6-management-tests/change-service-name.cypress.js
+++ b/cypress/e2e/dev/6-management-tests/change-service-name.cypress.js
@@ -5,10 +5,9 @@ const path = require('path')
 // local dependencies
 const { waitForApplication } = require('../../utils')
 
+const appIndexPath = path.join('app', 'views', 'index.html')
 const appConfigPath = path.join('app', 'config.json')
-
 const appConfig = path.join(Cypress.env('projectFolder'), appConfigPath)
-const backupAppConfig = path.join(Cypress.env('tempFolder'), 'temp-config.js')
 
 const originalText = 'Service name goes here'
 const newText = 'Cypress test'
@@ -19,20 +18,15 @@ const managePagePath = '/manage-prototype'
 
 describe('change service name', () => {
   before(() => {
+    // Restore index.html and config.json from prototype starter
+    cy.task('copyFromStarterFiles', { filename: appConfigPath })
+    cy.task('copyFromStarterFiles', { filename: appIndexPath })
     waitForApplication()
-    // backup config.js
-    cy.task('copyFile', { source: appConfig, target: backupAppConfig })
-    waitForApplication()
-  })
-
-  after(() => {
-    // restore config.js
-    cy.task('copyFile', { source: backupAppConfig, target: appConfig })
-    cy.task('deleteFile', { filename: backupAppConfig })
   })
 
   it('The service name should change to "cypress test" and the task should be set to "Done"', () => {
     cy.task('log', 'Visit the index page and navigate to the manage your prototype page')
+    cy.visit('/')
     cy.get('.govuk-heading-xl').should('contains.text', originalText)
     cy.get('p strong').should('contains.text', appConfigPath)
     cy.get(`main a[href="${managePagePath}"]`).should('contains.text', 'Manage your prototype').click()

--- a/cypress/e2e/dev/6-management-tests/clear-data-page.cypress.js
+++ b/cypress/e2e/dev/6-management-tests/clear-data-page.cypress.js
@@ -3,7 +3,12 @@
 const path = require('path')
 
 // local dependencies
-const { copyFile, deleteFile, createFile, replaceInFile } = require('../../utils')
+const {
+  copyFile,
+  createFile,
+  replaceInFile,
+  waitForApplication
+} = require('../../utils')
 
 const appViews = path.join(Cypress.env('projectFolder'), 'app', 'views')
 const templates = path.join(Cypress.config('fixturesFolder'), 'views')
@@ -47,12 +52,8 @@ describe('clear data page', () => {
     replaceInFile(questionView, '<p>[Insert question content here]</p>', questionComponent)
     replaceInFile(questionView, '/url/of/next/page', '', '/question-check')
     createFile(questionCheckView, { data: questionTestMarkUp })
-    cy.task('waitUntilAppRestarts')
-  })
-
-  after(() => {
-    deleteFile(questionView)
-    deleteFile(questionCheckView)
+    cy.task('copyFromStarterFiles', { filename: 'app/data/session-data-defaults.js' })
+    waitForApplication()
   })
 
   it('save and clear data', () => {

--- a/cypress/e2e/dev/6-management-tests/create-new-page-from-template.cypress.js
+++ b/cypress/e2e/dev/6-management-tests/create-new-page-from-template.cypress.js
@@ -17,7 +17,6 @@ const manageTemplatesPagePath = '/manage-prototype/templates'
 
 describe('create new page', () => {
   before(() => {
-    waitForApplication(manageTemplatesPagePath)
     Cypress.on('uncaught:exception', (err, runnable) => {
       // we expect an error with message 'Cannot read properties of undefined (reading 'documentReady')'
       // and don't want to fail the test so we return false
@@ -30,10 +29,6 @@ describe('create new page', () => {
     deleteFile(startPageView)
     deleteFile(validUnicodePageView)
     waitForApplication(manageTemplatesPagePath)
-  })
-
-  after(() => {
-    cy.task('deleteFile', { filename: startPageView })
   })
 
   it('View the start page from the management page', () => {

--- a/cypress/e2e/dev/6-management-tests/edit-home-page.cypress.js
+++ b/cypress/e2e/dev/6-management-tests/edit-home-page.cypress.js
@@ -6,9 +6,8 @@ const path = require('path')
 const { waitForApplication } = require('../../utils')
 
 const appHomePath = path.join('app', 'views', 'index.html')
-
+const appConfigPath = path.join('app', 'config.json')
 const appHome = path.join(Cypress.env('projectFolder'), appHomePath)
-const backupAppHome = path.join(Cypress.env('tempFolder'), 'temp-home.html')
 
 const originalText = 'Service name goes here'
 const newText = 'Cypress test service'
@@ -17,16 +16,10 @@ const managePagePath = '/manage-prototype'
 
 describe('edit home page', () => {
   before(() => {
+    // Restore index.html and config.json from prototype starter
+    cy.task('copyFromStarterFiles', { filename: appHomePath })
+    cy.task('copyFromStarterFiles', { filename: appConfigPath })
     waitForApplication(managePagePath)
-    // backup home.js
-    cy.task('copyFile', { source: appHome, target: backupAppHome })
-    waitForApplication(managePagePath)
-  })
-
-  after(() => {
-    // restore home.js
-    cy.task('copyFile', { source: backupAppHome, target: appHome })
-    cy.task('deleteFile', { filename: backupAppHome })
   })
 
   it(`The home page heading should change to "${newText}" and the task should be set to "Done"`, () => {

--- a/cypress/e2e/dev/7-layout-tests/default-layout.cypress.js
+++ b/cypress/e2e/dev/7-layout-tests/default-layout.cypress.js
@@ -14,7 +14,7 @@ const comments = el => cy.wrap(
     .map(commentNode => '<!--' + commentNode.data + '-->')
 )
 
-after(() => {
+before(() => {
   cy.task('copyFromStarterFiles', { filename: defaultLayoutFilePath })
   waitForApplication()
 })

--- a/cypress/e2e/plugins/0-plugins-tests/install-available-plugin.cypress.js
+++ b/cypress/e2e/plugins/0-plugins-tests/install-available-plugin.cypress.js
@@ -19,13 +19,6 @@ const pluginPageTemplate = '/templates/step-by-step-navigation.html'
 const pluginPageTitle = 'Step by step navigation'
 const pluginPagePath = '/step-by-step-navigation'
 
-const cleanup = () => {
-  deleteFile(path.join(appViews, 'step-by-step-navigation.html'))
-  // Make sure plugin version 1 is installed
-  installPlugin(plugin, version1)
-  cy.wait(8000)
-}
-
 const panelProcessingQuery = '[aria-live="polite"] #panel-processing'
 const panelCompleteQuery = '[aria-live="polite"] #panel-complete'
 const panelErrorQuery = '[aria-live="polite"] #panel-error'
@@ -98,11 +91,10 @@ const provePluginFunctionalityFails = () => {
 
 describe('Management plugins: ', () => {
   before(() => {
-    cleanup()
-  })
-
-  after(() => {
-    cleanup()
+    deleteFile(path.join(appViews, 'step-by-step-navigation.html'))
+    // Make sure plugin version 1 is installed
+    installPlugin(plugin, version1)
+    cy.wait(8000)
   })
 
   beforeEach(() => {


### PR DESCRIPTION
Cypress best practice is not to use an `after` hook unless it is strictly necessary [[1]]. This commit refactors all our acceptance tests so that any state setup is done before, not after, the spec. As well as making it easier to see what the state was for a failed test, it also should hopefully mean we can spend less time waiting for the kit to restart.

The downside is that it's more work to isolate each test from each other, as you have to make sure you reset everything that *could* affect the test in the `before` hook, even if you don't change that file in the test itself. As an exercise it does help to improve one's understanding of the test and the kit though!

[1]: https://docs.cypress.io/guides/references/best-practices#Using-after-or-afterEach-hooks