### PR TITLE
Fix migration script for layouts

### DIFF
--- a/migrator/index.js
+++ b/migrator/index.js
@@ -19,6 +19,7 @@ const {
   deleteIfUnchanged,
   removeOldPatternIncludesFromSassFile,
   updateUnbrandedLayouts,
+  upgradeLayoutIfUnchanged,
   upgradeIfPossible
 } = require('./migration-steps')
 
@@ -81,6 +82,8 @@ const filesToDeleteIfUnchanged = [
   'app/assets/sass/unbranded.scss',
   'app/views/includes/breadcrumb_examples.html',
   'app/views/includes/cookie-banner.html',
+  'app/views/includes/head.html',
+  'app/views/includes/scripts.html',
   'app/views/layout_unbranded.html'
 ]
 
@@ -118,19 +121,6 @@ async function prepareMigration (kitDependency, projectDirectory) {
   ])
 }
 
-// Special case app/views/layout.html, as it has moved in prototype
-// starter files, but we don't want to move for existing users
-async function upgradeLayoutIfUnchanged () {
-  const results = await upgradeIfUnchanged(
-    ['app/views/layout.html'],
-    'app/views/layouts/main.html',
-    () => deleteIfUnchanged([
-      'app/views/includes/head.html',
-      'app/views/includes/scripts.html'
-    ]))
-  return results.flat()
-}
-
 async function migrate () {
   await logger.setup()
 
@@ -143,8 +133,8 @@ async function migrate () {
       prepareSass('app/assets/sass/application.scss'),
       deleteUnusedFiles(filesToDelete),
       deleteUnusedDirectories(directoriesToDelete),
-      upgradeIfUnchanged(filesToUpdateIfUnchanged, '', upgradeIfPossible),
-      upgradeLayoutIfUnchanged(),
+      upgradeIfUnchanged(filesToUpdateIfUnchanged, upgradeIfPossible),
+      upgradeLayoutIfUnchanged('app/views/layout.html', 'app/views/layouts/main.html'),
       updateUnbrandedLayouts('app/views'),
       deleteIfUnchanged(filesToDeleteIfUnchanged),
       deleteIfUnchanged(patternsToDeleteIfUnchanged)

--- a/migrator/migrator.spec.js
+++ b/migrator/migrator.spec.js
@@ -21,6 +21,7 @@ jest.mock('./migration-steps', () => {
     deleteUnusedDirectories: jest.fn().mockResolvedValue(true),
     deleteEmptyDirectories: jest.fn().mockResolvedValue([true]),
     upgradeIfUnchanged: jest.fn(),
+    upgradeLayoutIfUnchanged: jest.fn().mockResolvedValue(true),
     upgradeIfPossible: jest.fn(),
     updateUnbrandedLayouts: jest.fn().mockResolvedValue(true),
     deleteIfUnchanged: jest.fn().mockResolvedValue([true, true, true]),


### PR DESCRIPTION
See the fix migration task within: [Layouts don't always work when a prototype is migrated](https://github.com/alphagov/govuk-prototype-kit/issues/2072)
- Move updating layouts into a separate migration script
- Add unit and integration tests