### PR TITLE
Stop sass compiling files that start with underscore

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -198,7 +198,7 @@ function _generateCssSync (sassPath, cssPath, options = {}) {
     .filter(file => ((
       file.endsWith('.scss') &&
       !file.startsWith('_') &&
-      !filesToSkip.includes(file)
+      !file.startsWith('_') && !filesToSkip.includes(file)
     )))
     .forEach(file => {
       const result = sass.compile(path.join(sassPath, file), {


### PR DESCRIPTION
Fixes #2087 

[Sass should not be compiling files that start an underscore](https://sass-lang.com/documentation/at-rules/import#partials)

This introduces errors if people refer to variables that exist in Frontend. When used as a partial in `application.scss` they work fine, but compiled standalone they don't.

When sass is given a directory, underscores are ignored, but we are passing individual files.