### PR TITLE
Add script maps

### DIFF
--- a/lib/plugins/plugins.js
+++ b/lib/plugins/plugins.js
@@ -68,14 +68,32 @@ const moduleToPluginConversion = {
 
 const readJsonFile = (filePath) => JSON.parse(fs.readFileSync(filePath, 'utf8'))
 
+const pathIsAlreadyInAssetList = (assetPath, assets) => assets.some((asset) => asset === assetPath || assetPath.startsWith(asset + '/'))
+
+function addScriptMaps (packageName, { scripts = [], assets = [] }) {
+  if (typeof scripts === 'string') {
+    scripts = [scripts]
+  }
+  if (typeof assets === 'string') {
+    assets = [assets]
+  }
+  return scripts.reduce((currentAssets, scriptPath) => {
+    const mapPath = scriptPath + '.map'
+    const pathToMapFile = getPathFromProjectRoot('node_modules', packageName, mapPath)
+    return fs.existsSync(pathToMapFile) && !pathIsAlreadyInAssetList(mapPath, currentAssets) ? [...currentAssets, mapPath] : currentAssets
+  }, assets) || assets
+}
+
 function getPackageConfig (packageName) {
-  if (fs.existsSync(pathToPackageConfigFile(packageName))) {
-    return readJsonFile(pathToPackageConfigFile(packageName))
+  let config
+  const pkgConfigFile = pathToPackageConfigFile(packageName)
+  if (fs.existsSync(pkgConfigFile)) {
+    config = readJsonFile(pkgConfigFile)
   }
   if (Object.prototype.hasOwnProperty.call(moduleToPluginConversion, packageName)) {
-    return moduleToPluginConversion[packageName]
+    config = moduleToPluginConversion[packageName]
   }
-  return {}
+  return config ? { ...config, assets: addScriptMaps(packageName, config) } : {}
 }
 
 /**

--- a/lib/plugins/plugins.test.js
+++ b/lib/plugins/plugins.test.js
@@ -177,6 +177,15 @@ describe('plugins', () => {
 
       expect(plugins.getPublicUrls('assets')).toEqual(['/plugin-assets/mine/abc%3Adef'])
     })
+    it('should include the url for the script mapping file', () => {
+      testScope.fileSystem.writeFile('node_modules/govuk-frontend/govuk/all.js.map'.split('/'), 'dummy mapping file')
+      mockPluginConfig('mine', {})
+      expect(plugins.getPublicUrls('assets')).toContain('/plugin-assets/govuk-frontend/govuk/all.js.map')
+    })
+    it('should not include the url for the script mapping file', () => {
+      mockPluginConfig('mine', {})
+      expect(plugins.getPublicUrls('assets')).not.toContain('/plugin-assets/govuk-frontend/govuk/all.js.map')
+    })
   })
 
   describe('Lookup public URLs with file system paths', () => {


### PR DESCRIPTION
See [Using GOV.UK Frontend 4.5.0, opening dev tools causes an error in the terminal](https://github.com/alphagov/govuk-prototype-kit/issues/1950)

This change will prevent the failure within the browser to load any script mapping file such as govuk-frontend/govuk/all.js.map

To achieve this, the plugin config scripts are parsed to dynamically update the plugin config assets with the location of any matching script map files if they exist.