### PR TITLE
Add acceptance tests for task-list plugin

### DIFF
--- a/cypress/e2e/plugins/1-available-plugins-tests/available-plugins.cypress.js
+++ b/cypress/e2e/plugins/1-available-plugins-tests/available-plugins.cypress.js
@@ -91,4 +91,10 @@ describe('Plugin tests', () => {
       { name: 'Question', filename: 'question.html' }
     ]
   })
+
+  installPluginTests({
+    plugin: '@govuk-prototype-kit/task-list',
+    version: '1.0.0',
+    templates: [{ name: 'Task list', filename: 'task-list.html' }]
+  })
 })


### PR DESCRIPTION
See: 

- [Create task list plugin](https://github.com/alphagov/govuk-prototyp-kit/issues/1913)
- [Move templates and patterns to plugins](https://github.com/alphagov/govuk-prototype-kit/issues/1653)

Note, this is dependent on [Move Common templates to the Common templates plugin](https://github.com/alphagov/govuk-prototype-kit/pull/1923)