### PR TITLE
Preparing release 13.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## Unreleased
 
+## 13.4.0
+
 ### New features
 
 - [#2005: Support user defined global functions](https://github.com/alphagov/govuk-prototype-kit/pull/2005)
   Added support for user defined functions
 
 ### Fixes
-
 
 - [#1982: Remove require leading slash](https://github.com/alphagov/govuk-prototype-kit/pull/1982)
   A leading slash is no longer required when creating a page from a template

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "govuk-prototype-kit",
-  "version": "13.3.0",
+  "version": "13.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-prototype-kit",
-      "version": "13.3.0",
+      "version": "13.4.0",
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "body-parser": "^1.20.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-prototype-kit",
   "description": "Rapidly create HTML prototypes of GOV.UK services",
-  "version": "13.3.0",
+  "version": "13.4.0",
   "engines": {
     "node": "^16.x || >= 18.x"
   },


### PR DESCRIPTION
New Prototype Kit release: 13.4.0

New features:

- When you create a page from a template, you do not need to use a leading slash.
- When you create or remove the settings.scss file, the page styling will update automatically.
- You can now install, upgrade and uninstall different prototype kits at the same time using multiple tabs and windows.
- You can complete an install, upgrade and uninstall with a slow connection.