### PR TITLE
Hiding govuk-frontend uninstall until we deal with dependent plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - [#2150: Prevent CSURF deprecated warning](https://github.com/alphagov/govuk-prototype-kit/pull/2150)
 
 - [#2130: Create our own file store functionality in place of the session-file-store package](https://github.com/alphagov/govuk-prototype-kit/pull/2130)
+- 
+- [#2172: Hiding govuk-frontend uninstall until we deal with dependent plugins](https://github.com/alphagov/govuk-prototype-kit/pull/2172)
 
 ## 13.6.2
 

--- a/cypress/e2e/plugins/2-prototype-kit-plugin-tests/remove-govuk-frontend.cypress.js
+++ b/cypress/e2e/plugins/2-prototype-kit-plugin-tests/remove-govuk-frontend.cypress.js
@@ -1,11 +1,20 @@
 const { managePluginsPagePath, performPluginAction } = require('../plugin-utils')
 const { uninstallPlugin, installPlugin } = require('../../utils')
+const path = require('path')
 
 const plugin = 'govuk-frontend'
 const pluginName = 'GOV.UK Frontend'
 const dependentPlugin = '@govuk-prototype-kit/common-templates'
+const appConfigPath = path.join('app', 'config.json')
 
 describe('Manage prototype pages without govuk-frontend', () => {
+  before(() => {
+    cy.task('copyFromStarterFiles', { filename: appConfigPath })
+    cy.task('addToConfigJson', { allowGovukFrontendUninstall: true })
+  })
+  after(() => {
+    cy.task('copyFromStarterFiles', { filename: appConfigPath })
+  })
   it('Uninstall govuk-frontend', () => {
     uninstallPlugin(dependentPlugin)
 

--- a/cypress/events/index.js
+++ b/cypress/events/index.js
@@ -13,6 +13,7 @@
 // core dependencies
 const fs = require('fs')
 const fsp = fs.promises
+const fse = require('fs-extra')
 const path = require('path')
 
 // npm dependencies
@@ -280,6 +281,15 @@ module.exports = function setupNodeEvents (on, config) {
               return validateExtractedVersion(fullFilename)
             })
         })
+        .then(makeSureCypressCanInterpretTheResult)
+    },
+
+    addToConfigJson: (additionalConfig) => {
+      log(`Adding config JSON => ${downloadsFolder}`)
+      const appConfigPath = path.join(config.env.projectFolder, 'app', 'config.json')
+      return fse.readJson(appConfigPath)
+        .then(existingConfig => Object.assign({}, existingConfig, additionalConfig))
+        .then(newConfig => fse.writeJson(appConfigPath, newConfig))
         .then(makeSureCypressCanInterpretTheResult)
     },
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -95,6 +95,7 @@ function getConfig (config, swallowError = true) {
   overrideOrDefault('logPerformanceSummary', 'LOG_PERFORMANCE_SUMMARY', asNumber, undefined)
   overrideOrDefault('verbose', 'VERBOSE', asBoolean, false)
   overrideOrDefault('showPrereleases', 'SHOW_PRERELEASES', asBoolean, false)
+  overrideOrDefault('allowGovukFrontendUninstall', 'ALLOW_GOVUK_FRONTEND_UNINSTALL', asBoolean, false)
 
   if (config.serviceName === undefined) {
     config.serviceName = 'GOV.UK Prototype Kit'

--- a/lib/config.test.js
+++ b/lib/config.test.js
@@ -33,6 +33,7 @@ describe('config', () => {
     useNjkExtensions: false,
     logPerformance: false,
     showPrereleases: false,
+    allowGovukFrontendUninstall: false,
     verbose: false
   })
 

--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -450,7 +450,7 @@ async function getPluginDetails () {
         const pluginPkgPath = path.join(projectDir, 'node_modules', pack.packageName, 'package.json')
         const pluginPkg = await fse.pathExists(pluginPkgPath) ? await fse.readJson(pluginPkgPath) : {}
         pack.installedVersion = pluginPkg.version
-        if (!['govuk-prototype-kit'].includes(pack.packageName)) {
+        if (!['govuk-prototype-kit', 'govuk-frontend'].includes(pack.packageName)) {
           pack.uninstallLink = `${contextPath}/plugins/uninstall?package=${encodeURIComponent(pack.packageName)}`
         }
       }

--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -450,7 +450,11 @@ async function getPluginDetails () {
         const pluginPkgPath = path.join(projectDir, 'node_modules', pack.packageName, 'package.json')
         const pluginPkg = await fse.pathExists(pluginPkgPath) ? await fse.readJson(pluginPkgPath) : {}
         pack.installedVersion = pluginPkg.version
-        if (!['govuk-prototype-kit', 'govuk-frontend'].includes(pack.packageName)) {
+        const mandatoryPlugins = ['govuk-prototype-kit']
+        if (!config.getConfig().allowGovukFrontendUninstall) {
+          mandatoryPlugins.push('govuk-frontend')
+        }
+        if (!mandatoryPlugins.includes(pack.packageName)) {
           pack.uninstallLink = `${contextPath}/plugins/uninstall?package=${encodeURIComponent(pack.packageName)}`
         }
       }


### PR DESCRIPTION
As mentioned in https://github.com/alphagov/govuk-prototype-kit/issues/2171 we don't have an optimal UI experience for uninstalling `govuk-frontend` right now so we are removing the button.  The kit still works without `govuk-frontend` as long as no other plugins expect it to be there.

In this PR I've made the button available when a feature flag is set - either `allowGovukFrontendUninstall` in the `config.json` or `ALLOW_GOVUK_FRONTEND_UNINSTALL` in the environment variables.  This is mostly to preserve the functionality and tests so that we can prove that the kit works without frontend.  It can be used by users too but we shouldn't be recommending that they use it.