### PR TITLE
Added performance logging.

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -21,6 +21,7 @@ const {
   publicCssDir,
   shadowNunjucksDir
 } = require('./utils/paths')
+const { startPerformanceTimer, endPerformanceTimer } = require('./utils/performance')
 
 const appSassOptions = {
   filesToSkip: [
@@ -35,6 +36,7 @@ const libSassOptions = {
 }
 
 function generateAssetsSync ({ verbose } = {}) {
+  const timer = startPerformanceTimer()
   plugins.setPluginsByType()
   clean()
   sassPlugins()
@@ -43,6 +45,7 @@ function generateAssetsSync ({ verbose } = {}) {
   proxyUserSassIfItExists('settings.scss')
 
   generateCssSync()
+  endPerformanceTimer('generateAssetsSync', timer)
 }
 
 function clean () {
@@ -57,6 +60,7 @@ function ensureTempDirExists (dir = tmpDir) {
 }
 
 function sassPlugins () {
+  const timer = startPerformanceTimer()
   let fileContents = ''
   // Keep $govuk-extensions-url-context for backwards compatibility
   // TODO: remove in v14
@@ -73,9 +77,11 @@ function sassPlugins () {
     .join('\n')
   ensureTempDirExists(tmpSassDir)
   fse.writeFileSync(path.join(tmpSassDir, '_plugins.scss'), fileContents)
+  endPerformanceTimer('sassPlugins', timer)
 }
 
 function proxyUserSassIfItExists (filename) {
+  const timer = startPerformanceTimer()
   const userFilePath = path.join(projectDir, 'app', 'assets', 'sass', filename)
   const proxyFilePath = path.join(tmpSassDir, 'user', filename)
   const proxyFileLines = []
@@ -85,6 +91,7 @@ function proxyUserSassIfItExists (filename) {
   ensureTempDirExists(path.dirname(proxyFilePath))
 
   fse.writeFileSync(path.join(proxyFilePath), proxyFileLines.join('\n'))
+  endPerformanceTimer('proxyUserSassIfItExists', timer)
 }
 
 function _generateCssSync (sassPath, cssPath, options = {}) {
@@ -112,11 +119,14 @@ function _generateCssSync (sassPath, cssPath, options = {}) {
 }
 
 function generateCssSync () {
+  const timer = startPerformanceTimer()
   _generateCssSync(appSassDir, publicCssDir, appSassOptions)
   _generateCssSync(libSassDir, publicCssDir, libSassOptions)
+  endPerformanceTimer('generateCssSync', timer)
 }
 
 function autoImportComponentsSync () {
+  const timer = startPerformanceTimer()
   const includeString = plugins.getByType('nunjucksMacros').map(({
     item: {
       macroName,
@@ -136,6 +146,7 @@ function autoImportComponentsSync () {
     fse.ensureDirSync(path.dirname(file.shadowPath))
     fse.writeFileSync(file.shadowPath, file.newContents, 'utf8')
   })
+  endPerformanceTimer('autoImportComponentsSync', timer)
 }
 
 module.exports = {

--- a/lib/config.js
+++ b/lib/config.js
@@ -29,6 +29,7 @@ function getConfigFromFile () {
 
 const asNumber = inputString => isString(inputString) ? Number(inputString) : inputString
 const asBoolean = inputString => isString(inputString) ? inputString.toLowerCase() === 'true' : inputString
+const asString = inputString => inputString
 const asJson = inputString => isString(inputString) ? JSON.parse(inputString) : inputString
 
 // Are we running on Glitch.com?
@@ -84,6 +85,9 @@ function getConfig (config) {
   overrideOrDefault('port', 'PORT', asNumber, 3000)
   overrideOrDefault('useBrowserSync', 'USE_BROWSER_SYNC', asBoolean, true)
   overrideOrDefault('useAutoStoreData', 'USE_AUTO_STORE_DATA', asBoolean, true)
+  overrideOrDefault('logPerformance', 'LOG_PERFORMANCE', asBoolean, false)
+  overrideOrDefault('logPerformanceMatching', 'LOG_PERFORMANCE_MATCHING', asString, undefined)
+  overrideOrDefault('logPerformanceSummary', 'LOG_PERFORMANCE_SUMMARY', asNumber, undefined)
 
   if (config.serviceName === undefined) {
     config.serviceName = 'GOV.UK Prototype Kit'

--- a/lib/config.test.js
+++ b/lib/config.test.js
@@ -29,7 +29,8 @@ describe('config', () => {
     isProduction: false,
     isDevelopment: false,
     isTest: true,
-    onGlitch: false
+    onGlitch: false,
+    logPerformance: false
   })
 
   const mergeWithDefaults = (config) => Object.assign({}, defaultConfig, config)

--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -22,6 +22,7 @@ const {
   publicCssDir
 } = require('./utils/paths')
 const fs = require('fs')
+const { logPerformanceSummaryOnce, startPerformanceTimer, endPerformanceTimer } = require('./utils/performance')
 
 // Build watch and serve
 async function runDevServer () {
@@ -73,6 +74,7 @@ function watchAfterStarting (nodemon) {
 }
 
 function runNodemon (port) {
+  const timer = startPerformanceTimer()
   // Let user know about restarts
   // We also rely on this in acceptance tests
   const onRestart = () => {
@@ -134,10 +136,16 @@ function runNodemon (port) {
   // set PORT so listen-on-port.js knows
 
   process.env.PORT = port
-  return nodemon(nodemonSettings)
+  const nodemonInstance = nodemon(nodemonSettings)
     .on('restart', onRestart)
     .on('crash', onCrash)
     .on('quit', onQuit)
+
+  endPerformanceTimer('runDevServer', timer)
+
+  logPerformanceSummaryOnce()
+
+  return nodemonInstance
 }
 
 module.exports = {

--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -29,6 +29,7 @@ const {
   name: currentKitName,
   version: currentKitVersion
 } = require(path.join(packageDir, 'package.json'))
+const { startPerformanceTimer, endPerformanceTimer } = require('./utils/performance')
 
 const latestReleaseVersions = plugins.getKnownPlugins().available
   .reduce((releaseVersions, nextPlugin) => {
@@ -36,10 +37,13 @@ const latestReleaseVersions = plugins.getKnownPlugins().available
   }, { 'govuk-prototype-kit': currentKitVersion })
 
 async function lookupPackageVersions (packageName) {
+  const timer = startPerformanceTimer()
   try {
     const packageInfo = await requestHttpsJson(`https://registry.npmjs.org/${encodeURIComponent(packageName)}`)
+    endPerformanceTimer('lookupPackageVersions (success)', timer)
     return packageInfo['dist-tags']
   } catch (e) {
+    endPerformanceTimer('lookupPackageVersions (failure)', timer)
     console.log('ignoring error', e.message)
   }
 }
@@ -56,7 +60,9 @@ async function lookupLatestPackageVersion (packageName) {
 }
 
 async function updateLatestReleaseVersions () {
+  const timer = startPerformanceTimer()
   await Promise.all(Object.keys(latestReleaseVersions).map(lookupLatestPackageVersion))
+  endPerformanceTimer('updateLatestReleaseVersions', timer)
   return latestReleaseVersions
 }
 

--- a/lib/plugins/plugins.js
+++ b/lib/plugins/plugins.js
@@ -44,6 +44,7 @@ const fse = require('fs-extra')
 // local dependencies
 const appConfig = require('../config')
 const { projectDir, packageDir, shadowNunjucksDir } = require('../utils/paths')
+const { startPerformanceTimer, endPerformanceTimer } = require('../utils/performance')
 const knownPlugins = require(path.join(packageDir, 'known-plugins.json'))
 
 const pkgPath = path.join(projectDir, 'package.json')
@@ -70,13 +71,17 @@ const moduleToPluginConversion = {
 const readJsonFile = (filePath) => JSON.parse(fs.readFileSync(filePath, 'utf8'))
 
 function getPluginConfig (packageName) {
+  const timer = startPerformanceTimer()
   const pluginConfigFile = pathToPluginConfigFile(packageName)
   if (fs.existsSync(pluginConfigFile)) {
+    endPerformanceTimer('getPluginConfig (fileSystem)', timer)
     return readJsonFile(pluginConfigFile)
   }
   if (moduleToPluginConversion[packageName]) {
+    endPerformanceTimer('getPluginConfig (backup)', timer)
     return moduleToPluginConversion[packageName]
   }
+  endPerformanceTimer('getPluginConfig (empty)', timer)
   return {}
 }
 
@@ -146,7 +151,8 @@ function getPackageNamesInOrder () {
  *
  */
 function getPluginsByType () {
-  return getPackageNamesInOrder()
+  const timer = startPerformanceTimer()
+  const result = getPackageNamesInOrder()
     .reduce((accum, packageName) => Object.assign({}, accum, objectMap(
       getPluginConfig(packageName),
       (listOfItemsForType, type) => (accum[type] || [])
@@ -155,6 +161,8 @@ function getPluginsByType () {
           item
         })))
     )), {})
+  endPerformanceTimer('getPluginsByType', timer)
+  return result
 }
 
 let pluginsByType
@@ -254,9 +262,12 @@ function expandToIncludeShadowNunjucks (arr) {
 }
 
 function getCurrentPlugins () {
+  const timer = startPerformanceTimer()
   const pkg = fs.existsSync(pkgPath) ? fse.readJsonSync(pkgPath) : {}
   const dependencies = pkg.dependencies || {}
-  return Object.keys(dependencies).filter((dependency) => fse.pathExistsSync(pathToPluginConfigFile(dependency)))
+  const result = Object.keys(dependencies).filter((dependency) => fse.pathExistsSync(pathToPluginConfigFile(dependency)))
+  endPerformanceTimer('getCurrentPlugins', timer)
+  return result
 }
 
 let previousPlugins = getCurrentPlugins()

--- a/lib/utils/performance.js
+++ b/lib/utils/performance.js
@@ -3,63 +3,68 @@ const config = require('../config').getConfig()
 const noopFn = () => {
 }
 const performanceLog = []
-const startPerformanceTimer = config.logPerformance || config.logPerformanceSummary ? () => process.hrtime() : noopFn
-const endPerformanceTimer = config.logPerformance || config.logPerformanceSummary
-  ? (name, timer) => {
-      const hrTime = process.hrtime(timer)
-      const timeTaken = (hrTime[0] * 1000000 + hrTime[1] / 1000) / 1000
-      addToSummary(name, timeTaken)
-      logPerformance(name, timeTaken)
-    }
-  : noopFn
 const logPerformanceMatching = config.logPerformanceMatching && config.logPerformanceMatching.split(',')
-const logPerformance = config.logPerformance
-  ? logPerformanceMatching
-    ? (name, timeTaken) => {
-        if (logPerformanceMatching.find(str => name.includes(str))) {
-          console.log('Performance: [%s] took [%s]ms', name, timeTaken)
-        }
-      }
-    : (name, timeTaken) => {
-        console.log('Performance: [%s] took [%s]ms', name, timeTaken)
-      }
-  : noopFn
-const addToSummary = config.logPerformanceSummary ? (name, timeTaken) => performanceLog.push({ name, timeTaken }) : noopFn
 
-const logPerformanceSummaryOnce = config.logPerformanceSummary
-  ? () => {
-      const summary = {}
-      const output = {}
-      performanceLog.forEach(({ name, timeTaken }) => {
-        const obj = summary[name] = summary[name] || { total: 0, count: 0 }
-        obj.total += timeTaken
-        obj.count++
-      })
-      Object.keys(summary).forEach((name) => {
-        const item = summary[name]
-        output[name] = {
-          'Average (ms)': (Math.round((item.total / item.count) * 100) / 100),
-          Count: item.count
-        }
-      })
-      console.log('Performance summary:')
-      console.log('')
-      console.table(output)
+const startPerformanceTimerFn = () => process.hrtime()
+
+const endPerformanceTimerFn = (name, timer) => {
+  const hrTime = process.hrtime(timer)
+  const timeTaken = (hrTime[0] * 1000000 + hrTime[1] / 1000) / 1000
+  addToSummary(name, timeTaken)
+  logPerformance(name, timeTaken)
+}
+const addToSummaryFn = (name, timeTaken) => performanceLog.push({ name, timeTaken })
+
+const logMatchingOutcomesOnly = (name, timeTaken) => {
+  if (logPerformanceMatching.find(str => name.includes(str))) {
+    console.log('Performance: [%s] took [%s]ms', name, timeTaken)
+  }
+}
+
+const logAllOutcomes = (name, timeTaken) => {
+  console.log('Performance: [%s] took [%s]ms', name, timeTaken)
+}
+
+const chooseOutcomeLogger = () => logPerformanceMatching ? logMatchingOutcomesOnly : logAllOutcomes
+
+const logPerformanceSummaryFn = () => {
+  const summary = {}
+  const output = {}
+  performanceLog.forEach(({ name, timeTaken }) => {
+    const obj = summary[name] = summary[name] || { total: 0, count: 0 }
+    obj.total += timeTaken
+    obj.count++
+  })
+  Object.keys(summary).forEach((name) => {
+    const item = summary[name]
+    output[name] = {
+      'Average (ms)': (Math.round((item.total / item.count) * 100) / 100),
+      Count: item.count
     }
-  : noopFn
+  })
+  console.log('Performance summary:')
+  console.log('')
+  console.table(output)
+}
 
-if (config.logPerformanceSummary) {
+function getTopLevelModuleFilename () {
   let topLevelModule = module.parent
   while (topLevelModule.parent !== null) {
     topLevelModule = topLevelModule.parent
   }
-  if (topLevelModule.filename.endsWith('listen-on-port.js')) {
-    setInterval(logPerformanceSummaryOnce, config.logPerformanceSummary)
-  }
+  return topLevelModule.filename
+}
+
+const logPerformance = config.logPerformance ? chooseOutcomeLogger() : noopFn
+const addToSummary = config.logPerformanceSummary ? addToSummaryFn : noopFn
+const logPerformanceSummaryOnce = config.logPerformanceSummary ? logPerformanceSummaryFn : noopFn
+
+if (config.logPerformanceSummary && getTopLevelModuleFilename().endsWith('listen-on-port.js')) {
+  setInterval(logPerformanceSummaryOnce, config.logPerformanceSummary)
 }
 
 module.exports = {
-  startPerformanceTimer,
-  endPerformanceTimer,
+  startPerformanceTimer: config.logPerformance || config.logPerformanceSummary ? startPerformanceTimerFn : noopFn,
+  endPerformanceTimer: config.logPerformance || config.logPerformanceSummary ? endPerformanceTimerFn : noopFn,
   logPerformanceSummaryOnce
 }

--- a/lib/utils/performance.js
+++ b/lib/utils/performance.js
@@ -1,0 +1,65 @@
+const config = require('../config').getConfig()
+
+const noopFn = () => {
+}
+const performanceLog = []
+const startPerformanceTimer = config.logPerformance || config.logPerformanceSummary ? () => process.hrtime() : noopFn
+const endPerformanceTimer = config.logPerformance || config.logPerformanceSummary
+  ? (name, timer) => {
+      const hrTime = process.hrtime(timer)
+      const timeTaken = (hrTime[0] * 1000000 + hrTime[1] / 1000) / 1000
+      addToSummary(name, timeTaken)
+      logPerformance(name, timeTaken)
+    }
+  : noopFn
+const logPerformanceMatching = config.logPerformanceMatching && config.logPerformanceMatching.split(',')
+const logPerformance = config.logPerformance
+  ? logPerformanceMatching
+    ? (name, timeTaken) => {
+        if (logPerformanceMatching.find(str => name.includes(str))) {
+          console.log('Performance: [%s] took [%s]ms', name, timeTaken)
+        }
+      }
+    : (name, timeTaken) => {
+        console.log('Performance: [%s] took [%s]ms', name, timeTaken)
+      }
+  : noopFn
+const addToSummary = config.logPerformanceSummary ? (name, timeTaken) => performanceLog.push({ name, timeTaken }) : noopFn
+
+const logPerformanceSummaryOnce = config.logPerformanceSummary
+  ? () => {
+      const summary = {}
+      const output = {}
+      performanceLog.forEach(({ name, timeTaken }) => {
+        const obj = summary[name] = summary[name] || { total: 0, count: 0 }
+        obj.total += timeTaken
+        obj.count++
+      })
+      Object.keys(summary).forEach((name) => {
+        const item = summary[name]
+        output[name] = {
+          'Average (ms)': (Math.round((item.total / item.count) * 100) / 100),
+          Count: item.count
+        }
+      })
+      console.log('Performance summary:')
+      console.log('')
+      console.table(output)
+    }
+  : noopFn
+
+if (config.logPerformanceSummary) {
+  let topLevelModule = module.parent
+  while (topLevelModule.parent !== null) {
+    topLevelModule = topLevelModule.parent
+  }
+  if (topLevelModule.filename.endsWith('listen-on-port.js')) {
+    setInterval(logPerformanceSummaryOnce, config.logPerformanceSummary)
+  }
+}
+
+module.exports = {
+  startPerformanceTimer,
+  endPerformanceTimer,
+  logPerformanceSummaryOnce
+}


### PR DESCRIPTION
To use this you can either edit the `config.json` or set environment variables.  I recommend using the environment variables.  Example usage:

Turn on all fine-grained performance logs:
```
LOG_PERFORMANCE=true npm run dev
```

Log performance summaries every 10 seconds and one performance summary when the dev server has started:

```
LOG_PERFORMANCE_SUMMARY=10000 npm run dev
```

Log performance summaries every 10 seconds (and one performance summary when the dev server has started) as well as all fine-grained performance logs:

```
LOG_PERFORMANCE=true LOG_PERFORMANCE_SUMMARY=10000 npm run dev
```

Only show fine-grained performance logs for one area (matching by partial strings, case sensitive):

```
LOG_PERFORMANCE=true LOG_PERFORMANCE_MATCHING=generateAssetsSync npm run dev
```

Only show fine-grained performance logs for a few areas (matching by partial strings, case sensitive):

```
LOG_PERFORMANCE=true LOG_PERFORMANCE_MATCHING=sass,generateAssetsSync,Css npm run dev
```

Note: I've written this for functionality and efficiency, I've prioritised speed over readability within the `performance.js` file as it's going to be called *a lot* and it would be a shame to degrade performance more than nessesery when adding a performance monitor.  I've particularly focussed on avoiding decreasing the performance when the features are turned off.