### PR TITLE
View templates with default layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixes
 
+- [#2120: View templates with default layout](https://github.com/alphagov/govuk-prototype-kit/pull/2120)  
+  Viewing templates in Manage Prototype now works even if app/views/layouts/main.html is missing
+
 - [#2100: Make sure exact versions of plugins are installed from the kit](https://github.com/alphagov/govuk-prototype-kit/pull/2100)
 
 ## 13.6.0

--- a/cypress/e2e/plugins/1-available-plugins-tests/view-template-with-default-layout.cypress.js
+++ b/cypress/e2e/plugins/1-available-plugins-tests/view-template-with-default-layout.cypress.js
@@ -1,0 +1,62 @@
+// core dependencies
+const path = require('path')
+
+// local dependencies
+const { waitForApplication, installPlugin } = require('../../utils')
+const { manageTemplatesPagePath, getTemplateLink } = require('../plugin-utils')
+
+const plugin = '@govuk-prototype-kit/step-by-step'
+const pluginPageTemplate = '/templates/step-by-step-navigation.html'
+const pluginPageTitle = 'Step by step navigation'
+
+const defaultLayoutFilePath = path.join('app', 'views', 'layouts', 'main.html')
+const backupLayoutComment = '<!-- could not find layouts/main.html or layouts/main.njk in prototype, using backup default template -->'
+
+const comments = el => cy.wrap(
+  [...el.childNodes]
+    .filter(node => node.nodeName === '#comment')
+    .map(commentNode => '<!--' + commentNode.data + '-->')
+)
+
+describe('view template with default layout', () => {
+  before(() => {
+    cy.task('copyFromStarterFiles', { filename: defaultLayoutFilePath })
+    installPlugin(plugin, 'latest')
+  })
+
+  after(() => {
+    cy.task('copyFromStarterFiles', { filename: defaultLayoutFilePath })
+  })
+
+  it('deleting default layout does not cause viewing a template to fail to render', () => {
+    cy.task('log', 'Visit the manage prototype plugins page')
+
+    waitForApplication(manageTemplatesPagePath)
+    cy.visit(manageTemplatesPagePath)
+
+    cy.task('log', `Preview the ${pluginPageTitle} template`)
+
+    cy.get(`a[href="${getTemplateLink('view', '@govuk-prototype-kit/step-by-step', pluginPageTemplate)}"]`).click()
+
+    cy.document().then(doc =>
+      comments(doc.head).should('not.contain', backupLayoutComment)
+    )
+
+    cy.task('deleteFile', { filename: path.join(Cypress.env('projectFolder'), defaultLayoutFilePath) })
+
+    waitForApplication(manageTemplatesPagePath)
+    cy.visit(manageTemplatesPagePath)
+
+    cy.task('log', `Preview the ${pluginPageTitle} template`)
+
+    cy.get(`a[href="${getTemplateLink('view', '@govuk-prototype-kit/step-by-step', pluginPageTemplate)}"]`).click()
+
+    cy.visit('/', { failOnStatusCode: false })
+    cy.get('body').should('not.contains.text', 'Error: template not found')
+
+    cy.document().then(doc => {
+      cy.log('head content', doc.head.innerHTML)
+      comments(doc.head).should('contain', backupLayoutComment)
+    })
+  })
+})

--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -18,7 +18,8 @@ const contextPath = '/manage-prototype'
 
 const appViews = plugins.getAppViews([
   path.join(projectDir, 'node_modules'),
-  path.join(projectDir, 'app/views/')
+  path.join(projectDir, 'app/views/'),
+  path.join(packageDir, 'lib/final-backup-nunjucks')
 ])
 
 const pkgPath = path.join(projectDir, 'package.json')


### PR DESCRIPTION
See: [If app/views/layouts/main.html is missing, viewing templates in Manage Prototype does not work](https://github.com/alphagov/govuk-prototype-kit/issues/2119)