### PR TITLE
Prevent uninstalling kit from ui

### DIFF
--- a/cypress/e2e/plugins/2-prototype-kit-plugin-tests/prevent-uninstalling-kit-from-ui.cypress.js
+++ b/cypress/e2e/plugins/2-prototype-kit-plugin-tests/prevent-uninstalling-kit-from-ui.cypress.js
@@ -1,0 +1,14 @@
+// local dependencies
+import { failAction, managePluginsPagePath } from '../plugin-utils'
+
+const plugin = 'govuk-prototype-kit'
+const pluginName = 'GOV.UK Prototype Kit'
+
+describe('Prevent uninstalling kit from ui', () => {
+  it('Should fail', () => {
+    cy.visit(`${managePluginsPagePath}/uninstall?package=${plugin}`)
+    cy.get('h2')
+      .should('contains.text', `Uninstall ${pluginName}`)
+    failAction('uninstall')
+  })
+})

--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -23,7 +23,10 @@ const appViews = plugins.getAppViews([
 
 const pkgPath = path.join(projectDir, 'package.json')
 
-const currentKitVersion = require(path.join(packageDir, 'package.json')).version
+const {
+  name: currentKitName,
+  version: currentKitVersion
+} = require(path.join(packageDir, 'package.json'))
 
 const latestReleaseVersions = plugins.getKnownPlugins().available
   .reduce((releaseVersions, nextPlugin) => {
@@ -581,6 +584,12 @@ async function postPluginsModeHandler (req, res) {
   const verb = verbs[mode]
 
   if (!verb) {
+    res.json({ startTimestamp, status: 'error' })
+    return
+  }
+
+  // Prevent uninstalling the kit itself
+  if (req.body.package === currentKitName && mode === 'uninstall') {
     res.json({ startTimestamp, status: 'error' })
     return
   }


### PR DESCRIPTION
Currently it is possible to uninstall the kit directly from a supplied link.  This blocks that action.

Please note this is dependent on [Refactor plugin tests](https://github.com/alphagov/govuk-prototype-kit/pull/1940)