### PR TITLE
preparing for release of version 13.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 13.8.0
+
 ### New features
 
 - [#2164: Get live reloading working with the error screen](https://github.com/alphagov/govuk-prototype-kit/pull/2164)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "govuk-prototype-kit",
-  "version": "13.7.1",
+  "version": "13.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-prototype-kit",
-      "version": "13.7.1",
+      "version": "13.8.0",
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "body-parser": "^1.20.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-prototype-kit",
   "description": "Rapidly create HTML prototypes of GOV.UK services",
-  "version": "13.7.1",
+  "version": "13.8.0",
   "engines": {
     "node": "^16.x || >= 18.x"
   },


### PR DESCRIPTION
We’ve improved our design for error pages and the page now automatically updates when you fix the error.

We’re still making improvements to these pages. If you have any feedback, please let us know in the replies.