### PR TITLE
Make it easier to set a page title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@
 
 ### New features
 
+- [#2030: Make it easier to set a page title](https://github.com/alphagov/govuk-prototype-kit/pull/2030)  
+  Set pageName variable on a page and the kit will make a GOV.UK page title for you.  
+  For example `{% set pageName="My example page" %}`
+
 - [#2035: Support html and njk extensions](https://github.com/alphagov/govuk-prototype-kit/pull/2035)  
-  Allows .html and .njk to be used interchangeably: 
+  Allows .html and .njk to be used interchangeably:
   - The default for creating views from templates will be .html, but .njk will be used if the app/config.json contains `"useNjkExtensions": true`.
   - If two views are in the same location with the same name but with different suffixes (html or njk), the default suffix (determined by the existence of the useNjkExtensions setting above) will be matched first followed by the alternative.
 

--- a/cypress/e2e/dev/6-layout-tests/title-variable.cypress.js
+++ b/cypress/e2e/dev/6-layout-tests/title-variable.cypress.js
@@ -14,34 +14,28 @@ it('should allow title to be set in multiple ways', () => {
   waitForApplication()
   cy.visit('/')
 
-  cy.title().should('eq', 'Home - Service name goes here - GOV.UK Prototype Kit')
+  cy.task('log', 'Should display standard home page title')
+
+  cy.title().should('eq', 'Home - Service name goes here - GOV.UK')
+
+  cy.task('log', 'Update index.html using "set pageName" to display customised page title')
 
   cy.task('createFile', {
     filename: path.join(Cypress.env('projectFolder'), indexFile),
     data: `
     {% extends "layouts/main.html" %}
 
-    {% set title="This is my custom title" %}`,
+    {% set pageName="This is my custom title" %}`,
     replace: true
   })
 
   cy.visit('/')
 
-  cy.title().should('eq', 'This is my custom title - Service name goes here - GOV.UK Prototype Kit')
-
-  cy.task('createFile', {
-    filename: path.join(Cypress.env('projectFolder'), indexFile),
-    data: `
-    {% extends "layouts/main.html" %}
-
-    {% set title="This is my custom title" %}
-    {% set titleOrganisation="GOV.UK" %}`,
-    replace: true
-  })
-
-  cy.visit('/')
+  cy.task('log', 'Should display customised page title')
 
   cy.title().should('eq', 'This is my custom title - Service name goes here - GOV.UK')
+
+  cy.task('log', 'Update index.html using "block pageTitle" to display overridden page title')
 
   cy.task('createFile', {
     filename: path.join(Cypress.env('projectFolder'), indexFile),
@@ -55,6 +49,8 @@ it('should allow title to be set in multiple ways', () => {
   })
 
   cy.visit('/')
+
+  cy.task('log', 'Should display overridden page title')
 
   cy.title().should('eq', 'This is my override title')
 })

--- a/cypress/e2e/dev/6-layout-tests/title-variable.cypress.js
+++ b/cypress/e2e/dev/6-layout-tests/title-variable.cypress.js
@@ -1,0 +1,60 @@
+// core dependencies
+const path = require('path')
+
+// local dependencies
+const { waitForApplication } = require('../../utils')
+
+const indexFile = path.join('app', 'views', 'index.html')
+
+before(() => {
+  cy.task('copyFromStarterFiles', { filename: indexFile })
+})
+
+it('should allow title to be set in multiple ways', () => {
+  waitForApplication()
+  cy.visit('/')
+
+  cy.title().should('eq', 'Home - Service name goes here - GOV.UK Prototype Kit')
+
+  cy.task('createFile', {
+    filename: path.join(Cypress.env('projectFolder'), indexFile),
+    data: `
+    {% extends "layouts/main.html" %}
+
+    {% set title="This is my custom title" %}`,
+    replace: true
+  })
+
+  cy.visit('/')
+
+  cy.title().should('eq', 'This is my custom title - Service name goes here - GOV.UK Prototype Kit')
+
+  cy.task('createFile', {
+    filename: path.join(Cypress.env('projectFolder'), indexFile),
+    data: `
+    {% extends "layouts/main.html" %}
+
+    {% set title="This is my custom title" %}
+    {% set titleOrganisation="GOV.UK" %}`,
+    replace: true
+  })
+
+  cy.visit('/')
+
+  cy.title().should('eq', 'This is my custom title - Service name goes here - GOV.UK')
+
+  cy.task('createFile', {
+    filename: path.join(Cypress.env('projectFolder'), indexFile),
+    data: `
+    {% extends "layouts/main.html" %}
+
+    {% block pageTitle %}
+      This is my override title
+    {% endblock %}`,
+    replace: true
+  })
+
+  cy.visit('/')
+
+  cy.title().should('eq', 'This is my override title')
+})

--- a/lib/nunjucks/govuk-prototype-kit/layouts/govuk-branded.njk
+++ b/lib/nunjucks/govuk-prototype-kit/layouts/govuk-branded.njk
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block pageTitle %}
-  GOV.UK Prototype Kit
+  {% if title %}{{ title }} - {% endif %}{{ serviceName }} - GOV.UK
 {% endblock %}
 
 {% block header %}

--- a/lib/nunjucks/govuk-prototype-kit/layouts/govuk-branded.njk
+++ b/lib/nunjucks/govuk-prototype-kit/layouts/govuk-branded.njk
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block pageTitle %}
-  {% if title %}{{ title }} - {% endif %}{{ serviceName }} - {% if titleOrganisation %}{{ titleOrganisation }}{% else %}GOV.UK Prototype Kit{% endif %}
+  {% if pageName %}{{ pageName }} - {% endif %}{{ serviceName }} - GOV.UK
 {% endblock %}
 
 {% block header %}

--- a/lib/nunjucks/govuk-prototype-kit/layouts/govuk-branded.njk
+++ b/lib/nunjucks/govuk-prototype-kit/layouts/govuk-branded.njk
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block pageTitle %}
-  {% if title %}{{ title }} - {% endif %}{{ serviceName }} - GOV.UK
+  {% if title %}{{ title }} - {% endif %}{{ serviceName }} - {% if titleOrganisation %}{{ titleOrganisation }}{% else %}GOV.UK Prototype Kit{% endif %}
 {% endblock %}
 
 {% block header %}

--- a/lib/nunjucks/views/manage-prototype/layout.njk
+++ b/lib/nunjucks/views/manage-prototype/layout.njk
@@ -2,9 +2,9 @@
 
 {% block pageTitle %}
   {% if currentPage !== "Home" %}{{ currentPage }}
-    – {% endif %}Manage your prototype
-  – {{ serviceName }}
-  – GOV.UK Prototype Kit
+    - {% endif %}Manage your prototype
+  - {{ serviceName }}
+  - GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent   %}

--- a/prototype-starter/app/views/index.html
+++ b/prototype-starter/app/views/index.html
@@ -1,8 +1,6 @@
 {% extends "layouts/main.html" %}
 
-{% block pageTitle %}
-Home - {{serviceName}} - GOV.UK Prototype Kit
-{% endblock %}
+{% set pageName="Home" %}
 
 {% block content %}
 

--- a/prototype-starter/app/views/index.html
+++ b/prototype-starter/app/views/index.html
@@ -1,7 +1,7 @@
 {% extends "layouts/main.html" %}
 
 {% block pageTitle %}
-Home – {{serviceName}} – GOV.UK Prototype Kit
+Home - {{serviceName}} - GOV.UK Prototype Kit
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
@frankieroberto [contributed a PR for this](https://github.com/alphagov/govuk-prototype-kit/pull/1976) with the comment "One possible implementation for https://github.com/alphagov/govuk-prototype-kit/issues/1975."

I have taken that PR, added tests and changed the behaviour slightly.  It now works as follows:

 - You can override the `pageTitle` block (as we have recommended so far) which gives you full control over the page title.
 - You can set a `title` variable and the `title` will have ` - <serviceName> - GOV.UK Prototype Kit` added to the end of it
 - You can set a `title` variable and a `titleOrganisation` the `title` will have ` - <serviceName> - <titleOrganisation>` added to the end of it

Next steps:

 - @frankieroberto can you check my PR and make sure it's in line with your expectations.
 - @joelanman and @oli-rose28 can you take a look and see if this is behaviour we want to add to the kit - note I've updated the dash character to match Frankie's PR, I'm not sure which dash is right and which one is wrong but I've avoided a mismatch.  If I've gone the wrong way feel free to change all the dashes in this PR to the correct type.