### PR TITLE
Fixing errors about session file store (issue 1733)

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -125,7 +125,7 @@ function getSessionMiddleware () {
   const config = getConfig()
   const workingDirectory = process.cwd()
 
-  // Session uses workng directory path to avoid clashes with other prototypes
+  // Session uses working directory path to avoid clashes with other prototypes
   const sessionName = getSessionNameFromWorkingDirectory(workingDirectory)
   const sessionHours = 4
   const sessionOptions = {

--- a/lib/session.js
+++ b/lib/session.js
@@ -117,21 +117,22 @@ function autoStoreData (req, res, next) {
   next()
 }
 
-function getSessionNameFromServiceName (serviceName) {
-  return 'govuk-prototype-kit-' + (Buffer.from(serviceName, 'utf8')).toString('hex')
+function getSessionNameFromServiceName (workingDirectory) {
+  return 'govuk-prototype-kit-' + (Buffer.from(workingDirectory, 'utf8')).toString('hex')
 }
 
 function getSessionMiddleware () {
   const config = getConfig()
+  const workingDirectory = process.cwd()
 
   // Session uses service name to avoid clashes with other prototypes
-  const sessionName = getSessionNameFromServiceName(config.serviceName)
+  const sessionName = getSessionNameFromServiceName(workingDirectory)
   const sessionHours = 4
   const sessionOptions = {
     secret: sessionName,
     cookie: {
       maxAge: 1000 * 60 * 60 * sessionHours,
-      secure: getConfig().isSecure
+      secure: config.isSecure
     }
   }
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -125,7 +125,7 @@ function getSessionMiddleware () {
   const config = getConfig()
   const workingDirectory = process.cwd()
 
-  // Session uses service name to avoid clashes with other prototypes
+  // Session uses workng directory path to avoid clashes with other prototypes
   const sessionName = getSessionNameFromWorkingDirectory(workingDirectory)
   const sessionHours = 4
   const sessionOptions = {

--- a/lib/session.js
+++ b/lib/session.js
@@ -117,7 +117,7 @@ function autoStoreData (req, res, next) {
   next()
 }
 
-function getSessionNameFromServiceName (workingDirectory) {
+function getSessionNameFromWorkingDirectory (workingDirectory) {
   return 'govuk-prototype-kit-' + (Buffer.from(workingDirectory, 'utf8')).toString('hex')
 }
 
@@ -126,7 +126,7 @@ function getSessionMiddleware () {
   const workingDirectory = process.cwd()
 
   // Session uses service name to avoid clashes with other prototypes
-  const sessionName = getSessionNameFromServiceName(workingDirectory)
+  const sessionName = getSessionNameFromWorkingDirectory(workingDirectory)
   const sessionHours = 4
   const sessionOptions = {
     secret: sessionName,
@@ -144,12 +144,18 @@ function getSessionMiddleware () {
     fileStoreOptions.logFn = sessionFileStoreQuietLogFn
   }
 
-  return session(Object.assign(sessionOptions, {
-    name: sessionName,
-    resave: false,
-    saveUninitialized: false,
-    store: new FileStore(fileStoreOptions)
-  }))
+  try {
+    return session(Object.assign(sessionOptions, {
+      name: sessionName,
+      resave: false,
+      saveUninitialized: false,
+      store: new FileStore(fileStoreOptions)
+    }))
+  } catch (err) {
+    err.message.contains('ENOENT: no such file or directory')
+      ? console.error('Warning: Please use different working directories for your prototypes to avoid session clashes')
+      : console.error(err)
+  }
 }
 
 module.exports = {

--- a/lib/session.js
+++ b/lib/session.js
@@ -137,25 +137,20 @@ function getSessionMiddleware () {
   }
 
   const fileStoreOptions = {
-    path: sessionStoreDir
+    path: sessionStoreDir,
+    retries: 1
   }
 
   if (config.isDevelopment) {
     fileStoreOptions.logFn = sessionFileStoreQuietLogFn
   }
 
-  try {
-    return session(Object.assign(sessionOptions, {
-      name: sessionName,
-      resave: false,
-      saveUninitialized: false,
-      store: new FileStore(fileStoreOptions)
-    }))
-  } catch (err) {
-    err.message.contains('ENOENT: no such file or directory')
-      ? console.error('Warning: Please use different working directories for your prototypes to avoid session clashes')
-      : console.error(err)
-  }
+  return session(Object.assign(sessionOptions, {
+    name: sessionName,
+    resave: false,
+    saveUninitialized: false,
+    store: new FileStore(fileStoreOptions)
+  }))
 }
 
 module.exports = {

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -211,6 +211,12 @@ function sessionFileStoreQuietLogFn (message) {
     // but this isn't useful for our users, so let's just swallow those messages
     return
   }
+
+  // Handling case where a user has multiple prototypes in the same working directory by giving a more useful error message
+  if (message.includes('ENOENT')) {
+    console.error('Warning: Please use different working directories for your prototypes to avoid session clashes')
+    return
+  }
   console.log(message)
 }
 


### PR DESCRIPTION
- Using working directory path to create session name now (as the service name was frequently causing clashes)
- Suppressed the number of duplicate error messages logged
- Replaced standard sesssion-file-store warning with a custom warning message which is more useful to the user