### PR TITLE
Using consistent names for fs, fse and fsp.

### DIFF
--- a/__tests__/spec/sanity-checks.js
+++ b/__tests__/spec/sanity-checks.js
@@ -5,7 +5,7 @@ const assert = require('assert')
 const path = require('path')
 
 // npm dependencies
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const request = require('supertest')
 const sass = require('sass')
 
@@ -29,7 +29,7 @@ describe('The Prototype Kit', () => {
     await mkPrototype(tmpDir, { allowTracking: false, overwrite: true })
     app = require(path.join(tmpDir, 'node_modules', 'govuk-prototype-kit', 'server.js'))
 
-    jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {})
+    jest.spyOn(fse, 'writeFileSync').mockImplementation(() => {})
     jest.spyOn(sass, 'compile').mockImplementation((css, options) => ({ css }))
 
     require('../../lib/build').generateAssetsSync()
@@ -40,7 +40,7 @@ describe('The Prototype Kit', () => {
   })
 
   it('should call writeFileSync with result css from sass.compile', () => {
-    expect(fs.writeFileSync).toHaveBeenCalledWith(
+    expect(fse.writeFileSync).toHaveBeenCalledWith(
       path.join(projectDir, '.tmp', 'public', 'stylesheets', 'application.css'),
       path.join(packageDir, 'lib', 'assets', 'sass', 'prototype.scss')
     )
@@ -82,7 +82,7 @@ describe('The Prototype Kit', () => {
           } else {
             assert.strictEqual(
               '' + res.text,
-              fs.readFileSync(path.join(projectDir, 'node_modules', 'govuk-frontend', 'govuk', 'all.js'), 'utf8')
+              fse.readFileSync(path.join(projectDir, 'node_modules', 'govuk-frontend', 'govuk', 'all.js'), 'utf8')
             )
             done()
           }
@@ -100,7 +100,7 @@ describe('The Prototype Kit', () => {
           } else {
             assert.strictEqual(
               '' + res.body,
-              fs.readFileSync(path.join(projectDir, 'node_modules', 'govuk-frontend', 'govuk', 'assets', 'images', 'favicon.ico'), 'utf8')
+              fse.readFileSync(path.join(projectDir, 'node_modules', 'govuk-frontend', 'govuk', 'assets', 'images', 'favicon.ico'), 'utf8')
             )
             done()
           }
@@ -135,7 +135,7 @@ describe('The Prototype Kit', () => {
             } else {
               assert.strictEqual(
                 '' + res.text,
-                fs.readFileSync(path.join(projectDir, 'node_modules', 'govuk-frontend', 'govuk', 'all.js'), 'utf8')
+                fse.readFileSync(path.join(projectDir, 'node_modules', 'govuk-frontend', 'govuk', 'all.js'), 'utf8')
               )
               done()
             }

--- a/__tests__/utils/index.js
+++ b/__tests__/utils/index.js
@@ -4,7 +4,7 @@ const os = require('os')
 const path = require('path')
 
 // npm dependencies
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 
 // local dependencies
 const { exec } = require('../../lib/exec')
@@ -30,7 +30,7 @@ function _mkdtempPath () {
  */
 function mkdtempSync () {
   const tempdir = _mkdtempPath()
-  fs.mkdirSync(tempdir, { recursive: true })
+  fse.mkdirSync(tempdir, { recursive: true })
   return tempdir
 }
 
@@ -54,14 +54,14 @@ async function mkPrototype (prototypePath, {
   npmInstallLinks = undefined,
   commandLineParameters = ''
 } = {}) { // TODO: Use kitPath if provided
-  if (fs.existsSync(prototypePath)) {
+  if (fse.existsSync(prototypePath)) {
     if (!overwrite) {
       const err = new Error(`path already exists '${prototypePath}'`)
       err.path = prototypePath
       err.code = 'EEXIST'
       throw err
     } else {
-      await fs.remove(prototypePath)
+      await fse.remove(prototypePath)
     }
   }
 
@@ -84,7 +84,7 @@ async function mkPrototype (prototypePath, {
     )
 
     if (allowTracking !== undefined) {
-      await fs.writeJson(path.join(prototypePath, 'usage-data-config.json'), { collectUsageData: !!allowTracking })
+      await fse.writeJson(path.join(prototypePath, 'usage-data-config.json'), { collectUsageData: !!allowTracking })
     }
 
     process.stderr.write(`Kit creation took [${Math.round((Date.now() - startTime) / 100) / 10}] seconds\n`)

--- a/bin/cli
+++ b/bin/cli
@@ -19,9 +19,9 @@ if (process.argv.indexOf('--suppress-node-version-warning') === -1 || (process.a
   }
 }
 
-const fs = require('fs-extra')
 const path = require('path')
 
+const fse = require('fs-extra')
 const { spawn, exec } = require('../lib/exec')
 const { parse } = require('./utils/argv-parser')
 const { prepareMigration, preflightChecks } = require('../migrator')
@@ -91,8 +91,8 @@ const packageJson = {
 
 async function updatePackageJson (packageJsonPath) {
   let newPackageJson = Object.assign({}, packageJson)
-  newPackageJson = Object.assign(newPackageJson, await fs.readJson(packageJsonPath))
-  await fs.writeJson(packageJsonPath, newPackageJson, packageJsonFormat)
+  newPackageJson = Object.assign(newPackageJson, await fse.readJson(packageJsonPath))
+  await fse.writeJson(packageJsonPath, newPackageJson, packageJsonFormat)
 }
 
 function displaySuccessMessage () {
@@ -207,7 +207,7 @@ function warnIfNpmStart (argv, env) {
 }
 
 function writeEmptyPackageJson (installDirectory) {
-  return fs.writeJson(path.join(installDirectory, 'package.json'), {})
+  return fse.writeJson(path.join(installDirectory, 'package.json'), {})
 }
 
 function getArgumentsToPassThrough () {
@@ -243,8 +243,8 @@ async function runCreate () {
   const installDirectory = getInstallLocation()
   const kitDependency = getChosenKitDependency()
 
-  await fs.ensureDir(installDirectory)
-  if ((await fs.readdir(installDirectory)).length > 0) {
+  await fse.ensureDir(installDirectory)
+  if ((await fse.readdir(installDirectory)).length > 0) {
     console.error(`Directory ${installDirectory} is not empty, please specify an empty location.`)
     process.exitCode = 3
     return
@@ -260,8 +260,8 @@ async function runCreate () {
 
   if ((argv.options.version || argv.options.v) === 'local-symlink') {
     const dependencyInstallLocation = path.join(installDirectory, 'node_modules', kitProjectName)
-    await fs.remove(dependencyInstallLocation)
-    await fs.ensureSymlink(kitDependency, dependencyInstallLocation)
+    await fse.remove(dependencyInstallLocation)
+    await fse.ensureSymlink(kitDependency, dependencyInstallLocation)
   }
 
   let runningWithinCreateScriptFlag = '--running-within-create-script'
@@ -285,19 +285,19 @@ async function runCreate () {
 }
 
 async function createStarterFiles (installDirectory) {
-  await fs.copy(path.join(kitRoot, 'prototype-starter'), installDirectory)
+  await fse.copy(path.join(kitRoot, 'prototype-starter'), installDirectory)
 
   async function addToConfigFile (key, value) {
     const configFileLocation = path.join(installDirectory, 'app', 'config.json')
-    const config = await fs.readJson(configFileLocation)
+    const config = await fse.readJson(configFileLocation)
     config[key] = value
-    await fs.writeJson(configFileLocation, config, { spaces: 2 })
+    await fse.writeJson(configFileLocation, config, { spaces: 2 })
   }
 
   function renameAllHtmlFilesToNjk () {
     return recursiveDirectoryContentsSync(appViewsDir)
       .filter(filePath => filePath.endsWith('.html'))
-      .map(filePath => fs.move(
+      .map(filePath => fse.move(
         path.join(appViewsDir, filePath),
         path.join(appViewsDir, filePath.substring(0, filePath.length - '.html'.length) + '.njk')
       ))
@@ -323,12 +323,12 @@ async function runInit () {
 
   const installDirectory = getInstallLocation()
 
-  const copyFile = (fileName) => fs.copy(path.join(kitRoot, fileName), path.join(installDirectory, fileName))
+  const copyFile = (fileName) => fse.copy(path.join(kitRoot, fileName), path.join(installDirectory, fileName))
 
   await Promise.all([
     createStarterFiles(installDirectory),
-    fs.writeFile(path.join(installDirectory, '.gitignore'), gitignore, 'utf8'),
-    fs.writeFile(path.join(installDirectory, '.npmrc'), npmrc, 'utf8'),
+    fse.writeFile(path.join(installDirectory, '.gitignore'), gitignore, 'utf8'),
+    fse.writeFile(path.join(installDirectory, '.npmrc'), npmrc, 'utf8'),
     copyFile('LICENCE.txt'),
     updatePackageJson(path.join(installDirectory, 'package.json'))
   ])
@@ -382,9 +382,9 @@ async function runMigrate () {
 
     await Promise.all([
       updatePackageJson(path.join(projectDirectory, 'package.json')),
-      fs.writeFile(path.join(projectDirectory, '.npmrc'), npmrc, 'utf8'),
-      fs.access(path.join(projectDirectory, '.gitignore'))
-        .catch(() => fs.writeFile(path.join(projectDirectory, '.gitignore'), gitignore, 'utf8'))
+      fse.writeFile(path.join(projectDirectory, '.npmrc'), npmrc, 'utf8'),
+      fse.access(path.join(projectDirectory, '.gitignore'))
+        .catch(() => fse.writeFile(path.join(projectDirectory, '.gitignore'), gitignore, 'utf8'))
     ])
 
     await require('../migrator').migrate()

--- a/migrator/file-helpers.js
+++ b/migrator/file-helpers.js
@@ -1,7 +1,7 @@
 // core dependencies
 const path = require('path')
 const os = require('os')
-const fs = require('fs').promises
+const fsp = require('fs').promises
 
 // npm dependencies
 const fse = require('fs-extra')
@@ -42,13 +42,13 @@ const splitIntoLines = fileContents => fileContents.split('\n')
 const successOutput = () => true
 
 async function getFileAsLines (filePath) {
-  const fileContents = await fs.readFile(filePath, 'utf8')
+  const fileContents = await fsp.readFile(filePath, 'utf8')
   return splitIntoLines(normaliseLineEndings(fileContents))
 }
 
 async function writeFileLinesToFile (filePath, updatedFileLines) {
   try {
-    await fs.writeFile(filePath, joinLines(updatedFileLines))
+    await fsp.writeFile(filePath, joinLines(updatedFileLines))
     return true
   } catch (e) {
     await verboseLogError(e)
@@ -92,13 +92,13 @@ async function removeLineFromFile ({ filePath, lineToRemove }) {
 }
 
 async function deleteFile (filePath) {
-  return (fs.rm || fs.unlink)(filePath)
+  return (fsp.rm || fsp.unlink)(filePath)
     .then(successOutput)
     .catch(handleNotFound(true))
 }
 
 async function deleteDirectory (dirPath) {
-  return (fs.rm || fs.rmdir)(dirPath, { recursive: true })
+  return (fsp.rm || fsp.rmdir)(dirPath, { recursive: true })
     .then(successOutput)
     .catch(handleNotFound(true))
 }
@@ -109,7 +109,7 @@ async function deleteDirectoryIfEmpty (partialPath) {
   if (!exists) {
     return undefined
   }
-  const dirContents = await fs.readdir(dirPath)
+  const dirContents = await fsp.readdir(dirPath)
   if (dirContents.length === 0) {
     return await deleteDirectory(dirPath, undefined)
   }
@@ -145,7 +145,7 @@ function normaliseContent (str) {
 }
 
 async function getFileHash (filePath) {
-  const fileBuffer = await fs.readFile(filePath)
+  const fileBuffer = await fsp.readFile(filePath)
   const hashSum = crypto.createHash('sha256')
 
   if (filePath.endsWith('png')) {

--- a/migrator/index.js
+++ b/migrator/index.js
@@ -1,9 +1,7 @@
-
-// core dependencies
-const fs = require('fs-extra')
 const path = require('path')
 
-// local dependencies
+const fse = require('fs-extra')
+
 const logger = require('./logger')
 const { projectDir } = require('../lib/utils/paths')
 const { npmInstall, packageJsonFormat } = require('../bin/utils')
@@ -104,10 +102,10 @@ async function prepareMigration (kitDependency, projectDirectory) {
   await logger.setup()
 
   // extract the name from the original package.json if it exists
-  const pkgJson = await fs.readJson(path.join(projectDirectory, 'package.json'))
+  const pkgJson = await fse.readJson(path.join(projectDirectory, 'package.json'))
   const { name } = pkgJson
   const pkgData = name ? { name } : {}
-  await fs.writeJson(path.join(projectDirectory, 'package.json'), pkgData, packageJsonFormat)
+  await fse.writeJson(path.join(projectDirectory, 'package.json'), pkgData, packageJsonFormat)
 
   console.log('Migrating your prototype to v13')
 

--- a/migrator/logger.js
+++ b/migrator/logger.js
@@ -1,6 +1,6 @@
 
 // core dependencies
-const fs = require('fs').promises
+const fsp = require('fs').promises
 const os = require('os')
 const path = require('path')
 
@@ -18,7 +18,7 @@ function sanitisePaths (str) {
 
 async function setup () {
   if (!migrateLogFileHandle) {
-    migrateLogFileHandle = await fs.open(migrateLogFilePath, 'a')
+    migrateLogFileHandle = await fsp.open(migrateLogFilePath, 'a')
 
     // log some information useful for debugging
     await module.exports.log(new Date().toISOString())


### PR DESCRIPTION
We use three different tools to access the file system:

`fs` - the core file system API which uses callbacks
`fs.promises` - the core file system API but using promises instead of callbacks
`fs-extra` - a node module, not part of node core which provides additional tools for interacting with file systems

A while ago we used to use `fs` for all of the above, then we started using `fs`, `fsp` and `fse` respectively but not all the code has been updated.  This makes our naming consistent across the codebase.