### PR TITLE
Rollback package scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@
   [Common templates plugin](https://github.com/alphagov/govuk-prototype-kit-common-templates)
 - [#1962: Make GOV.UK Notify client available as a plugin](https://github.com/alphagov/govuk-prototype-kit/pull/1962)
 
-### Fixes
-
-- [#1972: Fix permissions bug on managed devices by calling Node directly](https://github.com/alphagov/govuk-prototype-kit/pull/1972)
-
 ## 13.2.4
 
 ### Fixes

--- a/__tests__/spec/migrate.js
+++ b/__tests__/spec/migrate.js
@@ -71,9 +71,9 @@ describe('migrate test prototype', () => {
     ])
 
     expect(scripts).toEqual({
-      dev: 'node node_modules/govuk-prototype-kit/bin/cli dev',
-      serve: 'node node_modules/govuk-prototype-kit/bin/cli serve',
-      start: 'node node_modules/govuk-prototype-kit/bin/cli start'
+      dev: 'govuk-prototype-kit dev',
+      serve: 'govuk-prototype-kit serve',
+      start: 'govuk-prototype-kit start'
     })
 
     expect(name).toEqual('test-prototype')

--- a/bin/cli
+++ b/bin/cli
@@ -59,13 +59,11 @@ usage-data-config.json
 .idea
 `.trimStart()
 
-const cliPath = 'node_modules/govuk-prototype-kit/bin/cli'
-
 const packageJson = {
   scripts: {
-    dev: `node ${cliPath} dev`,
-    serve: `node ${cliPath} serve`,
-    start: `node ${cliPath} start`
+    dev: 'govuk-prototype-kit dev',
+    serve: 'govuk-prototype-kit serve',
+    start: 'govuk-prototype-kit start'
   }
 }
 
@@ -246,7 +244,7 @@ async function runCreate () {
 
   progressLogger('Setting up your prototype')
 
-  await spawn('node', [cliPath, 'init', runningWithinCreateScriptFlag, installDirectory, `--created-from-version=${kitVersion}`, ...(getArgumentsToPassThrough())], {
+  await spawn('npx', ['govuk-prototype-kit', 'init', runningWithinCreateScriptFlag, installDirectory, `--created-from-version=${kitVersion}`, ...(getArgumentsToPassThrough())], {
     cwd: installDirectory,
     stdio: 'inherit'
   })
@@ -304,7 +302,7 @@ async function runMigrate () {
 
     await prepareMigration(kitDependency, projectDirectory)
 
-    await spawn('node', [cliPath, 'migrate', '--', projectDirectory], {
+    await spawn('npx', ['govuk-prototype-kit', 'migrate', '--', projectDirectory], {
       stdio: 'inherit'
     })
   } else {


### PR DESCRIPTION
The changes made to support GDS Managed Laptops creates a new external interface for the kit code which we'd like to avoid if we can.  This reverts it while we look at our options.