### PR TITLE
Update extends unbranded correctly during migrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
   - The default for creating views from templates will be .html, but .njk will be used if the app/config.json contains `"useNjkExtensions": true`.
   - If two views are in the same location with the same name but with different suffixes (html or njk), the default suffix (determined by the existence of the useNjkExtensions setting above) will be matched first followed by the alternative.
 
+### Fixes
+
+- [#2050: Update extends unbranded correctly during migrate](https://github.com/alphagov/govuk-prototype-kit/pull/2050)  
+  All occurences of "layout_unbranded.html" within the nunjucks files in the users app folder will be replaced with "govuk-prototype-kit/layouts/unbranded.html" during the migration process.
+
+
 ## 13.4.0
 
 ### New features

--- a/__tests__/fixtures/test-v11-prototype/app/views/nested-test-folder/unbranded-test.html
+++ b/__tests__/fixtures/test-v11-prototype/app/views/nested-test-folder/unbranded-test.html
@@ -1,0 +1,6 @@
+{% extends "layout_unbranded.html" %}
+{% block pageScripts %}
+  <script>
+    console.log('Hello Unbranded')
+  </script>
+{% endblock %}

--- a/__tests__/spec/migrate.js
+++ b/__tests__/spec/migrate.js
@@ -155,6 +155,19 @@ describe('migrate test prototype', () => {
     )
   })
 
+  it('unbranded-test.html should replace unbranded extend', () => {
+    const unbrandedFileContents = getNormalisedFileContent(path.join(appDirectory, 'views', 'nested-test-folder', 'unbranded-test.html'))
+
+    expect(unbrandedFileContents).toEqual(
+      '{% extends "govuk-prototype-kit/layouts/unbranded.html" %}\n' +
+      '{% block pageScripts %}\n' +
+      '  <script>\n' +
+      '    console.log(\'Hello Unbranded\')\n' +
+      '  </script>\n' +
+      '{% endblock %}'
+    )
+  })
+
   it('migrate.log does not contain user home directory', () => {
     const migrateLog = getNormalisedFileContent(path.join(projectDirectory, 'migrate.log'))
 

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -2,6 +2,7 @@
 // core dependencies
 const crypto = require('crypto')
 const fs = require('fs')
+const fsp = fs.promises
 const https = require('https')
 const path = require('path')
 const { existsSync } = require('fs')
@@ -255,6 +256,27 @@ function recursiveDirectoryContentsSync (baseDir) {
   return goThroughDir()
 }
 
+async function searchAndReplaceFiles (dir, searchText, replaceText, extensions) {
+  const files = await fsp.readdir(dir)
+  const modifiedFiles = await Promise.all(files.map(async file => {
+    const filePath = path.join(dir, file)
+    const fileStat = await fsp.stat(filePath)
+
+    if (fileStat.isDirectory()) {
+      return await searchAndReplaceFiles(filePath, searchText, replaceText, extensions)
+    } else if (extensions.some(extension => file.endsWith(extension))) {
+      let fileContent = await fsp.readFile(filePath, 'utf8')
+      if (fileContent.includes(searchText)) {
+        fileContent = fileContent.replace(new RegExp(searchText, 'g'), replaceText)
+        await fsp.writeFile(filePath, fileContent)
+        return filePath
+      }
+    }
+  }))
+
+  return modifiedFiles.flat().filter(Boolean)
+}
+
 module.exports = {
   prototypeAppScripts: scripts,
   addNunjucksFilters,
@@ -268,5 +290,6 @@ module.exports = {
   encryptPassword,
   requestHttpsJson,
   sessionFileStoreQuietLogFn,
+  searchAndReplaceFiles,
   recursiveDirectoryContentsSync
 }

--- a/migrator/index.js
+++ b/migrator/index.js
@@ -17,7 +17,8 @@ const {
   deleteEmptyDirectories,
   upgradeIfUnchanged,
   deleteIfUnchanged,
-  removeOldPatternIncludesFromSassFile
+  removeOldPatternIncludesFromSassFile,
+  updateUnbrandedLayouts
 } = require('./migration-steps')
 
 const supportPage = 'https://prototype-kit.service.gov.uk/docs/support'
@@ -143,6 +144,7 @@ async function migrate () {
       deleteUnusedDirectories(directoriesToDelete),
       upgradeIfUnchanged(filesToUpdateIfUnchanged),
       upgradeLayoutIfUnchanged(),
+      updateUnbrandedLayouts('app/views'),
       deleteIfUnchanged(filesToDeleteIfUnchanged),
       deleteIfUnchanged(patternsToDeleteIfUnchanged)
     ])

--- a/migrator/migration-steps.js
+++ b/migrator/migration-steps.js
@@ -7,6 +7,7 @@ const fse = require('fs-extra')
 const lodash = require('lodash')
 
 // local dependencies
+const { searchAndReplaceFiles } = require('../lib/utils')
 const { appDir, projectDir, packageDir } = require('../lib/utils/paths')
 const config = require('../lib/config')
 const logger = require('./logger')
@@ -232,6 +233,15 @@ async function upgradeIfUnchanged (filePaths, starterFilePath, additionalStep) {
   }))
 }
 
+async function updateUnbrandedLayouts (dir) {
+  const results = await searchAndReplaceFiles(
+    path.join(projectDir, dir),
+    '"layout_unbranded.html"',
+    '"govuk-prototype-kit/layouts/unbranded.html"',
+    ['.html', '.njk'])
+  return results.flat()
+}
+
 module.exports = {
   getOldConfig,
   preflightChecks,
@@ -243,5 +253,6 @@ module.exports = {
   deleteUnusedDirectories,
   deleteEmptyDirectories,
   deleteIfUnchanged,
-  upgradeIfUnchanged
+  upgradeIfUnchanged,
+  updateUnbrandedLayouts
 }

--- a/migrator/migration-steps.spec.js
+++ b/migrator/migration-steps.spec.js
@@ -21,6 +21,12 @@ jest.mock('./reporter', () => {
   }
 })
 
+jest.mock('../lib/utils', () => {
+  return {
+    searchAndReplaceFiles: jest.fn().mockResolvedValue([])
+  }
+})
+
 jest.mock('./file-helpers', () => {
   return {
     getFileAsLines: jest.fn().mockResolvedValue(true),

--- a/migrator/migrator.spec.js
+++ b/migrator/migrator.spec.js
@@ -21,6 +21,7 @@ jest.mock('./migration-steps', () => {
     deleteUnusedDirectories: jest.fn().mockResolvedValue(true),
     deleteEmptyDirectories: jest.fn().mockResolvedValue([true]),
     upgradeIfUnchanged: jest.fn(),
+    updateUnbrandedLayouts: jest.fn().mockResolvedValue(true),
     deleteIfUnchanged: jest.fn().mockResolvedValue([true, true, true]),
     removeOldPatternIncludesFromSassFile: jest.fn().mockResolvedValue(true)
   }


### PR DESCRIPTION
See [Migration script doesn't update extends lines](https://github.com/alphagov/govuk-prototype-kit/issues/1842)

- All occurences of "layout_unbranded.html" within the nunjucks files in the users app folder will be replaced with "govuk-prototype-kit/layouts/unbranded.html" during the migration process.