### PR TITLE
Install a specific plugin version

### DIFF
--- a/.github/workflows/test-acceptance.yaml
+++ b/.github/workflows/test-acceptance.yaml
@@ -18,7 +18,7 @@ jobs:
 
     name: Acceptance test kit on Node v${{ matrix.node-version }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 25
+    timeout-minutes: 35
 
     env:
       CYPRESS_CACHE_FOLDER: ~/.cache/Cypress

--- a/lib/assets/javascripts/manage-prototype/manage-plugins.js
+++ b/lib/assets/javascripts/manage-prototype/manage-plugins.js
@@ -1,6 +1,7 @@
 window.GOVUKPrototypeKit.documentReady(() => {
   const params = new URLSearchParams(window.location.search)
   const packageName = params.get('package')
+  const version = params.get('version')
   const mode = params.get('mode') || window.location.pathname.split('/').pop()
   let startTimestamp = ''
   let requestTimeoutId
@@ -44,7 +45,8 @@ window.GOVUKPrototypeKit.documentReady(() => {
       'CSRF-Token': token
     },
     body: JSON.stringify({
-      package: packageName
+      package: packageName,
+      version
     })
   })
 
@@ -60,7 +62,7 @@ window.GOVUKPrototypeKit.documentReady(() => {
     if (timedOut) {
       showErrorStatus()
     } else {
-      postRequest('/manage-prototype/plugins/status')
+      postRequest(`/manage-prototype/plugins/${mode}/status`)
         .then(response => response.json())
         .then(data => {
           requestTimeoutId = setTimeout(() => {

--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -60,12 +60,16 @@ function watchAfterStarting (nodemon) {
     if (added.length) {
       console.log(`Added ${added.join(', ')}`)
     }
-    console.log('Restarting kit')
     nodemon.emit('restart')
   })
 }
 
 function runNodemon (port) {
+  // Let user know about restarts
+  // We also rely on this in acceptance tests
+  const onRestart = () => {
+    console.log('Restarting kit...')
+  }
   // Warn about npm install on crash
   const onCrash = () => {
     console.log(colour.cyan('[nodemon] For missing modules try running `npm install`'))
@@ -90,6 +94,7 @@ function runNodemon (port) {
       'app/assets/*'
     ]
   })
+    .on('restart', onRestart)
     .on('crash', onCrash)
     .on('quit', onQuit)
 }

--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -30,14 +30,24 @@ const latestReleaseVersions = plugins.getKnownPlugins().available
     return { ...releaseVersions, [nextPlugin]: 0 }
   }, { 'govuk-prototype-kit': currentKitVersion })
 
-async function lookupLatestPackageVersion (packageName) {
+async function lookupPackageVersions (packageName) {
   try {
     const packageInfo = await requestHttpsJson(`https://registry.npmjs.org/${encodeURIComponent(packageName)}`)
-    latestReleaseVersions[packageName] = packageInfo['dist-tags'].latest
+    return packageInfo['dist-tags']
   } catch (e) {
     console.log('ignoring error', e.message)
   }
-  return latestReleaseVersions[packageName]
+}
+
+async function isValidVersion (packageName, version) {
+  const distTags = await lookupPackageVersions(packageName) || {}
+  return Object.values(distTags).some(distVersion => distVersion === version)
+}
+
+async function lookupLatestPackageVersion (packageName) {
+  const { latest } = await lookupPackageVersions(packageName) || {}
+  latestReleaseVersions[packageName] = latest
+  return latest
 }
 
 async function updateLatestReleaseVersions () {
@@ -389,8 +399,10 @@ async function prepareForPluginPage () {
 
   installedOut.name = 'Installed'
   installedOut.plugins = []
+  installedOut.status = 'installed'
   availableOut.name = 'Available'
   availableOut.plugins = []
+  availableOut.status = 'available'
 
   all.forEach(packageInfo => {
     if (packageInfo.installedVersion) {
@@ -406,7 +418,7 @@ async function prepareForPluginPage () {
 function getCommand (mode, chosenPlugin) {
   switch (mode) {
     case 'upgrade': return chosenPlugin.upgradeCommand
-    case 'install': return chosenPlugin.installCommand
+    case 'install': return chosenPlugin.version ? `${chosenPlugin.installCommand}@${chosenPlugin.version}` : chosenPlugin.installCommand
     case 'uninstall': return chosenPlugin.uninstallCommand
   }
 }
@@ -455,16 +467,26 @@ async function getPluginsHandler (req, res) {
 
 async function getPluginForRequest (req) {
   const searchPackage = req.query.package || req.body.package
+  const version = req.query.version || req.body.version
+  let chosenPlugin
   if (searchPackage) {
-    return (await getPluginDetails())
+    chosenPlugin = (await getPluginDetails())
       .filter(({ packageName }) => packageName === searchPackage)[0]
+    if (chosenPlugin && version) {
+      if (await isValidVersion(searchPackage, version)) {
+        chosenPlugin.version = version
+      } else {
+        return // chosen plugin will be invalid
+      }
+    }
   }
+  return chosenPlugin
 }
 
-function modeIsComplete (mode, { installedVersion, latestVersion }) {
+function modeIsComplete (mode, { installedVersion, latestVersion, version }) {
   switch (mode) {
     case 'upgrade': return installedVersion === latestVersion
-    case 'install': return !!installedVersion
+    case 'install': return version ? installedVersion === version : !!installedVersion
     case 'uninstall': return !installedVersion
   }
 }
@@ -472,6 +494,7 @@ function modeIsComplete (mode, { installedVersion, latestVersion }) {
 async function getPluginsModeHandler (req, res) {
   const isSameOrigin = req.headers['sec-fetch-site'] === 'same-origin'
   const { mode } = req.params
+  const { version } = req.query
   const verb = verbs[mode]
 
   if (!verb) {
@@ -479,7 +502,7 @@ async function getPluginsModeHandler (req, res) {
     return
   }
 
-  const chosenPlugin = await getPluginForRequest(req) || plugins.preparePackageNameForDisplay(req.query.package)
+  const chosenPlugin = await getPluginForRequest(req) || plugins.preparePackageNameForDisplay(req.query.package, version)
 
   const pageName = `${verb.title} ${chosenPlugin.name}`
 
@@ -505,7 +528,9 @@ async function postPluginsStatusHandler (req, res) {
       status = 'error'
     }
   } catch (e) {
-    console.log(e)
+    if (req.params.mode !== 'uninstall') {
+      console.log(e)
+    }
   }
   res.json({ startTimestamp, status })
 }
@@ -537,16 +562,18 @@ async function postPluginsModeHandler (req, res) {
       status = 'completed'
     } else {
       const command = getCommand(mode, chosenPlugin)
-      exec(command, { cwd: projectDir }).finally(() => {
-        console.log(`Completed ${command}`)
-        // force the application to stop after a delay as nodemon restart does not always work on Windows when running acceptance tests
-        setTimeout(() => {
-          process.exit(1)
-        }, 6000)
-      })
+      exec(command, { cwd: projectDir })
+        .finally(() => {
+          console.log(`Completed ${command}`)
+          // force the application to stop after a delay as nodemon restart does not always work on Windows when running acceptance tests
+          setTimeout(() => {
+            process.exit(1)
+          }, 6000)
+        })
     }
   } catch (e) {
     console.log(e)
+    status = 'error'
   }
   res.json({ startTimestamp, status })
 }

--- a/lib/manage-prototype-handlers.test.js
+++ b/lib/manage-prototype-handlers.test.js
@@ -81,6 +81,9 @@ describe('manage-prototype-handlers', () => {
     fse.readJsonSync.mockReturnValue({})
     req = {
       headers: {},
+      body: {},
+      query: {},
+      params: {},
       originalUrl: '/current-url'
     }
     res = {
@@ -113,9 +116,7 @@ describe('manage-prototype-handlers', () => {
   })
 
   it('getPasswordHandler', () => {
-    req.query = {
-      returnUrl: '/'
-    }
+    req.query.returnUrl = '/'
     getPasswordHandler(req, res)
     expect(res.render).toHaveBeenCalledWith(
       'views/manage-prototype/password.njk',
@@ -129,9 +130,7 @@ describe('manage-prototype-handlers', () => {
     })
 
     it('correct password', () => {
-      req.body = {
-        password: 'password'
-      }
+      req.body.password = 'password'
       res.cookie = jest.fn()
       postPasswordHandler(req, res)
       expect(res.cookie).toHaveBeenCalled()
@@ -139,9 +138,7 @@ describe('manage-prototype-handlers', () => {
     })
 
     it('incorrect password', async () => {
-      req.body = {
-        password: 'xxxxx'
-      }
+      req.body.password = 'xxxxx'
       res.cookie = jest.fn()
       postPasswordHandler(req, res)
       expect(res.cookie).not.toHaveBeenCalled()
@@ -186,10 +183,8 @@ describe('manage-prototype-handlers', () => {
     beforeEach(() => {
       mockSend = jest.fn()
       res.status = jest.fn().mockReturnValue({ send: mockSend })
-      req.query = {
-        package: packageName,
-        template: templatePath
-      }
+      req.query.package = packageName
+      req.query.template = templatePath
       res.send = mockSend
       plugins.getByType.mockReturnValue([{
         packageName,
@@ -288,9 +283,7 @@ describe('manage-prototype-handlers', () => {
 
       describe('postTemplatesInstallHandler', () => {
         it('chosen url success', async () => {
-          req.body = {
-            'chosen-url': chosenUrl
-          }
+          req.body['chosen-url'] = chosenUrl
           fse.exists.mockResolvedValue(false)
           await postTemplatesInstallHandler(req, res)
           expect(res.redirect).toHaveBeenCalledWith(
@@ -301,9 +294,7 @@ describe('manage-prototype-handlers', () => {
         describe('chosen url failures', () => {
           const testPostTemplatesInstallHandler = ([errorType, chosenUrl]) => {
             it(`error type is ${errorType} when chosen url is "${chosenUrl}"`, async () => {
-              req.body = {
-                'chosen-url': chosenUrl
-              }
+              req.body['chosen-url'] = chosenUrl
               await postTemplatesInstallHandler(req, res)
               expect(res.redirect).toHaveBeenCalledWith(
                 `${req.originalUrl}?package=${packageName}&template=${encodedTemplatePath}&chosen-url=${encodeURIComponent(chosenUrl)}&errorType=${errorType}`
@@ -345,16 +336,17 @@ describe('manage-prototype-handlers', () => {
   describe('plugins handlers', () => {
     const csrfToken = 'CSRF-TOKEN'
     const packageName = 'test-package'
-    const pluginVersion = '1.0.0'
+    const latestVersion = '2.0.0'
+    const previousVersion = '1.0.0'
     const pluginDisplayName = { name: 'Test Package' }
     const availablePlugin = {
       installCommand: `npm install ${packageName}`,
       installLink: `/manage-prototype/plugins/install?package=${packageName}`,
-      latestVersion: pluginVersion,
+      latestVersion,
       name: pluginDisplayName.name,
       packageName,
       uninstallCommand: `npm uninstall ${packageName}`,
-      upgradeCommand: `npm install ${packageName}@${pluginVersion}`
+      upgradeCommand: `npm install ${packageName}@${latestVersion}`
     }
 
     beforeEach(() => {
@@ -363,7 +355,8 @@ describe('manage-prototype-handlers', () => {
       plugins.getKnownPlugins.mockReturnValue({ available: [packageName] })
       utils.requestHttpsJson.mockResolvedValue({
         'dist-tags': {
-          latest: pluginVersion
+          latest: latestVersion,
+          'latest-1': previousVersion
         }
       })
       fse.readJsonSync.mockReturnValue({
@@ -373,29 +366,23 @@ describe('manage-prototype-handlers', () => {
     })
 
     it('getPluginsHandler', async () => {
-      req.query = {
-        mode: 'install'
-      }
+      req.query.mode = 'install'
       await getPluginsHandler(req, res)
       expect(res.render).toHaveBeenCalledWith(
         'views/manage-prototype/plugins.njk',
         expect.objectContaining({
           currentPage: 'Plugins',
           groupsOfPlugins: [
-            { name: 'Installed', plugins: [] },
-            { name: 'Available', plugins: [availablePlugin] }
+            { name: 'Installed', plugins: [], status: 'installed' },
+            { name: 'Available', plugins: [availablePlugin], status: 'available' }
           ]
         })
       )
     })
 
     it('getPluginsModeHandler', async () => {
-      req.params = {
-        mode: 'install'
-      }
-      req.query = {
-        package: packageName
-      }
+      req.params.mode = 'install'
+      req.query.package = packageName
       req.csrfToken = jest.fn().mockReturnValue(csrfToken)
       await getPluginsModeHandler(req, res)
       expect(res.render).toHaveBeenCalledWith(
@@ -412,10 +399,12 @@ describe('manage-prototype-handlers', () => {
     })
 
     describe('postPluginsStatusHandler', () => {
+      beforeEach(() => {
+        req.params.mode = 'install'
+      })
+
       it('is processing', async () => {
-        req.query = {
-          package: packageName
-        }
+        req.query.package = packageName
         await postPluginsStatusHandler(req, res)
         expect(res.json).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -425,9 +414,7 @@ describe('manage-prototype-handlers', () => {
       })
 
       it('is in error', async () => {
-        req.query = {
-          package: 'invalid-package'
-        }
+        req.query.package = 'invalid-package'
         await postPluginsStatusHandler(req, res)
         expect(res.json).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -453,13 +440,8 @@ describe('manage-prototype-handlers', () => {
 
     describe('postPluginsModeHandler', () => {
       beforeEach(() => {
-        req.params = {
-          mode: 'install'
-        }
-        req.query = {}
-        req.body = {
-          package: packageName
-        }
+        req.params.mode = 'install'
+        req.body.package = packageName
       })
 
       it('processing', async () => {
@@ -475,10 +457,34 @@ describe('manage-prototype-handlers', () => {
         )
       })
 
-      it('error', async () => {
-        req.body = {
-          package: 'invalid-package'
-        }
+      it('processing specific version', async () => {
+        req.body.version = previousVersion
+        availablePlugin.installCommand += `@${previousVersion}`
+        await postPluginsModeHandler(req, res)
+        expect(exec.exec).toHaveBeenCalledWith(
+          availablePlugin.installCommand,
+          { cwd: projectDir }
+        )
+        expect(res.json).toHaveBeenCalledWith(
+          expect.objectContaining({
+            status: 'processing'
+          })
+        )
+      })
+
+      it('error invalid package', async () => {
+        req.body.package = 'invalid-package'
+        await postPluginsModeHandler(req, res)
+        expect(exec.exec).not.toHaveBeenCalled()
+        expect(res.json).toHaveBeenCalledWith(
+          expect.objectContaining({
+            status: 'error'
+          })
+        )
+      })
+
+      it('error invalid version', async () => {
+        req.body.version = '1.0.0-invalid'
         await postPluginsModeHandler(req, res)
         expect(exec.exec).not.toHaveBeenCalled()
         expect(res.json).toHaveBeenCalledWith(

--- a/lib/manage-prototype-routes.js
+++ b/lib/manage-prototype-routes.js
@@ -59,9 +59,9 @@ router.get('/templates/post-install', getTemplatesPostInstallHandler)
 
 router.get('/plugins', getPluginsHandler)
 
-router.get('/plugins/:mode', csrfProtection, getPluginsModeHandler)
+router.post('/plugins/:mode/status', postPluginsStatusHandler)
 
-router.post('/plugins/status', postPluginsStatusHandler)
+router.get('/plugins/:mode', csrfProtection, getPluginsModeHandler)
 
 router.post('/plugins/:mode', postPluginsModeMiddleware)
 

--- a/lib/nunjucks/views/manage-prototype/plugin-install-or-uninstall.njk
+++ b/lib/nunjucks/views/manage-prototype/plugin-install-or-uninstall.njk
@@ -11,7 +11,7 @@
       <h1 class="govuk-heading-l">Plugins</h1>
 
       <h2 class="govuk-heading-m">
-        {{ verb.title }} {{ chosenPlugin.name }} {% if chosenPlugin.scope %} from {{ chosenPlugin.scope }} {% endif %}
+        {{ verb.title }} {{ chosenPlugin.name }} {% if chosenPlugin.version %} version {{ chosenPlugin.version }} {% endif %} {% if chosenPlugin.scope %} from {{ chosenPlugin.scope }} {% endif %}
       </h2>
 
       <div id="panel-manual-instructions" class="govuk-prototype-kit-manage-prototype-plugin-instructions js-hidden">

--- a/lib/nunjucks/views/manage-prototype/plugins.njk
+++ b/lib/nunjucks/views/manage-prototype/plugins.njk
@@ -15,9 +15,9 @@
       {% for group in groupsOfPlugins %}
         <h2 class="govuk-heading-m">{{ group.name }}</h2>
 
-        <ul class="govuk-list govuk-prototype-kit-manage-prototype-plugin-list-plugin-list">
+        <ul class="govuk-list govuk-prototype-kit-manage-prototype-plugin-list-plugin-list" data-plugin-group-status="{{ group.status }}">
           {% for plugin in group.plugins %}
-            <li class="govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item">
+            <li class="govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item" data-plugin-package-name="{{ plugin.packageName }}">
               <span class="govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item-name">
                 {{ plugin.name }}
                 {% if plugin.scope %}

--- a/lib/plugins/plugins.js
+++ b/lib/plugins/plugins.js
@@ -218,21 +218,23 @@ function prepareName (name) {
     .map(prepareWordForPackageNameDisplay).join(' ')
 }
 
-function preparePackageNameForDisplay (packageName) {
+function preparePackageNameForDisplay (packageName, version) {
   const safePackageName = (packageName || '')
 
+  const packageNameDetails = {}
+
   if (safePackageName.startsWith('@')) {
-    const name = prepareName(safePackageName.split('/')[1])
-    const scope = prepareName(safePackageName.split('/')[0].split('@')[1])
-    return {
-      name,
-      scope
-    }
+    packageNameDetails.name = prepareName(safePackageName.split('/')[1])
+    packageNameDetails.scope = prepareName(safePackageName.split('/')[0].split('@')[1])
   } else {
-    return {
-      name: prepareName(safePackageName)
-    }
+    packageNameDetails.name = prepareName(safePackageName)
   }
+
+  if (version) {
+    packageNameDetails.version = version
+  }
+
+  return packageNameDetails
 }
 
 function listInstalledPlugins () {


### PR DESCRIPTION
This is based and expanded from some of the experimental ideas that Laurence had worked on prior to leaving the team.  This PR is here so that the work is not lost.  Some of the unfinished work has been expanded to give the functionality to install a specific plugin version as will be required soon.

The following changes are included:
- Allow the install of a specific plugin version using the UI by linking directly to the install action page including a version in the query string.
- Add validation to check the specific version exists.
- Update plugins unit tests to test for this new functionality.
- Update plugins acceptance tests to test this new functionality.
- Tidy up the declaration of body, query, and params properties within the unit tests for plugins.