### PR TITLE
Release - 13.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 13.6.1
+
 ### Fixes
 
 - [#2120: View templates with default layout](https://github.com/alphagov/govuk-prototype-kit/pull/2120)  

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "govuk-prototype-kit",
-  "version": "13.6.0",
+  "version": "13.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-prototype-kit",
-      "version": "13.6.0",
+      "version": "13.6.1",
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "body-parser": "^1.20.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-prototype-kit",
   "description": "Rapidly create HTML prototypes of GOV.UK services",
-  "version": "13.6.0",
+  "version": "13.6.1",
   "engines": {
     "node": "^16.x || >= 18.x"
   },


### PR DESCRIPTION
### Fixes

We’ve made a fix to the process to migrate old prototypes to v13 where the prototype has a customised layout. 

We’ve also made a fix to ensure that prototypes run properly online.
