### PR TITLE
Auto restart when settings created and removed

### DIFF
--- a/cypress/e2e/dev/1-watch-files/watch-settings-styles.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-settings-styles.cypress.js
@@ -14,31 +14,15 @@ const settingsStyle = path.join(appStylesFolder, `settings.scss`)
 
 const RED = 'rgb(255, 0, 0)'
 
-const oldSettingsContent = `
-h1.govuk-heading-xl { 
-    background-color: ${RED};
-}
-`
-
-const newContent = `
-  {% block stylesheets %}
-    {{ super() }}
-    <link href="/public/stylesheets/settings.css" rel="stylesheet" type="text/css" />
-  {% endblock %}
-  {% block content %}
-  `
-
-const oldContent = '{% block content %}'
+const oldSettingsContent = `$govuk-brand-colour: ${RED}`
 
 describe('watching settings.scss', () => {
 
     before(() => {
         cy.task('deleteFile', { filename: settingsStyle })
-        replaceInFile(indexView, oldContent, '', newContent)
     })
 
     after('', () => {
-        replaceInFile(indexView, newContent, '', oldContent)
         cy.task('deleteFile', { filename: settingsStyle })
     })
 
@@ -50,7 +34,7 @@ describe('watching settings.scss', () => {
         createFile(settingsStyle, { data: oldSettingsContent })
 
         cy.task('log', 'The colour of the header should be changed to red')
-        cy.get('h1.govuk-heading-xl').should('have.css', 'background-color', RED)
+        cy.get('.govuk-header__container').should('have.css', 'border-bottom-color', RED)
     })
 
 })

--- a/cypress/e2e/dev/1-watch-files/watch-settings-styles.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-settings-styles.cypress.js
@@ -1,0 +1,49 @@
+// core dependencies
+const path = require('path')
+
+// local dependencies
+const { waitForApplication, replaceInFile, createFile } = require('../../utils')
+
+const appViews = path.join(Cypress.env('projectFolder'), 'app', 'views')
+const indexView = path.join(appViews, 'index.html')
+
+const appStylesPath = path.join('app', 'assets', 'sass')
+const appStylesFolder = path.join(Cypress.env('projectFolder'), appStylesPath)
+
+const settingsStyle = path.join(appStylesFolder, `settings.scss`)
+const styleContent = `
+body { 
+    color: green; 
+    background: pink;
+}
+`
+const newContent = `<link href="/public/stylesheets/settings.css" rel="stylesheet" type="text/css" />
+
+{% include "./stylesheets-plugins.njk" %}`
+
+const oldContent = `{% include "./stylesheets-plugins.njk" %}`
+
+describe('watching settings.scss', () => {
+    
+    before(() => {
+        cy.task('deleteFile', { filename: settingsStyle })
+        console.log(indexView)
+        createFile(settingsStyle, { data: styleContent })
+        replaceInFile(indexView, oldContent, '', newContent)
+
+    })
+
+    after('', () => {
+        replaceInFile(indexView, newContent, '', oldContent)
+        cy.task('deleteFile', { filename: settingsStyle })
+    })
+
+    it('Successfully reloaed changes', () => {
+        waitForApplication()
+
+        cy.task('log', `Hello Ben!`)
+
+        
+    })
+
+})

--- a/cypress/e2e/dev/1-watch-files/watch-settings-styles.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-settings-styles.cypress.js
@@ -11,26 +11,30 @@ const appStylesPath = path.join('app', 'assets', 'sass')
 const appStylesFolder = path.join(Cypress.env('projectFolder'), appStylesPath)
 
 const settingsStyle = path.join(appStylesFolder, `settings.scss`)
-const styleContent = `
-body { 
-    color: green; 
-    background: pink;
+
+const RED = 'rgb(255, 0, 0)'
+
+const oldSettingsContent = `
+h1.govuk-heading-xl { 
+    background-color: ${RED};
 }
 `
-const newContent = `<link href="/public/stylesheets/settings.css" rel="stylesheet" type="text/css" />
 
