### PR TITLE
removed robots.txt to test with google tools

### DIFF
--- a/server.js
+++ b/server.js
@@ -125,11 +125,6 @@ require('./lib/manage-prototype-routes.js')
 require('./lib/plugins/plugins-routes.js')
 utils.addRouters(app)
 
-app.get('/robots.txt', (req, res) => {
-  res.type('text/plain')
-  res.send('User-agent: *\nDisallow: /')
-})
-
 // Strip .html, .htm and .njk if provided
 app.get(/\.(html|htm|njk)$/i, (req, res) => {
   let path = req.path


### PR DESCRIPTION
Having looked at the test url removing disallow * from robots has allowed specification of no-index which is now being recognised by Google URL Tools.