### PR TITLE
Release to v13.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 13.5.0
+
 ### New features
 
 - [#2030: Make it easier to set a page title](https://github.com/alphagov/govuk-prototype-kit/pull/2030)  

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "govuk-prototype-kit",
-  "version": "13.4.0",
+  "version": "13.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-prototype-kit",
-      "version": "13.4.0",
+      "version": "13.5.0",
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "body-parser": "^1.20.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-prototype-kit",
   "description": "Rapidly create HTML prototypes of GOV.UK services",
-  "version": "13.4.0",
+  "version": "13.5.0",
   "engines": {
     "node": "^16.x || >= 18.x"
   },


### PR DESCRIPTION
## 13.5.0

### New features

- [#2030: Make it easier to set a page title](https://github.com/alphagov/govuk-prototype-kit/pull/2030)  
  Set pageName variable on a page and the kit will make a GOV.UK page title for you.  
  - For example `{% set pageName="My example page" %}`

- [#2035: Support html and njk extensions](https://github.com/alphagov/govuk-prototype-kit/pull/2035)  
  Allows .html and .njk to be used interchangeably:
  - The default for creating views from templates will be .html, but .njk will be used if the app/config.json contains `"useNjkExtensions": true`.
  - If two views are in the same location with the same name but with different suffixes (html or njk), the default suffix (determined by the existence of the useNjkExtensions setting above) will be matched first followed by the alternative.

- [#2039: Design error handling](https://github.com/alphagov/govuk-prototype-kit/issues/2039)
  - Implement new Error pages for 404 and 500 error's.

- [#2039: Display stack trace in browser when there's an error](https://github.com/alphagov/govuk-prototype-kit/issues/2038)
  - Display error stack for on Server Error page.

### Fixes

- [#2050: Update extends unbranded correctly during migrate](https://github.com/alphagov/govuk-prototype-kit/pull/2050)  
  All occurrences of "layout_unbranded.html" within the nunjucks files in the users app folder will be replaced with "govuk-prototype-kit/layouts/unbranded.html" during the migration process.