### PR TITLE
Allow installation of prereleases.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -90,7 +90,7 @@ function getConfig (config) {
   overrideOrDefault('logPerformanceMatching', 'LOG_PERFORMANCE_MATCHING', asString, undefined)
   overrideOrDefault('logPerformanceSummary', 'LOG_PERFORMANCE_SUMMARY', asNumber, undefined)
   overrideOrDefault('verbose', 'VERBOSE', asBoolean, false)
-  overrideOrDefault('showPrereleaseUpgrades', 'SHOW_PRERELEASE_UPGRADES', asBoolean, false)
+  overrideOrDefault('showPrereleases', 'SHOW_PRERELEASES', asBoolean, false)
 
   if (config.serviceName === undefined) {
     config.serviceName = 'GOV.UK Prototype Kit'

--- a/lib/config.js
+++ b/lib/config.js
@@ -89,6 +89,8 @@ function getConfig (config) {
   overrideOrDefault('logPerformance', 'LOG_PERFORMANCE', asBoolean, false)
   overrideOrDefault('logPerformanceMatching', 'LOG_PERFORMANCE_MATCHING', asString, undefined)
   overrideOrDefault('logPerformanceSummary', 'LOG_PERFORMANCE_SUMMARY', asNumber, undefined)
+  overrideOrDefault('verbose', 'VERBOSE', asBoolean, false)
+  overrideOrDefault('showPrereleaseUpgrades', 'SHOW_PRERELEASE_UPGRADES', asBoolean, false)
 
   if (config.serviceName === undefined) {
     config.serviceName = 'GOV.UK Prototype Kit'

--- a/lib/config.test.js
+++ b/lib/config.test.js
@@ -31,7 +31,9 @@ describe('config', () => {
     isTest: true,
     onGlitch: false,
     useNjkExtensions: false,
-    logPerformance: false
+    logPerformance: false,
+    showPrereleaseUpgrades: false,
+    verbose: false
   })
 
   const mergeWithDefaults = (config) => Object.assign({}, defaultConfig, config)

--- a/lib/config.test.js
+++ b/lib/config.test.js
@@ -32,7 +32,7 @@ describe('config', () => {
     onGlitch: false,
     useNjkExtensions: false,
     logPerformance: false,
-    showPrereleaseUpgrades: false,
+    showPrereleases: false,
     verbose: false
   })
 

--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -97,11 +97,9 @@ function runNodemon (port) {
     watch: [
       path.join(projectDir, '.env'),
       path.join(appDir, '**', '*.js'),
-      path.join(appDir, '**', '*.json'),
-      path.join(projectDir, 'node_modules', 'govuk-prototype-kit', '**', '*.js')
+      path.join(appDir, '**', '*.json')
     ],
     script: path.join(packageDir, 'listen-on-port.js'),
-    ignoreRoot: ['.git'],
     ignore: [
       'app/assets/*'
     ]

--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -10,7 +10,7 @@ const querystring = require('querystring')
 const config = require('./config')
 const plugins = require('./plugins/plugins')
 const { exec } = require('./exec')
-const { requestHttpsJson, prototypeAppScripts } = require('./utils')
+const { requestHttpsJson, prototypeAppScripts, sortByObjectKey } = require('./utils')
 const { projectDir, packageDir, appViewsDir } = require('./utils/paths')
 const nunjucksConfiguration = require('./nunjucks/nunjucksConfiguration')
 
@@ -31,33 +31,52 @@ const {
   version: currentKitVersion
 } = require(path.join(packageDir, 'package.json'))
 const { startPerformanceTimer, endPerformanceTimer } = require('./utils/performance')
+const { verboseLog } = require('./utils/verboseLogger')
 
 const latestReleaseVersions = plugins.getKnownPlugins().available
   .reduce((releaseVersions, nextPlugin) => {
     return { ...releaseVersions, [nextPlugin]: 0 }
   }, { 'govuk-prototype-kit': currentKitVersion })
 
-async function lookupPackageVersions (packageName) {
+async function lookupPackageInfo (packageName) {
   const timer = startPerformanceTimer()
   try {
     const packageInfo = await requestHttpsJson(`https://registry.npmjs.org/${encodeURIComponent(packageName)}`)
-    endPerformanceTimer('lookupPackageVersions (success)', timer)
-    return packageInfo['dist-tags']
+    endPerformanceTimer('lookupPackageInfo (success)', timer)
+    return packageInfo
   } catch (e) {
-    endPerformanceTimer('lookupPackageVersions (failure)', timer)
+    endPerformanceTimer('lookupPackageInfo (failure)', timer)
     console.log('ignoring error', e.message)
   }
 }
 
 async function isValidVersion (packageName, version) {
-  const distTags = await lookupPackageVersions(packageName) || {}
-  return Object.values(distTags).some(distVersion => distVersion === version)
+  const versions = Object.keys(((await lookupPackageInfo(packageName) || {}).versions || {}))
+  const isVersionValid = versions.some(distVersion => distVersion === version)
+  if (!isVersionValid) {
+    console.log('version', version, ' is not valid, valid options are:\n\n', versions)
+  }
+  return isVersionValid
 }
 
 async function lookupLatestPackageVersion (packageName) {
-  const { latest } = await lookupPackageVersions(packageName) || {}
-  latestReleaseVersions[packageName] = latest
-  return latest
+  try {
+    const packageInfo = (await lookupPackageInfo(packageName) || {})
+    if (config.getConfig().showPrereleaseUpgrades) {
+      latestReleaseVersions[packageName] = Object.values(packageInfo['dist-tags'])
+        .map(version => ({ version, date: packageInfo.time[version] }))
+        .sort(sortByObjectKey('date'))
+        .at(-1)
+        .version
+    } else {
+      latestReleaseVersions[packageName] = packageInfo['dist-tags'].latest
+    }
+    return latestReleaseVersions[packageName]
+  } catch (e) {
+    verboseLog('Error when looking up latest package')
+    verboseLog(e)
+    return null
+  }
 }
 
 async function updateLatestReleaseVersions () {
@@ -389,10 +408,9 @@ async function getPluginDetails () {
     .map(async (packageName) => {
       // Only those plugins not referenced locally can be looked up
       const reference = pkg.dependencies[packageName] || ''
-      const canLookUp = !reference.startsWith('file:')
       return {
         packageName,
-        latestVersion: canLookUp && await lookupLatestPackageVersion(packageName),
+        latestVersion: await lookupLatestPackageVersion(packageName),
         installedLocally: reference.startsWith('file:')
       }
     })
@@ -401,7 +419,7 @@ async function getPluginDetails () {
       Object.assign(pack, plugins.preparePackageNameForDisplay(pack.packageName), {
         installLink: `${contextPath}/plugins/install?package=${encodeURIComponent(pack.packageName)}`,
         installCommand: `npm install ${pack.packageName}`,
-        upgradeCommand: `npm install ${pack.packageName}@${pack.latestVersion}`,
+        upgradeCommand: pack.latestVersion && `npm install ${pack.packageName}@${pack.latestVersion}`,
         uninstallCommand: `npm uninstall ${pack.packageName}`
       })
       if (installed.includes(pack.packageName)) {

--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -62,7 +62,7 @@ async function isValidVersion (packageName, version) {
 async function lookupLatestPackageVersion (packageName) {
   try {
     const packageInfo = (await lookupPackageInfo(packageName) || {})
-    if (config.getConfig().showPrereleaseUpgrades) {
+    if (config.getConfig().showPrereleases) {
       latestReleaseVersions[packageName] = Object.values(packageInfo['dist-tags'])
         .map(version => ({ version, date: packageInfo.time[version] }))
         .sort(sortByObjectKey('date'))

--- a/lib/manage-prototype-handlers.test.js
+++ b/lib/manage-prototype-handlers.test.js
@@ -375,11 +375,15 @@ describe('manage-prototype-handlers', () => {
       plugins.listInstalledPlugins.mockReturnValue([])
       plugins.preparePackageNameForDisplay.mockReturnValue(pluginDisplayName)
       plugins.getKnownPlugins.mockReturnValue({ available: [packageName] })
+      const versions = {}
+      versions[latestVersion] = {}
+      versions[previousVersion] = {}
       utils.requestHttpsJson.mockResolvedValue({
         'dist-tags': {
           latest: latestVersion,
           'latest-1': previousVersion
-        }
+        },
+        versions
       })
       fse.readJsonSync.mockReturnValue({
         dependencies: {}

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -289,6 +289,18 @@ function getInternalGovukFrontendDir () {
   return internalGovukFrontendDir
 }
 
+function sortByObjectKey (key) {
+  return function (a, b) {
+    if (a[key] > b[key]) {
+      return 1
+    }
+    if (b[key] > a[key]) {
+      return -1
+    }
+    return 0
+  }
+}
+
 module.exports = {
   prototypeAppScripts: scripts,
   addNunjucksFilters,
@@ -304,5 +316,6 @@ module.exports = {
   sessionFileStoreQuietLogFn,
   searchAndReplaceFiles,
   recursiveDirectoryContentsSync,
-  getInternalGovukFrontendDir
+  getInternalGovukFrontendDir,
+  sortByObjectKey
 }

--- a/lib/utils/verboseLogger.js
+++ b/lib/utils/verboseLogger.js
@@ -1,0 +1,12 @@
+const { getConfig } = require('../config')
+const config = getConfig()
+
+function verboseLog () {
+  if (config.verbose) {
+    console.log.apply(console, arguments)
+  }
+}
+
+module.exports = {
+  verboseLog
+}


### PR DESCRIPTION
This is mostly intended for internal use but could be used by any user.  Setting `showPrereleaseUpgrades: true` in a prototype's `config.json` will mean that they will be prompted to upgrade to the latest release* whether or not it has the `latest` tag.

This would be used for many Alpha, Beta and Release Candidate releases.

The primary purpose of this ticket is to allow the Prototype Kit team to test Release Candidates in the UI before deciding to release them to everyone, it allows developers of other plug-ins the same functionality and it allows users who are wanting to receive pre-release plugins (which might not work as expected) to see the changes that are on their way to being released.

This will be particularly helpful if plugins (like `govuk-frontend`) release prereleases when they're preparing for breaking changes as they can set up a kit, hit the upgrade button and see how a user will experience those changes.