### PR TITLE
Making symlinks more reliable when working on the kit

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -14,6 +14,7 @@ const { npmInstall, packageJsonFormat, getPackageVersionFromPackageJson, splitSe
 const currentDirectory = process.cwd()
 const kitRoot = path.join(__dirname, '..')
 const kitVersion = require('../package.json').version
+const kitProjectName = require('../package.json').name
 
 const argv = parse(process.argv, {
   booleans: ['no-version-control', 'verbose', 'running-within-create-script']
@@ -151,7 +152,7 @@ function getChosenKitDependency () {
     return defaultValue
   }
 
-  if (versionRequested === 'local') {
+  if (versionRequested === 'local' || versionRequested === 'local-symlink') {
     return kitRoot
   } else if (versionRequested) {
     if (versionRequested.match(/\d+\.\d+\.\d+/) ||
@@ -235,6 +236,12 @@ async function runCreate () {
   progressLogger('Installing dependencies')
 
   await npmInstall(installDirectory, [kitDependency, 'govuk-frontend', '@govuk-prototype-kit/common-templates'])
+
+  if ((argv.options.version || argv.options.v) === 'local-symlink') {
+    const dependencyInstallLocation = path.join(installDirectory, 'node_modules', kitProjectName)
+    await fs.remove(dependencyInstallLocation)
+    await fs.ensureSymlink(kitDependency, dependencyInstallLocation)
+  }
 
   let runningWithinCreateScriptFlag = '--running-within-create-script'
 

--- a/scripts/refresh-companion-kit
+++ b/scripts/refresh-companion-kit
@@ -1,6 +1,4 @@
 #!/bin/sh
 
-mkdir -p ~/projects/prototype-kits/ && rm -Rf ~/projects/prototype-kits/companion-prototype-kit && ./bin/cli create --version=local ~/projects/prototype-kits/companion-prototype-kit --use-njk-extensions
-rm -Rf ~/projects/prototype-kits/companion-prototype-kit/node_modules/govuk-prototype-kit
-ln -s $(pwd) ~/projects/prototype-kits/companion-prototype-kit/node_modules/govuk-prototype-kit
+mkdir -p ~/projects/prototype-kits/ && rm -Rf ~/projects/prototype-kits/companion-prototype-kit && ./bin/cli create --version=local-symlink ~/projects/prototype-kits/companion-prototype-kit --use-njk-extensions
 echo '{"collectUsageData": false}' > ~/projects/prototype-kits/companion-prototype-kit/usage-data-config.json


### PR DESCRIPTION
On my machine I always get a symlink when I run `create` with `--version=local` but we've had a few people report that it doesn't happen for them.  This introduces `--version=local-symlink` to make sure you're working with a symlink.

I've added this on top of a previous PR (https://github.com/alphagov/govuk-prototype-kit/pull/2015) which watches for changes in symlinked dependencies.

Together these two changes make working on the kit more reliable and smoother.