### PR TITLE
Make sure exact versions of plugins are installed from the kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## Unreleased
+
+### Fixes
+
+- [#2100: Make sure exact versions of plugins are installed from the kit](https://github.com/alphagov/govuk-prototype-kit/pull/2100)
+
 ## 13.6.0
 
 ### New features

--- a/__tests__/utils/index.js
+++ b/__tests__/utils/index.js
@@ -113,7 +113,7 @@ async function installPlugins (prototypePath, pluginNames) {
     pluginNamesProcessed = [pluginNames]
   }
   return exec(
-    `npm install ${pluginNamesProcessed.join(' ')}`,
+    `npm install ${pluginNamesProcessed.join(' ')} --save-exact`,
     { cwd: prototypePath, env: { ...process.env, env: 'test' }, stdio: 'inherit' }
   )
 }

--- a/bin/utils/index.js
+++ b/bin/utils/index.js
@@ -6,6 +6,7 @@ const fse = require('fs-extra')
 const packageJsonFormat = { encoding: 'utf8', spaces: 2 }
 
 async function npmInstall (cwd, dependencies) {
+  dependencies.push('--save-exact')
   return spawn(
     'npm', [
       'install',

--- a/cypress/e2e/utils.js
+++ b/cypress/e2e/utils.js
@@ -48,7 +48,7 @@ function installPlugin (plugin, version = '') {
     version = '@' + version
   }
   cy.task('log', `Installing ${plugin}${version}`)
-  cy.exec(`cd ${Cypress.env('projectFolder')} && npm install ${plugin}${version}`)
+  cy.exec(`cd ${Cypress.env('projectFolder')} && npm install ${plugin}${version} --save-exact `)
   if (plugin.startsWith('file:')) {
     plugin = plugin.substring(plugin.lastIndexOf('/') + 1)
   }

--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -442,10 +442,17 @@ async function prepareForPluginPage () {
 }
 
 function getCommand (mode, chosenPlugin) {
+  let { upgradeCommand, installCommand, uninstallCommand, version } = chosenPlugin
+  if (version && installCommand) {
+    installCommand = installCommand + `@${version}`
+  }
   switch (mode) {
-    case 'upgrade': return chosenPlugin.upgradeCommand
-    case 'install': return chosenPlugin.version ? `${chosenPlugin.installCommand}@${chosenPlugin.version}` : chosenPlugin.installCommand
-    case 'uninstall': return chosenPlugin.uninstallCommand
+    case 'upgrade':
+      return upgradeCommand + ' --save-exact'
+    case 'install':
+      return installCommand + ' --save-exact'
+    case 'uninstall':
+      return uninstallCommand
   }
 }
 

--- a/lib/manage-prototype-handlers.test.js
+++ b/lib/manage-prototype-handlers.test.js
@@ -410,7 +410,7 @@ describe('manage-prototype-handlers', () => {
         'views/manage-prototype/plugin-install-or-uninstall.njk',
         expect.objectContaining({
           chosenPlugin: availablePlugin,
-          command: `npm install ${packageName}`,
+          command: `npm install ${packageName} --save-exact`,
           csrfToken,
           currentSection: 'Plugins',
           pageName: `Install ${pluginDisplayName.name}`,
@@ -498,7 +498,7 @@ describe('manage-prototype-handlers', () => {
       it('processing', async () => {
         await postPluginsModeHandler(req, res)
         expect(exec.exec).toHaveBeenCalledWith(
-          availablePlugin.installCommand,
+          availablePlugin.installCommand + ' --save-exact',
           { cwd: projectDir }
         )
         expect(res.json).toHaveBeenCalledWith(
@@ -510,10 +510,10 @@ describe('manage-prototype-handlers', () => {
 
       it('processing specific version', async () => {
         req.body.version = previousVersion
-        availablePlugin.installCommand += `@${previousVersion}`
+        const installSpecificCommand = availablePlugin.installCommand + `@${previousVersion}`
         await postPluginsModeHandler(req, res)
         expect(exec.exec).toHaveBeenCalledWith(
-          availablePlugin.installCommand,
+          installSpecificCommand + ' --save-exact',
           { cwd: projectDir }
         )
         expect(res.json).toHaveBeenCalledWith(

--- a/scripts/performance-test-prepare
+++ b/scripts/performance-test-prepare
@@ -19,6 +19,6 @@ rm -Rf govuk-prototype-kit-performance-kit
 git clone git@github.com:alphagov/govuk-prototype-kit-performance-kit.git
 cd govuk-prototype-kit-performance-kit
 echo '{"collectUsageData": false}' > usage-data-config.json
-npm install $dependency
+npm install $dependency --save-exact
 npm install
 npm run dev


### PR DESCRIPTION
See: [Discrepancy between local and installed versions of the kit](https://github.com/alphagov/govuk-prototype-kit/issues/2096)
- All executed `npm install` commands now have the additional `--save-exact` option to make sure only the exact version is installed.