### PR TITLE
Fixed unstyled unbranded issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- [#2215: Fixed unstyled unbranded issue](https://github.com/alphagov/govuk-prototype-kit/pull/2215)
+
 ## 13.8.0
 
 ### New features

--- a/lib/nunjucks/govuk-prototype-kit/layouts/unbranded.njk
+++ b/lib/nunjucks/govuk-prototype-kit/layouts/unbranded.njk
@@ -1,4 +1,4 @@
-{% extends "govuk/template.njk" %}
+{% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}
 
 {% block headIcons %}
   <link rel="shortcut icon" href="/plugin-assets/govuk-prototype-kit/lib/assets/images/unbranded.ico" type="image/x-icon" />


### PR DESCRIPTION
This restores unbranded pages to be styled as they used to be.
As the unbranded layout no longer extends the govuk-branded layout, the overriding block for stylesheets is not rendered.