### PR TITLE
Fixing create message

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -26,13 +26,15 @@ const verboseLogger = !argv.options.verbose
   }
 
 const progressLogger = function () {
-  const versionOfInstaller = argv.options['created-from-version']
-  if (!versionOfInstaller) {
-    return
-  }
-  const version = splitSemverVersion(versionOfInstaller)
-  if (version.major === 13 && version.minor < 2) {
-    return
+  if (argv.command === 'init') {
+    const versionOfInstaller = argv.options['created-from-version']
+    if (!versionOfInstaller) {
+      return
+    }
+    const version = splitSemverVersion(versionOfInstaller)
+    if (version.major === 13 && version.minor < 2) {
+      return
+    }
   }
 
   console.log(' - ', ...arguments)


### PR DESCRIPTION
When we released `v13.2.0` and `v13.2.1` we knew we had to work with situations where an older installer creates a new version of the kit.  What we implemented  in `v13.2.0` worked with a new installer but not an old installer, what we implemented in `v13.2.1` works with an old installer but not with a new installer.  This version recognises that `create` and `init` need to be handled separately even though they're in the same file because they can be run from different versions.

To test the current live version:

`npx govuk-prototype-kit@13.2.1 create ~/somewhere`

To test this version:

`npx govuk-prototype-kit@github:alphagov/govuk-prototype-kit#fix-create-message create --version=alphagov/govuk-prototype-kit#fix-create-message ~/somewhere`

You can also mix older versions and newer versions e.g. this installer running with an older kit where you'd expect to see no status messages:

`npx govuk-prototype-kit@github:alphagov/govuk-prototype-kit#fix-create-message create --version=13.0.0 ~/somewhere`

or an older installer running this version of the kit where you'd expect also expect to see no status messages:

`npx govuk-prototype-kit@13.0.0 create --version=alphagov/govuk-prototype-kit#fix-create-message ~/somewhere`

And then the you'll see the full output (three status messages) by running this version of the installer with this version of the kit:

`npx govuk-prototype-kit@github:alphagov/govuk-prototype-kit#fix-create-message create --version=alphagov/govuk-prototype-kit#fix-create-message ~/somewhere`