### PR TITLE
Consolidating common session errors into one easier to read message.

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -18,6 +18,8 @@ const plugins = require('../plugins/plugins')
 const routes = require('../routes/api')
 const { appDir, projectDir } = require('./paths')
 
+let alreadyDisplayedSharedNameError = false
+
 // Tweak the Markdown renderer
 const defaultMarkedRenderer = marked.defaults.renderer || new marked.Renderer()
 
@@ -155,7 +157,7 @@ function matchRoutes (req, res, next) {
   if (path === '') {
     path = 'index'
   }
-
+  
   renderPath(path, res, next)
 }
 
@@ -209,6 +211,13 @@ function sessionFileStoreQuietLogFn (message) {
   if (message.endsWith('Deleting expired sessions')) {
     // session-file-store logs every time it prunes files for expired sessions,
     // but this isn't useful for our users, so let's just swallow those messages
+    return
+  }
+  if (message.startsWith('[session-file-store] will retry, error on last attempt')) {
+    if (!alreadyDisplayedSharedNameError) {
+      alreadyDisplayedSharedNameError = true
+      console.log('There was a problem loading session, this can happen with more than one prototype sharing a name.  This shouldn\'t cause any further problems.')
+    }
     return
   }
   console.log(message)


### PR DESCRIPTION
The following console logs show up regularly for me:

```
[session-file-store] will retry, error on last attempt: Error: ENOENT: no such file or directory, open '/Users/natalie.carey/projects/prototype-kits/companion-prototype-kit/.tmp/sessions/WSerxmSthkoRku_lXY6etQJT-wHExmxL.json'
[session-file-store] will retry, error on last attempt: Error: ENOENT: no such file or directory, open '/Users/natalie.carey/projects/prototype-kits/companion-prototype-kit/.tmp/sessions/WSerxmSthkoRku_lXY6etQJT-wHExmxL.json'
[session-file-store] will retry, error on last attempt: Error: ENOENT: no such file or directory, open '/Users/natalie.carey/projects/prototype-kits/companion-prototype-kit/.tmp/sessions/WSerxmSthkoRku_lXY6etQJT-wHExmxL.json'
[session-file-store] will retry, error on last attempt: Error: ENOENT: no such file or directory, open '/Users/natalie.carey/projects/prototype-kits/companion-prototype-kit/.tmp/sessions/WSerxmSthkoRku_lXY6etQJT-wHExmxL.json'
[session-file-store] will retry, error on last attempt: Error: ENOENT: no such file or directory, open '/Users/natalie.carey/projects/prototype-kits/companion-prototype-kit/.tmp/sessions/WSerxmSthkoRku_lXY6etQJT-wHExmxL.json'
```

It happens when you start two kits with the same service name, that's something that will come up more regularly for us than for most users but it's likely to come up for our users sometimes.  It can be reproduce by running:

```
npx create govuk-prototype-kit --version=13.2.4 kit1
npx create govuk-prototype-kit --version=13.2.4 kit2
cd kit1
npm run dev
[visit the homepage of the kit in the browser]
[in terminal press ^c to close the kit]
cd ../kit2
npm run dev
[visit the homepage of the kit in the browser]
```

I've put in a new error message but I think that wording can be improved.  To see the new message run:

```
npx create govuk-prototype-kit --version=alphagov/govuk-prottoype-kit#session-error-message kit1
npx create govuk-prototype-kit -- version=alphagov/govuk-prottoype-kit#session-error-message kit2
cd kit1
npm run dev
[visit the homepage of the kit in the browser]
[in terminal press ^c to close the kit]
cd ../kit2
npm run dev
[visit the homepage of the kit in the browser]
```