### PR TITLE
Provide fallback for people who haven't installed npm modules.

### DIFF
--- a/__tests__/spec/migrate.js
+++ b/__tests__/spec/migrate.js
@@ -72,7 +72,7 @@ describe('migrate test prototype', () => {
     ])
 
     expect(scripts).toEqual({
-      dev: 'govuk-prototype-kit dev',
+      dev: 'govuk-prototype-kit dev || npm install && govuk-prototype-kit dev',
       serve: 'govuk-prototype-kit serve',
       start: 'govuk-prototype-kit start'
     })

--- a/bin/cli
+++ b/bin/cli
@@ -57,7 +57,7 @@ usage-data-config.json
 
 const packageJson = {
   scripts: {
-    dev: 'govuk-prototype-kit dev',
+    dev: 'govuk-prototype-kit dev || npm install && govuk-prototype-kit dev',
     serve: 'govuk-prototype-kit serve',
     start: 'govuk-prototype-kit start'
   }


### PR DESCRIPTION
To test this:

```
npx govuk-prototype-kit create --version=github:alphagov/govuk-prototype-kit#install-on-dev-failure example-kit
cd example-kit
rm -Rf node_modules
npm run dev
```

This emulates one person creating it, pushing it (with `node_modules` ignored as it should be), someone else cloning it and not realising they should install node modules before starting.