### PR TITLE
Let cypress test the symptom and not the implementation

### DIFF
--- a/cypress/e2e/dev/1-watch-files/watch-javascripts.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-javascripts.cypress.js
@@ -1,4 +1,3 @@
-
 // core dependencies
 const path = require('path')
 
@@ -8,31 +7,34 @@ const { waitForApplication } = require('../../utils')
 const appJsPath = path.join('app', 'assets', 'javascripts', 'application.js')
 const appJs = path.join(Cypress.env('projectFolder'), appJsPath)
 
+const heading = 'Test Heading'
+
+const scriptToAdd = `
+  document.querySelector("h1").innerHTML = "${heading}"
+`
+
 describe('watch application.js', () => {
   before(() => {
     // Restore application.js from prototype starter
     cy.task('copyFromStarterFiles', { filename: appJsPath })
-    waitForApplication()
   })
 
-  it('changes to application.js should be reflected in browser', (done) => {
-    const onAlert = cy.stub()
-    cy.on('window:alert', onAlert)
+  it('changes to application.js should be reflected in browser', () => {
+    waitForApplication()
+
+    cy.get('h1').should('not.contain.text', heading)
 
     const markerText = '// Add JavaScript here'
-    const newText = markerText + '\n  ' + "window.alert('Test')"
 
     cy.task('replaceTextInFile', {
       filename: appJs,
       originalText: markerText,
-      newText
+      newText: markerText + scriptToAdd
     })
 
-    // wait for page to be reloaded by Browsersync
-    cy.once('window:load', () => {
-      cy.wait(1000)
-      expect(onAlert).to.be.calledWith('Test')
-      done()
-    })
+    cy.get('h1').contains(heading)
+
+    // Restore application.js from prototype starter
+    cy.task('copyFromStarterFiles', { filename: appJsPath })
   })
 })


### PR DESCRIPTION
The original cypress test for watching the update of the application.js file was occasionally problematic as it was testing for the browser sync and not just for the symptom caused by the javascript updating.  The new test just waits for the heading in the page to change which will only happen when the changed application.js script is executed.