### PR TITLE
Correct the change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### New features
+
+- [#1915: Move Task list template to Task list plugin](https://github.com/alphagov/govuk-prototype-kit/pull/1915)
+  The Task list template has been moved to the new
+  [Task list plugin](https://github.com/alphagov/govuk-prototype-kit-task-list)
+
 ## 13.2.1
 
 ### Fixes
@@ -13,9 +19,6 @@
 ### New features
 
 - [#1906: Improved messaging when creating a prototype](https://github.com/alphagov/govuk-prototype-kit/pull/1906)
-- [#1915: Move Task list template to Task list plugin](https://github.com/alphagov/govuk-prototype-kit/pull/1915)
-  The Task list template has been moved to the new
-  [Task list plugin](https://github.com/alphagov/govuk-prototype-kit-task-list)
 
 ### Fixes
 


### PR DESCRIPTION
The change log was updated incorrectly durring a merge for https://github.com/alphagov/govuk-prototype-kit/pull/1915
This moves the entry to the correct position in the file. 