### PR TITLE
Preparing for release 13.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 13.3.0
+
 ### New features
 
 - [#1915: Move Task list template to Task list plugin](https://github.com/alphagov/govuk-prototype-kit/pull/1915)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "govuk-prototype-kit",
-  "version": "13.2.4",
+  "version": "13.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-prototype-kit",
-      "version": "13.2.4",
+      "version": "13.3.0",
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "body-parser": "^1.20.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-prototype-kit",
   "description": "Rapidly create HTML prototypes of GOV.UK services",
-  "version": "13.2.4",
+  "version": "13.3.0",
   "engines": {
     "node": "^16.x || >= 18.x"
   },


### PR DESCRIPTION
New features:

 - GOV.UK Notify client is now available as a plugin. You can install it from the Plugins page in the Manage your prototype section.
 - We have moved all of the templates to plugins to have more flexibility in the future. 
 - When you create a new prototype the common templates are installed by default.
 - When you update an existing prototype, you can install the common templates from the Templates page. 
 - Task list is now a separate plugin.
