### PR TITLE
Fix tests as common templates dist-tags have lost version 1.0.0

### DIFF
--- a/cypress/e2e/plugins/1-available-plugins-tests/available-plugins.cypress.js
+++ b/cypress/e2e/plugins/1-available-plugins-tests/available-plugins.cypress.js
@@ -6,11 +6,8 @@ const panelCompleteQuery = '[aria-live="polite"] #panel-complete'
 
 async function installPluginTests ({ plugin, templates, version }) {
   describe(plugin, () => {
-    before(() => {
-      uninstallPlugin(plugin)
-    })
-
     it(`The ${plugin} plugin templates are not available`, () => {
+      uninstallPlugin(plugin)
       loadTemplatesPage()
       cy.get(`[data-plugin-package-name="${plugin}"]`).should('not.exist')
     })
@@ -64,7 +61,7 @@ async function installPluginTests ({ plugin, templates, version }) {
 describe('Plugin tests', () => {
   installPluginTests({
     plugin: '@govuk-prototype-kit/common-templates',
-    version: '1.0.0',
+    version: '1.1.1',
     templates: [
       { name: 'Blank GOV.UK', filename: 'blank-govuk.html' },
       { name: 'Blank unbranded', filename: 'blank-unbranded.html' },


### PR DESCRIPTION
The dist-tags in npm for common-templates no longer mention version 1.0.0 since 1.1.1 was published.