### PR TITLE
Experimental Reload browser on server restart

### DIFF
--- a/cypress/e2e/dev/1-watch-files/watch-config.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-config.cypress.js
@@ -11,21 +11,23 @@ const appConfig = path.join(Cypress.env('projectFolder'), appConfigPath)
 const originalText = 'Service name goes here'
 const newText = 'Cypress test'
 
-const serverNameQuery = 'a.govuk-header__link.govuk-header__service-name, a.govuk-header__link--service-name'
+const serverNameQuery = 'h1.govuk-heading-xl'
+
+function restore () {
+  // Restore config.json from prototype starter
+  cy.task('copyFromStarterFiles', { filename: appConfigPath })
+}
 
 describe('watch config file', () => {
   describe(`service name in config file ${appConfig} should be changed and restored`, () => {
-    before(() => {
-      // Restore config.json from prototype starter
-      cy.task('copyFromStarterFiles', { filename: appConfigPath })
-    })
+    before(restore)
+    after(restore)
 
     it('The service name should change to "cypress test"', () => {
-      waitForApplication()
-      cy.visit('/')
+      waitForApplication('/')
       cy.get(serverNameQuery).contains(originalText)
       cy.task('replaceTextInFile', { filename: appConfig, originalText, newText })
-      waitForApplication()
+      cy.wait(5000)
       cy.get(serverNameQuery).contains(newText)
     })
   })

--- a/cypress/e2e/dev/1-watch-files/watch-javascripts.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-javascripts.cypress.js
@@ -13,11 +13,14 @@ const scriptToAdd = `
   document.querySelector("h1").innerHTML = "${heading}"
 `
 
+function restore () {
+  // Restore application.js from prototype starter
+  cy.task('copyFromStarterFiles', { filename: appJsPath })
+}
+
 describe('watch application.js', () => {
-  before(() => {
-    // Restore application.js from prototype starter
-    cy.task('copyFromStarterFiles', { filename: appJsPath })
-  })
+  before(restore)
+  after(restore)
 
   it('changes to application.js should be reflected in browser', () => {
     waitForApplication()

--- a/cypress/e2e/dev/5-management-tests/edit-home-page.cypress.js
+++ b/cypress/e2e/dev/5-management-tests/edit-home-page.cypress.js
@@ -14,12 +14,15 @@ const newText = 'Cypress test service'
 
 const managePagePath = '/manage-prototype'
 
+function restore () {
+  // Restore index.html and config.json from prototype starter
+  cy.task('copyFromStarterFiles', { filename: appHomePath })
+  cy.task('copyFromStarterFiles', { filename: appConfigPath })
+}
+
 describe('edit home page', () => {
-  before(() => {
-    // Restore index.html and config.json from prototype starter
-    cy.task('copyFromStarterFiles', { filename: appHomePath })
-    cy.task('copyFromStarterFiles', { filename: appConfigPath })
-  })
+  before(restore)
+  after(restore)
 
   it(`The home page heading should change to "${newText}" and the task should be set to "Done"`, () => {
     waitForApplication(managePagePath)

--- a/cypress/e2e/dev/6-layout-tests/title-variable.cypress.js
+++ b/cypress/e2e/dev/6-layout-tests/title-variable.cypress.js
@@ -6,51 +6,56 @@ const { waitForApplication } = require('../../utils')
 
 const indexFile = path.join('app', 'views', 'index.html')
 
-before(() => {
+function restore () {
   cy.task('copyFromStarterFiles', { filename: indexFile })
-})
+}
 
-it('should allow title to be set in multiple ways', () => {
-  waitForApplication()
-  cy.visit('/')
+describe('title-variable', () => {
+  before(restore)
+  after(restore)
 
-  cy.task('log', 'Should display standard home page title')
+  it('should allow title to be set in multiple ways', () => {
+    waitForApplication()
+    cy.visit('/')
 
-  cy.title().should('eq', 'Home - Service name goes here - GOV.UK')
+    cy.task('log', 'Should display standard home page title')
 
-  cy.task('log', 'Update index.html using "set pageName" to display customised page title')
+    cy.title().should('eq', 'Home - Service name goes here - GOV.UK')
 
-  cy.task('createFile', {
-    filename: path.join(Cypress.env('projectFolder'), indexFile),
-    data: `
+    cy.task('log', 'Update index.html using "set pageName" to display customised page title')
+
+    cy.task('createFile', {
+      filename: path.join(Cypress.env('projectFolder'), indexFile),
+      data: `
     {% extends "layouts/main.html" %}
 
     {% set pageName="This is my custom title" %}`,
-    replace: true
-  })
+      replace: true
+    })
 
-  cy.visit('/')
+    cy.visit('/')
 
-  cy.task('log', 'Should display customised page title')
+    cy.task('log', 'Should display customised page title')
 
-  cy.title().should('eq', 'This is my custom title - Service name goes here - GOV.UK')
+    cy.title().should('eq', 'This is my custom title - Service name goes here - GOV.UK')
 
-  cy.task('log', 'Update index.html using "block pageTitle" to display overridden page title')
+    cy.task('log', 'Update index.html using "block pageTitle" to display overridden page title')
 
-  cy.task('createFile', {
-    filename: path.join(Cypress.env('projectFolder'), indexFile),
-    data: `
+    cy.task('createFile', {
+      filename: path.join(Cypress.env('projectFolder'), indexFile),
+      data: `
     {% extends "layouts/main.html" %}
 
     {% block pageTitle %}
       This is my override title
     {% endblock %}`,
-    replace: true
+      replace: true
+    })
+
+    cy.visit('/')
+
+    cy.task('log', 'Should display overridden page title')
+
+    cy.title().should('eq', 'This is my override title')
   })
-
-  cy.visit('/')
-
-  cy.task('log', 'Should display overridden page title')
-
-  cy.title().should('eq', 'This is my override title')
 })

--- a/lib/errorServer.js
+++ b/lib/errorServer.js
@@ -2,6 +2,7 @@ const path = require('path')
 const fs = require('fs')
 
 const { getNunjucksAppEnv } = require('./nunjucks/nunjucksConfiguration')
+const syncChanges = require('./sync-changes')
 
 function runErrorServer (error) {
   let port
@@ -10,6 +11,7 @@ function runErrorServer (error) {
   } catch (e) {
     port = process.env.PORT || 3000
   }
+  const proxyPort = port - 50
   const http = require('http')
   const fileExtensionsToMimeTypes = {
     js: 'application/javascript',
@@ -28,6 +30,9 @@ function runErrorServer (error) {
   }
 
   const requestListener = function (req, res) {
+    if (req.url.startsWith('/browser-sync')) {
+      return
+    }
     if (knownPaths[req.url]) {
       res.setHeader('Content-Type', knownPaths[req.url].type)
       res.writeHead(200)
@@ -72,7 +77,7 @@ function runErrorServer (error) {
 
   const server = http.createServer(requestListener)
 
-  server.listen(port, () => {
+  server.listen(proxyPort, () => {
     console.log('')
     console.log('')
     console.log(`There's an error, you can see it below or at http://localhost:${port}`)
@@ -83,6 +88,11 @@ function runErrorServer (error) {
     console.log('')
     console.log('')
     console.log('')
+    syncChanges({
+      port,
+      proxyPort,
+      files: ['app/**/*.*']
+    })
   })
 }
 

--- a/lib/sync-changes.js
+++ b/lib/sync-changes.js
@@ -1,0 +1,24 @@
+// npm dependencies
+const browserSync = require('browser-sync')
+
+module.exports = ({ port, proxyPort, files }) => {
+  browserSync({
+    proxy: 'localhost:' + proxyPort,
+    port,
+    ui: false,
+    files,
+    ghostMode: false,
+    open: false,
+    notify: false,
+    logLevel: 'error',
+    callbacks: {
+      ready: async () => {
+        // Force browser sync to reload to catch any changes during the restart after 250 milliseconds
+        setTimeout(browserSync.reload, 250)
+        // Reload again at 1 second and then 6 seconds just in case some are missed on a slower machine as happens in the acceptance tests within Google actions
+        setTimeout(browserSync.reload, 1000)
+        setTimeout(browserSync.reload, 6000)
+      }
+    }
+  })
+}

--- a/listen-on-port.js
+++ b/listen-on-port.js
@@ -1,15 +1,16 @@
 
 // npm dependencies
-const browserSync = require('browser-sync')
 const { runErrorServer } = require('./lib/errorServer')
 
 try {
   // local dependencies
+  const syncChanges = require('./lib/sync-changes')
   const server = require('./server.js')
   const { generateAssetsSync } = require('./lib/build')
   const config = require('./lib/config.js').getConfig(null, false)
 
   const port = config.port
+  const proxyPort = port - 50
 
   generateAssetsSync()
 
@@ -28,16 +29,11 @@ try {
     if (config.isProduction || !config.useBrowserSync) {
       server.listen(port)
     } else {
-      server.listen(port - 50, () => {
-        browserSync({
-          proxy: 'localhost:' + (port - 50),
+      server.listen(proxyPort, () => {
+        syncChanges({
           port,
-          ui: false,
-          files: ['.tmp/public/**/*.*', 'app/views/**/*.*', 'app/assets/**/*.*', 'app/config.json'],
-          ghostMode: false,
-          open: false,
-          notify: false,
-          logLevel: 'error'
+          proxyPort,
+          files: ['.tmp/public/**/*.*', 'app/views/**/*.*', 'app/assets/**/*.*', 'app/config.json']
         })
       })
     }


### PR DESCRIPTION
BrowserSync will reload when the server restarts allowing files such as the config.json to be updated and the page to reflect the change without manually refreshing the browser.