### PR TITLE
Remove require leading slash

### DIFF
--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -345,7 +345,7 @@ async function postTemplatesInstallHandler (req, res) {
   await fse.copy(templatePath, installLocation)
 
   // Inject a forward slash if the user hasn't included one
-  if (chosenUrl[0] === '/') {
+  if (chosenUrl[0] !== '/') {
     chosenUrl = '/' + chosenUrl
   }
 

--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -283,7 +283,6 @@ function getTemplatesInstallHandler (req, res) {
         singleSlash: 'Path must not be a single forward slash (/)',
         endsWithSlash: 'Path must not end in a forward slash (/)',
         multipleSlashes: 'must not include a slash followed by another slash (//)',
-        slash: 'Path must begin with a forward slash (/)',
         invalid: 'Path must not include !$&\'()*+,;=:?#[]@.% or space'
       })[req.query.errorType],
       chosenUrl: req.query['chosen-url']
@@ -297,7 +296,7 @@ async function postTemplatesInstallHandler (req, res) {
   const templateConfig = locateTemplateConfig(req)
   const templatePath = path.join(projectDir, 'node_modules', templateConfig.path)
 
-  const chosenUrl = req.body['chosen-url'].trim().normalize()
+  let chosenUrl = req.body['chosen-url'].trim().normalize()
 
   const installLocation = path.join(projectDir, 'app', 'views', `${chosenUrl}.html`)
 
@@ -318,11 +317,6 @@ async function postTemplatesInstallHandler (req, res) {
 
   if (chosenUrl === '/') {
     renderError('singleSlash')
-    return
-  }
-
-  if (chosenUrl[0] !== '/') {
-    renderError('slash')
     return
   }
 
@@ -349,6 +343,11 @@ async function postTemplatesInstallHandler (req, res) {
 
   await fse.ensureDir(path.dirname(installLocation))
   await fse.copy(templatePath, installLocation)
+
+  // Inject a forward slash if the user hasn't included one
+  if (chosenUrl[0] === '/') {
+    chosenUrl = '/' + chosenUrl
+  }
 
   res.redirect(`/manage-prototype/templates/post-install?chosen-url=${encodeURIComponent(chosenUrl)}`)
 }

--- a/lib/manage-prototype-handlers.test.js
+++ b/lib/manage-prototype-handlers.test.js
@@ -282,13 +282,26 @@ describe('manage-prototype-handlers', () => {
       })
 
       describe('postTemplatesInstallHandler', () => {
-        it('chosen url success', async () => {
-          req.body['chosen-url'] = chosenUrl
-          fse.exists.mockResolvedValue(false)
-          await postTemplatesInstallHandler(req, res)
-          expect(res.redirect).toHaveBeenCalledWith(
-            `/manage-prototype/templates/post-install?chosen-url=${encodeURIComponent(chosenUrl)}`
-          )
+        describe('chosen url success', () => {
+          beforeEach(() => {
+            fse.exists.mockResolvedValue(false)
+          })
+
+          it('where chosen url starts with a forward slash', async () => {
+            req.body['chosen-url'] = chosenUrl
+            await postTemplatesInstallHandler(req, res)
+            expect(res.redirect).toHaveBeenCalledWith(
+              `/manage-prototype/templates/post-install?chosen-url=${encodeURIComponent(chosenUrl)}`
+            )
+          })
+
+          it('where chosen url does not start with a forward slash', async () => {
+            req.body['chosen-url'] = 'no-forward-slash'
+            await postTemplatesInstallHandler(req, res)
+            expect(res.redirect).toHaveBeenCalledWith(
+              `/manage-prototype/templates/post-install?chosen-url=${encodeURIComponent('/no-forward-slash')}`
+            )
+          })
         })
 
         describe('chosen url failures', () => {

--- a/lib/manage-prototype-handlers.test.js
+++ b/lib/manage-prototype-handlers.test.js
@@ -265,7 +265,6 @@ describe('manage-prototype-handlers', () => {
           singleSlash: 'Path must not be a single forward slash (/)',
           endsWithSlash: 'Path must not end in a forward slash (/)',
           multipleSlashes: 'must not include a slash followed by another slash (//)',
-          slash: 'Path must begin with a forward slash (/)',
           invalid: 'Path must not include !$&\'()*+,;=:?#[]@.% or space'
         }).forEach(([errorType, errorMessage]) => {
           it(`error type is ${errorType}`, async () => {
@@ -308,8 +307,7 @@ describe('manage-prototype-handlers', () => {
             missing: '',
             singleSlash: '/',
             endsWithSlash: '/slash-at-end/',
-            multipleSlashes: '//multiple-slashes',
-            slash: 'no-forward-slash'
+            multipleSlashes: '//multiple-slashes'
           }).forEach(testPostTemplatesInstallHandler)
 
           // Test each invalid character


### PR DESCRIPTION
See: [Don't require a leading slash when creating a page from a template](https://github.com/alphagov/govuk-prototype-kit/issues/1660)

- Made changes to the manage prototype handler
- Updated the unit tests