### PR TITLE
Preparing release 13.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Unreleased
 
+## 13.7.0
+
 ### New features
 
 - [#2101: Show an error in the browser when the kit couldn't start](https://github.com/alphagov/govuk-prototype-kit/pull/2101)
-- 
+
 - [#2142: Node version checking](https://github.com/alphagov/govuk-prototype-kit/pull/2142) - We now make sure you are using a compatible version of Node.JS before creating, running or migrating a kit.
 
 ### Fixes
@@ -15,7 +17,7 @@
 - [#2150: Prevent CSURF deprecated warning](https://github.com/alphagov/govuk-prototype-kit/pull/2150)
 
 - [#2130: Create our own file store functionality in place of the session-file-store package](https://github.com/alphagov/govuk-prototype-kit/pull/2130)
-- 
+
 - [#2172: Hiding govuk-frontend uninstall until we deal with dependent plugins](https://github.com/alphagov/govuk-prototype-kit/pull/2172)
 
 ## 13.6.2

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "govuk-prototype-kit",
-  "version": "13.6.2",
+  "version": "13.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-prototype-kit",
-      "version": "13.6.2",
+      "version": "13.7.0",
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "body-parser": "^1.20.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-prototype-kit",
   "description": "Rapidly create HTML prototypes of GOV.UK services",
-  "version": "13.6.2",
+  "version": "13.7.0",
   "engines": {
     "node": "^16.x || >= 18.x"
   },


### PR DESCRIPTION
### New features

- [#2101: Show an error in the browser when the kit couldn't start](https://github.com/alphagov/govuk-prototype-kit/pull/2101)

- [#2142: Node version checking](https://github.com/alphagov/govuk-prototype-kit/pull/2142) - We now make sure you are using a compatible version of Node.JS before creating, running or migrating a kit.

### Fixes

- [#2163: Replace chalk with ansi-colors as it is installed as a dependency](https://github.com/alphagov/govuk-prototype-kit/pull/2163)

- [#2150: Prevent CSURF deprecated warning](https://github.com/alphagov/govuk-prototype-kit/pull/2150)

- [#2130: Create our own file store functionality in place of the session-file-store package](https://github.com/alphagov/govuk-prototype-kit/pull/2130)

- [#2172: Hiding govuk-frontend uninstall until we deal with dependent plugins](https://github.com/alphagov/govuk-prototype-kit/pull/2172)
