### PR TITLE
Allow smooth upgrade from 13.1.0 to 13.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- [#1942: Allow smooth upgrade from 13.1.0 to 13.2.4](https://github.com/alphagov/govuk-prototype-kit/pull/1942)
+
 ## 13.2.3
 
 ### Fixes

--- a/lib/assets/javascripts/manage-prototype/manage-plugins.js
+++ b/lib/assets/javascripts/manage-prototype/manage-plugins.js
@@ -62,6 +62,8 @@ window.GOVUKPrototypeKit.documentReady(() => {
     if (timedOut) {
       showErrorStatus()
     } else {
+      // Be aware that changing this path for monitoring the status of a plugin will affect the
+      // kit upgrade process as the browser request and server route would be out of sync.
       postRequest(`/manage-prototype/plugins/${mode}/status`)
         .then(response => response.json())
         .then(data => {

--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -547,6 +547,13 @@ async function postPluginsModeMiddleware (req, res, next) {
 
 async function postPluginsModeHandler (req, res) {
   const { mode } = req.params
+
+  // Allow smooth upgrade from 13.1.0 as the status route is incorrectly matched
+  if (mode === 'status') {
+    req.params.mode = 'upgrade'
+    return postPluginsStatusHandler(req, res)
+  }
+
   const verb = verbs[mode]
 
   if (!verb) {

--- a/lib/manage-prototype-handlers.test.js
+++ b/lib/manage-prototype-handlers.test.js
@@ -501,6 +501,22 @@ describe('manage-prototype-handlers', () => {
           })
         )
       })
+
+      it('is passed on to the postPluginsStatusHandler when status matches mode during upgrade from 13.1 to 13.2.4 and upwards', async () => {
+        plugins.listInstalledPlugins.mockReturnValue([packageName])
+        req.params.mode = 'status'
+
+        await postPluginsModeHandler(req, res)
+
+        // req.params.mode should change to upgrade
+        expect(req.params.mode).toEqual('upgrade')
+
+        expect(res.json).toHaveBeenCalledWith(
+          expect.objectContaining({
+            status: 'completed'
+          })
+        )
+      })
     })
   })
 })

--- a/lib/manage-prototype-routes.js
+++ b/lib/manage-prototype-routes.js
@@ -59,6 +59,8 @@ router.get('/templates/post-install', getTemplatesPostInstallHandler)
 
 router.get('/plugins', getPluginsHandler)
 
+// Be aware that changing this path for monitoring the status of a plugin will affect the
+// kit upgrade process as the browser request and server route would be out of sync.
 router.post('/plugins/:mode/status', postPluginsStatusHandler)
 
 router.get('/plugins/:mode', csrfProtection, getPluginsModeHandler)


### PR DESCRIPTION
This fix resolves the following:

The **13.1.0** status request from the browser is: **/manage-prototype/plugins/status**
The **13.2.3** route **/manage-prototype/plugins/:mode** is matching the request where a mode of 'status' is not the expected 'install, uninstall, or upgrade'.

This causes the error status to be returned which triggers the error to be displayed.