### PR TITLE
Add home-office-kit to list of known plugins

### DIFF
--- a/known-plugins.json
+++ b/known-plugins.json
@@ -5,6 +5,7 @@
       "@govuk-prototype-kit/common-templates",
       "@govuk-prototype-kit/step-by-step",
       "@govuk-prototype-kit/task-list",
+      "home-office-kit",
       "hmrc-frontend",
       "jquery",
       "notifications-node-client"


### PR DESCRIPTION
Proposal to add the Home Office plugin (npm: https://www.npmjs.com/package/home-office-kit, source code: https://github.com/UKHomeOffice/home-office-kit) as a known plugin to the GOV.UK prototype kit. This contains some features to make prototyping easier in the Home Office, as well as easy access to Home Office styling (https://design.homeoffice.gov.uk/).

When you get chance, if you could provide any feedback to improve the plugin that would be appreicated, I've tried to namespace everything relevant, but I've possibly missed some.