### PR TITLE
Make notifications node client available

### DIFF
--- a/__tests__/spec/install.js
+++ b/__tests__/spec/install.js
@@ -9,12 +9,15 @@ const utils = require('../utils')
 const { exec } = require('../../lib/exec')
 
 describe('npm install', () => {
-  const tmpDir = utils.mkdtempSync()
+  let testDir
+
+  beforeAll(async () => {
+    const tmpDir = utils.mkdtempSync()
+    testDir = path.join(tmpDir, 'install-no-optional')
+    await utils.mkPrototype(testDir)
+  })
 
   it('does not install dev dependencies by default', async () => {
-    const testDir = path.join(tmpDir, 'install-no-optional')
-    await utils.mkPrototype(testDir)
-
     await exec(
       'npm install',
       { cwd: testDir }

--- a/known-plugins.json
+++ b/known-plugins.json
@@ -6,7 +6,8 @@
       "@govuk-prototype-kit/step-by-step",
       "@govuk-prototype-kit/task-list",
       "hmrc-frontend",
-      "jquery"
+      "jquery",
+      "notifications-node-client"
     ]
   }
 }

--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -485,8 +485,8 @@ async function getPluginForRequest (req) {
   const version = req.query.version || req.body.version
   let chosenPlugin
   if (searchPackage) {
-    chosenPlugin = (await getPluginDetails())
-      .filter(({ packageName }) => packageName === searchPackage)[0]
+    const pluginDetails = await getPluginDetails()
+    chosenPlugin = pluginDetails.find(({ packageName }) => packageName === searchPackage)
     if (chosenPlugin && version) {
       if (await isValidVersion(searchPackage, version)) {
         chosenPlugin.version = version

--- a/lib/plugins/plugins.js
+++ b/lib/plugins/plugins.js
@@ -58,7 +58,8 @@ const objectMap = (object, mapFn) => Object.keys(object).reduce((result, key) =>
 
 // File utilities
 const getPathFromProjectRoot = (...all) => path.join(...[projectDir].concat(all))
-const pathToPackageConfigFile = packageName => getPathFromProjectRoot('node_modules', packageName, 'govuk-prototype-kit.config.json')
+const pathToPluginConfigFile = packageName => getPathFromProjectRoot('node_modules', packageName, 'govuk-prototype-kit.config.json')
+
 const moduleToPluginConversion = {
   jquery: {
     scripts: ['/dist/jquery.js'],
@@ -68,11 +69,12 @@ const moduleToPluginConversion = {
 
 const readJsonFile = (filePath) => JSON.parse(fs.readFileSync(filePath, 'utf8'))
 
-function getPackageConfig (packageName) {
-  if (fs.existsSync(pathToPackageConfigFile(packageName))) {
-    return readJsonFile(pathToPackageConfigFile(packageName))
+function getPluginConfig (packageName) {
+  const pluginConfigFile = pathToPluginConfigFile(packageName)
+  if (fs.existsSync(pluginConfigFile)) {
+    return readJsonFile(pluginConfigFile)
   }
-  if (Object.prototype.hasOwnProperty.call(moduleToPluginConversion, packageName)) {
+  if (moduleToPluginConversion[packageName]) {
     return moduleToPluginConversion[packageName]
   }
   return {}
@@ -146,7 +148,7 @@ function getPackageNamesInOrder () {
 function getPluginsByType () {
   return getPackageNamesInOrder()
     .reduce((accum, packageName) => Object.assign({}, accum, objectMap(
-      getPackageConfig(packageName),
+      getPluginConfig(packageName),
       (listOfItemsForType, type) => (accum[type] || [])
         .concat([].concat(listOfItemsForType).map(item => ({
           packageName,
@@ -237,18 +239,8 @@ function preparePackageNameForDisplay (packageName, version) {
   return packageNameDetails
 }
 
-function listInstalledPlugins () {
-  const plugins = []
-  Object.keys(pluginsByType).forEach(key => {
-    pluginsByType[key].forEach(config => {
-      const currentPlugin = config.packageName
-      if (!plugins.includes(currentPlugin)) {
-        plugins.push(currentPlugin)
-      }
-    })
-  })
-  return plugins
-}
+const listInstalledPlugins = () => getPackageNamesInOrder()
+  .filter((packageName) => Object.keys(getPluginConfig(packageName)).length || getKnownPlugins().available.includes(packageName))
 
 function expandToIncludeShadowNunjucks (arr) {
   const out = []
@@ -263,7 +255,7 @@ function expandToIncludeShadowNunjucks (arr) {
 function getCurrentPlugins () {
   const pkg = fs.existsSync(pkgPath) ? fse.readJsonSync(pkgPath) : {}
   const dependencies = pkg.dependencies || {}
-  return Object.keys(dependencies).filter((dependency) => fse.pathExistsSync(pathToPackageConfigFile(dependency)))
+  return Object.keys(dependencies).filter((dependency) => fse.pathExistsSync(pathToPluginConfigFile(dependency)))
 }
 
 let previousPlugins = getCurrentPlugins()


### PR DESCRIPTION
See [Make Notify client a Plugin](https://github.com/alphagov/govuk-prototype-kit/issues/1710)

- Added notifications-node-client to the list of known plugins
- Allow known plugins to be installed without a plugin config
- Simplify some of the functionality
- Rename some functions to make them easier for the new starters
- Allow install.js test to pass in windows node 18.x (This shouldn't have been affected by this change, but was)