### PR TITLE
Fix plugin install acceptance tests

### DIFF
--- a/cypress/e2e/plugins/1-available-plugins-tests/install-available-plugin.cypress.js
+++ b/cypress/e2e/plugins/1-available-plugins-tests/install-available-plugin.cypress.js
@@ -2,7 +2,7 @@
 const path = require('path')
 
 // local dependencies
-const { deleteFile } = require('../../utils')
+const { deleteFile, uninstallPlugin } = require('../../utils')
 const {
   failAction,
   performPluginAction,
@@ -58,6 +58,8 @@ const provePluginFunctionalityFails = () => {
 
 describe('Management plugins: ', () => {
   before(() => {
+    uninstallPlugin(plugin)
+    cy.wait(8000)
     deleteFile(path.join(appViews, 'step-by-step-navigation.html'))
   })
 

--- a/cypress/e2e/plugins/plugin-utils.js
+++ b/cypress/e2e/plugins/plugin-utils.js
@@ -30,6 +30,8 @@ function performPluginAction (action, plugin, pluginName) {
   cy.get('h2')
     .contains(`${capitalize(action)} ${pluginName}`)
 
+  const processingText = `${action === 'upgrade' ? 'Upgrad' : action}ing ...`
+
   cy.get(panelCompleteQuery, { timeout: 20000 })
     .should('not.be.visible')
   cy.get(panelCompleteQuery)
@@ -38,7 +40,9 @@ function performPluginAction (action, plugin, pluginName) {
     .should('not.be.visible')
   cy.get(panelProcessingQuery)
     .should('be.visible')
-    .contains(`${capitalize(action === 'upgrade' ? 'Upgrad' : action)}ing ...`)
+    .contains(capitalize(processingText))
+
+  cy.task('log', `The ${plugin} plugin is ${action === 'upgrade' ? 'upgrad' : action}ing`)
 
   cy.get(panelProcessingQuery, { timeout: 20000 })
     .should('not.be.visible')
@@ -48,10 +52,14 @@ function performPluginAction (action, plugin, pluginName) {
     .should('be.visible')
     .contains(`${capitalize(action)} complete`)
 
+  cy.task('log', `The ${plugin} plugin ${action} has completed`)
+
   cy.get('#instructions-complete a')
     .contains('Back to plugins')
     .wait(3000)
     .click()
+
+  cy.task('log', 'Returning to plugins page')
 
   cy.get('h1').contains('Plugins')
 }

--- a/lib/assets/javascripts/manage-prototype/manage-plugins.js
+++ b/lib/assets/javascripts/manage-prototype/manage-plugins.js
@@ -71,7 +71,7 @@ window.GOVUKPrototypeKit.documentReady(() => {
               clearTimeout(actionTimeoutId)
               showErrorStatus()
             } else if (data.status === 'completed') {
-              showCompleteStatus()
+              setTimeout(showCompleteStatus, 2000)
             } else {
               // poll status again if prototype hasn't restarted
               pollStatus()


### PR DESCRIPTION
- This makes the plugins tests more stable by making sure the step-by-step plugin is unistalled before the tests begin.
- Additional logging within the tests themselves was added so the timing of the tests can be observed to be in sync with the kit.
- A delay in the front end of two seconds after receiving the completed status gives the kit extra time to have updated the installed plugins prior to giving the user the option to return to the plugins page.