### PR TITLE
Adding RC release script

### DIFF
--- a/scripts/clean-publish-before-script.sh
+++ b/scripts/clean-publish-before-script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Meant to be used with https://github.com/shashkovdanil/clean-publish#readme
 # npx clean-publish --before-script scripts/clean-publish-before-script.sh

--- a/scripts/release-rc.sh
+++ b/scripts/release-rc.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+
+branch=$1
+version=$2
+currentBranch=$(git branch --show-current)
+
+if [ $# != 2 ]; then
+  echo 1>&2 ""
+  echo 1>&2 "Please specify a branch and a release version for example:"
+  echo 1>&2 ""
+  echo 1>&2 "$0 my-branch 13.0.0-rc.0"
+  echo 1>&2 ""
+  exit 2
+fi
+
+if [[ "$version" != *"-rc."* ]]; then
+  echo 1>&2 ""
+  echo 1>&2 "release candidates must include '-rc.' for example:"
+  echo 1>&2 ""
+  echo 1>&2 "$0 my-branch 13.0.0-rc.0"
+  echo 1>&2 ""
+  exit 2
+fi
+
+if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
+  echo 1>&2 ""
+  echo 1>&2 "You have changes, please commit or stash before running the script."
+  echo 1>&2 ""
+  exit 2
+fi
+
+set -x
+
+git checkout -b release-$version
+git fetch
+git reset --hard origin/$branch
+npm version $version
+git push -u origin release-$version
+npm login
+npm run clean-publish -- --tag snapshot
+npm logout
+git checkout $currentBranch > /dev/null


### PR DESCRIPTION
The script can be used to create a "Release Candidate" release tagged as "snapshot".  The command is used as follows:

```
./scripts/release-rc.sh main 13.7.0-rc.0
```

The command above will release version from `main` branch called `13.7.0-rc.0` which is tagged as `snapshot`.