-{% include "./stylesheets-plugins.njk" %}`
+const newContent = `
+  {% block stylesheets %}
+    {{ super() }}
+    <link href="/public/stylesheets/settings.css" rel="stylesheet" type="text/css" />
+  {% endblock %}
+  {% block content %}
+  `
 
-const oldContent = `{% include "./stylesheets-plugins.njk" %}`
+const oldContent = '{% block content %}'
 
 describe('watching settings.scss', () => {
-    
+
     before(() => {
         cy.task('deleteFile', { filename: settingsStyle })
-        console.log(indexView)
-        createFile(settingsStyle, { data: styleContent })
         replaceInFile(indexView, oldContent, '', newContent)
-
     })
 
     after('', () => {
@@ -38,12 +42,15 @@ describe('watching settings.scss', () => {
         cy.task('deleteFile', { filename: settingsStyle })
     })
 
-    it('Successfully reloaed changes', () => {
+    it('Successfully reloaded changes', () => {
         waitForApplication()
 
-        cy.task('log', `Hello Ben!`)
+        cy.wait(2000)
 
-        
+        createFile(settingsStyle, { data: oldSettingsContent })
+
+        cy.task('log', 'The colour of the header should be changed to red')
+        cy.get('h1.govuk-heading-xl').should('have.css', 'background-color', RED)
     })
 
 })

--- a/lib/build.js
+++ b/lib/build.js
@@ -140,5 +140,6 @@ function autoImportComponentsSync () {
 
 module.exports = {
   generateAssetsSync,
-  generateCssSync
+  generateCssSync,
+  proxyUserSassIfItExists
 }

--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -9,7 +9,7 @@ const fse = require('fs-extra')
 const nodemon = require('nodemon')
 
 // local dependencies
-const { generateAssetsSync, generateCssSync } = require('./build')
+const { generateAssetsSync, generateCssSync, proxyUserSassIfItExists } = require('./build')
 const plugins = require('./plugins/plugins')
 const { collectDataUsage } = require('./usage-data')
 const utils = require('./utils')
@@ -37,14 +37,22 @@ async function runDevServer () {
   watchAfterStarting(nodemon)
 }
 
+function proxyAndGenerateCssSync (fullFilename) {
+  const filename = fullFilename.split(path.sep).pop().toLowerCase()
+  if (filename === 'settings.scss') {
+    proxyUserSassIfItExists(filename)
+    generateCssSync()
+  }
+}
+
 function watchSass (sassPath) {
   if (!fse.existsSync(sassPath)) return
   chokidar.watch(sassPath, {
     ignoreInitial: true,
     disableGlobbing: true // Prevents square brackets from being mistaken for globbing characters
-  }).on('all', () => {
-    generateCssSync()
-  })
+  }).on('add', proxyAndGenerateCssSync)
+    .on('unlink', proxyAndGenerateCssSync)
+    .on('all', generateCssSync)
 }
 
 function watchBeforeStarting () {

--- a/prototype-starter/app/config.json
+++ b/prototype-starter/app/config.json
@@ -1,3 +1,3 @@
 {
-  "serviceName": "Test Service"
+  "serviceName": "Service name goes here"
 }

--- a/prototype-starter/app/config.json
+++ b/prototype-starter/app/config.json
@@ -1,3 +1,3 @@
 {
-  "serviceName": "Service name goes here"
+  "serviceName": "Test Service"
 }


### PR DESCRIPTION
See [Adding a settings.scss file requires a manual restart](https://github.com/alphagov/govuk-prototype-kit/issues/1945)

- Watch for the creation of the settings.scss file and add the include statement to the proxy sass file for settings.scss
- Watch for the deletion of the settings.scss file and remove the include statement from the proxy sass file for settings.scss
- Add a cypress test to make sure the functionality above works and the page updates as expected with the changes