### PR TITLE
Fix permissions bug on managed devices by calling node directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   The Common templates have been moved to the new
   [Common templates plugin](https://github.com/alphagov/govuk-prototype-kit-common-templates)
 
+### Fixes
+
+- [#1972: Fix permissions bug on managed devices by calling Node directly](https://github.com/alphagov/govuk-prototype-kit/pull/1972)
+
 ## 13.2.4
 
 ### Fixes

--- a/__tests__/spec/migrate.js
+++ b/__tests__/spec/migrate.js
@@ -71,9 +71,9 @@ describe('migrate test prototype', () => {
     ])
 
     expect(scripts).toEqual({
-      dev: 'govuk-prototype-kit dev',
-      serve: 'govuk-prototype-kit serve',
-      start: 'govuk-prototype-kit start'
+      dev: 'node node_modules/govuk-prototype-kit/bin/cli dev',
+      serve: 'node node_modules/govuk-prototype-kit/bin/cli serve',
+      start: 'node node_modules/govuk-prototype-kit/bin/cli start'
     })
 
     expect(name).toEqual('test-prototype')

--- a/bin/cli
+++ b/bin/cli
@@ -59,11 +59,13 @@ usage-data-config.json
 .idea
 `.trimStart()
 
+const cliPath = 'node_modules/govuk-prototype-kit/bin/cli'
+
 const packageJson = {
   scripts: {
-    dev: 'govuk-prototype-kit dev',
-    serve: 'govuk-prototype-kit serve',
-    start: 'govuk-prototype-kit start'
+    dev: `node ${cliPath} dev`,
+    serve: `node ${cliPath} serve`,
+    start: `node ${cliPath} start`
   }
 }
 
@@ -244,7 +246,7 @@ async function runCreate () {
 
   progressLogger('Setting up your prototype')
 
-  await spawn('npx', ['govuk-prototype-kit', 'init', runningWithinCreateScriptFlag, installDirectory, `--created-from-version=${kitVersion}`, ...(getArgumentsToPassThrough())], {
+  await spawn('node', [cliPath, 'init', runningWithinCreateScriptFlag, installDirectory, `--created-from-version=${kitVersion}`, ...(getArgumentsToPassThrough())], {
     cwd: installDirectory,
     stdio: 'inherit'
   })
@@ -302,7 +304,7 @@ async function runMigrate () {
 
     await prepareMigration(kitDependency, projectDirectory)
 
-    await spawn('npx', ['govuk-prototype-kit', 'migrate', '--', projectDirectory], {
+    await spawn('node', [cliPath, 'migrate', '--', projectDirectory], {
       stdio: 'inherit'
     })
   } else {


### PR DESCRIPTION
This should fix #1898 

previously: calls to npx, which then executes the cli file (not always allowed)
changed to: a call to node (which is allowed) to run the cli file

I think the logic is also easier to follow - previously npx was executing code in node_modules but that was not clear