### PR TITLE
Watching dependencies that are symbolic links.

### DIFF
--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -1,4 +1,3 @@
-
 // node dependencies
 const path = require('path')
 
@@ -22,6 +21,7 @@ const {
 
   publicCssDir
 } = require('./utils/paths')
+const fs = require('fs')
 
 // Build watch and serve
 async function runDevServer () {
@@ -88,10 +88,9 @@ function runNodemon (port) {
     process.exit(0)
   }
 
-  // set PORT so listen-on-port.js knows
-  process.env.PORT = port
+  const nodeModulesPath = path.join(projectDir, 'node_modules')
 
-  return nodemon({
+  const nodemonSettings = {
     watch: [
       path.join(projectDir, '.env'),
       path.join(appDir, '**', '*.js'),
@@ -101,7 +100,41 @@ function runNodemon (port) {
     ignore: [
       'app/assets/*'
     ]
+  }
+
+  const linkedDependencyDirectories = fs.readdirSync(nodeModulesPath).map(dirName => {
+    function getFileInfo (fullPath) {
+      return {
+        isSymLink: fs.lstatSync(fullPath).isSymbolicLink(),
+        fullPath
+      }
+    }
+
+    const fullPath = path.join(nodeModulesPath, dirName)
+    if (dirName.startsWith('@')) {
+      return fs.readdirSync(fullPath).map(fileName => {
+        const fullPathOfSubDir = path.join(fullPath, fileName)
+        return getFileInfo(fullPathOfSubDir)
+      })
+    }
+    return getFileInfo(fullPath)
   })
+    .flat()
+    .filter(({ isSymLink }) => isSymLink)
+
+  if (linkedDependencyDirectories.length > 0) {
+    nodemonSettings.watch.push(...linkedDependencyDirectories.map(({ fullPath }) => [`${fullPath}/**/*.js`, `${fullPath}/**/*.json`]).flat())
+    nodemonSettings.ignoreRoot = ['.git']
+    linkedDependencyDirectories.forEach(({ fullPath }) => {
+      console.log('Watching dependency', fullPath.substring(nodeModulesPath.length + 1), 'as it\'s a symbolic link.')
+    })
+    console.log()
+  }
+
+  // set PORT so listen-on-port.js knows
+
+  process.env.PORT = port
+  return nodemon(nodemonSettings)
     .on('restart', onRestart)
     .on('crash', onCrash)
     .on('quit', onQuit)


### PR DESCRIPTION
When we're developing the kit we use a symbolic link to load our version of the kit into a "companion kit" (any prototype that uses the dev version).  We don't get the benefit of auto restarting when we make changes.  This PR solves that.

If it detects a symbolic link in the `node_modules` directory (including scoped packages) it will watch them for changes and reload the app when `.js` or `.json` files change.

Average users won't have this behaviour as they won't be using symbolic links in their node modules.