### PR TITLE
Using formatting for underline rather than additional characters.

### DIFF
--- a/lib/usage-data.js
+++ b/lib/usage-data.js
@@ -8,16 +8,17 @@ const path = require('path')
 const inquirer = require('inquirer')
 const universalAnalytics = require('universal-analytics')
 const { v4: uuidv4 } = require('uuid')
+const chalk = require('chalk')
 
 // local dependencies
 const packageJson = require('../package.json')
 const { projectDir } = require('./utils/paths')
 
 const usageDataFilePath = path.join(projectDir, 'usage-data-config.json')
+const headline = chalk.underline('Help us improve the GOV.UK Prototype Kit')
 
 const USAGE_DATA_PROMPT = `
-Help us improve the GOV.UK Prototype Kit
-────────────────────────────────────────
+${headline}
 
 With your permission, the kit can send useful anonymous usage data
 for analysis to help the team improve the service. Read more here:


### PR DESCRIPTION
When running some accessibility tests this line of dashes was unhelpful when using a screenreader.

In this PR I replace the line of dashes with an underline format.