### PR TITLE
Fix build on kit upgrade get version correctly

### DIFF
--- a/__tests__/spec/build.js
+++ b/__tests__/spec/build.js
@@ -37,7 +37,10 @@ describe('the build pipeline', () => {
       jest.spyOn(fse, 'writeFileSync').mockImplementation(() => {})
       jest.spyOn(fse, 'readJsonSync').mockImplementation(() => ({
         sass: ['test.scss'],
-        dependencies: { 'govuk-frontend': '4.0.0' },
+        dependencies: {
+          'govuk-frontend': '4.0.0',
+          'govuk-prototype-kit': '13.0.1'
+        },
         version: '13.0.1'
       }))
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -126,8 +126,7 @@ function sassLegacyPatterns () {
 
 function sassPlugins () {
   const timer = startPerformanceTimer()
-  const packageConfig = fse.readJsonSync(path.join(packageDir, 'package.json'))
-  const [majorVersion] = packageConfig.version.split('.')
+  const majorVersion = '13'
   let fileContents = ''
   // Keep $govuk-extensions-url-context for backwards compatibility
   // TODO: remove in v14

--- a/lib/build.js
+++ b/lib/build.js
@@ -124,15 +124,22 @@ function sassLegacyPatterns () {
   endPerformanceTimer('sassLegacyPatterns', timer)
 }
 
+function getMajorKitVersion () {
+  const packageConfig = fse.readJsonSync(path.join(projectDir, 'package.json'))
+  // Use regex just in case this is not of the format 13.1.0
+  const [version] = packageConfig.dependencies['govuk-prototype-kit'].match(/\d+\.\d+\.\d+/) || ['13']
+  const [majorVersion] = version.split('.')
+  return majorVersion
+}
+
 function sassPlugins () {
   const timer = startPerformanceTimer()
-  const majorVersion = '13'
   let fileContents = ''
   // Keep $govuk-extensions-url-context for backwards compatibility
   // TODO: remove in v14
   fileContents += '$govuk-extensions-url-context: "/plugin-assets";\n'
   fileContents += '$govuk-plugins-url-context: "/plugin-assets";\n'
-  fileContents += `$govuk-prototype-kit-major-version: ${majorVersion};\n`
+  fileContents += `$govuk-prototype-kit-major-version: ${getMajorKitVersion()};\n`
   if (plugins.legacyGovukFrontendFixesNeeded()) {
     fileContents += '$govuk-global-styles: true !default;\n'
     fileContents += '$govuk-new-link-styles: true !default;\n'


### PR DESCRIPTION
Get the new govuk-prototype-kit major version from the prototype package dependencies as this is safer than trying to get it from the kit package.json that is currently being installed.

Please note this doesn't fix the CSRF error when upgrading from pre 13.6.1 to 13.6.2.  I have a feeling it may be ok from 13.6.1 to 13.6.2

This maybe because of the changes to the layout and page templates in the manage-prototype pages.  I'm not sure.

