### PR TITLE
Improvements to plugin validator

### DIFF
--- a/__tests__/spec/plugin-validator.js
+++ b/__tests__/spec/plugin-validator.js
@@ -22,9 +22,11 @@ describe('plugin-validator', () => {
   it('should work', async () => {
     const result = await runShellCommand('valid-plugin')
 
-    expect(result.stdout).toEqual(`Config file exists, validating contents.
+    expect(result.stdout).toEqual(`
+Config file exists, validating contents.
 Validating whether config paths meet criteria.
 The plugin config is valid.
+
 `)
   })
 
@@ -32,7 +34,8 @@ The plugin config is valid.
     const result = await runShellCommand('invalid-plugin')
 
     expect(result.exitCode).toEqual(100)
-    expect(result.stderr).toEqual(`Error: In section sass, the path '/sass/_step-by-step-navigation.scss' does not exist
+    expect(result.stderr).toEqual(`
+Error: In section sass, the path '/sass/_step-by-step-navigation.scss' does not exist
 Error: In section sass, the path '/sass/_step-by-step-navigation-header.scss' does not exist
 Error: In section sass, the path '/sass/_step-by-step-navigation-related.scss' does not exist
 Error: In section scripts, the path 'javascripts/step-by-step-navigation.js' does not start with a '/'
@@ -40,6 +43,7 @@ Error: In section scripts, the path 'javascripts/step-by-step-polyfills.js' does
 Error: In section scripts, the path 'javascripts/modules/foo-module-one.js' does not start with a '/'
 Error: In section templates, the path '/templates/step-by-step-navigation.html' does not exist
 Error: In section templates, the path '/templates/start-with-step-by-step.html' does not exist
+
 `)
   })
 
@@ -47,27 +51,39 @@ Error: In section templates, the path '/templates/start-with-step-by-step.html' 
     const result = await runShellCommand('plugin-invalid-keys')
 
     expect(result.exitCode).toEqual(100)
-    expect(result.stderr).toEqual('Error: The following invalid keys exist in your config: scss,unknown-key\n')
+    expect(result.stderr).toEqual(`
+Error: The following invalid keys exist in your config: scss,unknown-key
+
+`)
   })
 
   it('should return error because config does not exist', async () => {
     const result = await runShellCommand('plugin-no-config')
 
     expect(result.exitCode).toEqual(100)
-    expect(result.stderr).toEqual('Error: The plugin does not have a govuk-prototype-kit.config.json file, all plugins must have this file to be valid.\n')
+    expect(result.stderr).toEqual(`
+Error: The plugin does not have a govuk-prototype-kit.config.json file, all plugins must have this file to be valid.
+
+`)
   })
 
   it('should return error because config is not a valid json', async () => {
     const result = await runShellCommand('plugin-invalid-json')
 
     expect(result.exitCode).toEqual(100)
-    expect(result.stderr).toEqual('Error: Your govuk-prototype-kit.config.json file is not valid json.\n')
+    expect(result.stderr).toEqual(`
+Error: Your govuk-prototype-kit.config.json file is not valid json.
+
+`)
   })
 
   it('should return error because config is empty', async () => {
     const result = await runShellCommand('plugin-empty-config')
 
     expect(result.exitCode).toEqual(100)
-    expect(result.stderr).toEqual('Error: There are no contents in your govuk-prototype.config file!\n')
+    expect(result.stderr).toEqual(`
+Error: There are no contents in your govuk-prototype.config file!
+
+`)
   })
 })

--- a/__tests__/spec/plugin-validator.js
+++ b/__tests__/spec/plugin-validator.js
@@ -2,18 +2,25 @@
 
 const path = require('path')
 const cliPath = path.join(__dirname, '..', '..', 'bin', 'cli')
-const {exec} = require('child_process')
+const { exec } = require('child_process')
+const ansiColors = require('ansi-colors')
 
-function runShellCommand(fixtureDirectoryName) {
-  const fixtureProjectDirectory = path.join(__dirname, '..', 'fixtures', 'mockPlugins',fixtureDirectoryName) 
+function runShellCommand (fixtureDirectoryName) {
+  const fixtureProjectDirectory = path.join(__dirname, '..', 'fixtures', 'mockPlugins', fixtureDirectoryName)
   return new Promise((resolve, reject) => {
-    const abc = exec(`"${process.execPath}" ${cliPath} validate-plugin ${fixtureProjectDirectory}`,
-      {env: process.env, stdio: 'inherit'}, function (err, stdout, stderr) {
-        resolve({
+    const execResult = exec(`"${process.execPath}" ${cliPath} validate-plugin ${fixtureProjectDirectory}`,
+      { env: process.env, stdio: 'inherit' }, function (err, stdout, stderr) {
+        const output = {
           stdout,
           stderr,
-          exitCode: abc.exitCode
-        })
+          exitCode: execResult.exitCode
+        }
+
+        if (err) {
+          resolve(output)
+        } else {
+          resolve(output)
+        }
       })
   })
 }
@@ -25,7 +32,8 @@ describe('plugin-validator', () => {
     expect(result.stdout).toEqual(`
 Config file exists, validating contents.
 Validating whether config paths meet criteria.
-The plugin config is valid.
+
+${ansiColors.green('The plugin config is valid.')}
 
 `)
   })
@@ -35,14 +43,14 @@ The plugin config is valid.
 
     expect(result.exitCode).toEqual(100)
     expect(result.stderr).toEqual(`
-Error: In section sass, the path '/sass/_step-by-step-navigation.scss' does not exist
-Error: In section sass, the path '/sass/_step-by-step-navigation-header.scss' does not exist
-Error: In section sass, the path '/sass/_step-by-step-navigation-related.scss' does not exist
-Error: In section scripts, the path 'javascripts/step-by-step-navigation.js' does not start with a '/'
-Error: In section scripts, the path 'javascripts/step-by-step-polyfills.js' does not start with a '/'
-Error: In section scripts, the path 'javascripts/modules/foo-module-one.js' does not start with a '/'
-Error: In section templates, the path '/templates/step-by-step-navigation.html' does not exist
-Error: In section templates, the path '/templates/start-with-step-by-step.html' does not exist
+${ansiColors.red('Error: In section sass, the path \'/sass/_step-by-step-navigation.scss\' does not exist')}
+${ansiColors.red('Error: In section sass, the path \'/sass/_step-by-step-navigation-header.scss\' does not exist')}
+${ansiColors.red('Error: In section sass, the path \'/sass/_step-by-step-navigation-related.scss\' does not exist')}
+${ansiColors.red('Error: In section scripts, the path \'javascripts/step-by-step-navigation.js\' does not start with a \'/\'')}
+${ansiColors.red('Error: In section scripts, the path \'javascripts/step-by-step-polyfills.js\' does not start with a \'/\'')}
+${ansiColors.red('Error: In section scripts, the path \'javascripts/modules/foo-module-one.js\' does not start with a \'/\'')}
+${ansiColors.red('Error: In section templates, the path \'/templates/step-by-step-navigation.html\' does not exist')}
+${ansiColors.red('Error: In section templates, the path \'/templates/start-with-step-by-step.html\' does not exist')}
 
 `)
   })
@@ -52,7 +60,7 @@ Error: In section templates, the path '/templates/start-with-step-by-step.html' 
 
     expect(result.exitCode).toEqual(100)
     expect(result.stderr).toEqual(`
-Error: The following invalid keys exist in your config: scss,unknown-key
+${ansiColors.red('Error: The following invalid keys exist in your config: scss,unknown-key')}
 
 `)
   })
@@ -62,7 +70,7 @@ Error: The following invalid keys exist in your config: scss,unknown-key
 
     expect(result.exitCode).toEqual(100)
     expect(result.stderr).toEqual(`
-Error: The plugin does not have a govuk-prototype-kit.config.json file, all plugins must have this file to be valid.
+${ansiColors.red('Error: The plugin does not have a govuk-prototype-kit.config.json file, all plugins must have this file to be valid.')}
 
 `)
   })
@@ -72,7 +80,7 @@ Error: The plugin does not have a govuk-prototype-kit.config.json file, all plug
 
     expect(result.exitCode).toEqual(100)
     expect(result.stderr).toEqual(`
-Error: Your govuk-prototype-kit.config.json file is not valid json.
+${ansiColors.red('Error: Your govuk-prototype-kit.config.json file is not valid json.')}
 
 `)
   })
@@ -82,7 +90,7 @@ Error: Your govuk-prototype-kit.config.json file is not valid json.
 
     expect(result.exitCode).toEqual(100)
     expect(result.stderr).toEqual(`
-Error: There are no contents in your govuk-prototype.config file!
+${ansiColors.red('Error: There are no contents in your govuk-prototype.config file!')}
 
 `)
   })

--- a/__tests__/spec/plugin-validator.js
+++ b/__tests__/spec/plugin-validator.js
@@ -2,77 +2,72 @@
 
 const path = require('path')
 const cliPath = path.join(__dirname, '..', '..', 'bin', 'cli')
-const { exec } = require('child_process')
+const {exec} = require('child_process')
 
-function runShellCommand (fixtureProjectDirectory) {
+function runShellCommand(fixtureDirectoryName) {
+  const fixtureProjectDirectory = path.join(__dirname, '..', 'fixtures', 'mockPlugins',fixtureDirectoryName) 
   return new Promise((resolve, reject) => {
-    exec(`"${process.execPath}" ${cliPath} validate-plugin ${fixtureProjectDirectory}`,
-      { cwd: fixtureProjectDirectory, env: process.env, stdio: 'inherit' }, function (err, stdout, stderr) {
-        if (err) {
-          reject(stderr)
-        } else {
-          resolve(stdout)
-        }
+    const abc = exec(`"${process.execPath}" ${cliPath} validate-plugin ${fixtureProjectDirectory}`,
+      {env: process.env, stdio: 'inherit'}, function (err, stdout, stderr) {
+        resolve({
+          stdout,
+          stderr,
+          exitCode: abc.exitCode
+        })
       })
   })
 }
 
 describe('plugin-validator', () => {
   it('should work', async () => {
-    const fixtureProjectDirectory = path.join(__dirname, '..', 'fixtures', 'mockPlugins', 'valid-plugin')
-    const result = await runShellCommand(fixtureProjectDirectory)
-    const outputs = result.split('\n')
-    const outputToCheck = outputs[outputs.length - 2]
+    const result = await runShellCommand('valid-plugin')
 
-    expect(outputToCheck).toEqual('The plugin config is valid.')
+    expect(result.stdout).toEqual(`Config file exists, validating contents.
+Validating whether config paths meet criteria.
+The plugin config is valid.
+`)
   })
 
   it('should return list of path errors found', async () => {
-    const expectedOutput = 'In section sass, the path \'/sass/_step-by-step-navigation.scss\' does not exist,In section sass, the path \'/sass/_step-by-step-navigation-header.scss\' does not exist,In section sass, the path \'/sass/_step-by-step-navigation-related.scss\' does not exist,In section scripts, the path \'javascripts/step-by-step-navigation.js\' does not start with a \'/\',In section scripts, the path \'javascripts/step-by-step-polyfills.js\' does not start with a \'/\',In section scripts, the path \'javascripts/modules/foo-module-one.js\' does not start with a \'/\',In section templates, the path \'/templates/step-by-step-navigation.html\' does not exist,In section templates, the path \'/templates/start-with-step-by-step.html\' does not exist'
-    const fixtureProjectDirectory = path.join(__dirname, '..', 'fixtures', 'mockPlugins', 'invalid-plugin')
+    const result = await runShellCommand('invalid-plugin')
 
-    const result = await runShellCommand(fixtureProjectDirectory)
-    const outputs = result.split('\n')
-    const outputToCheck = outputs[outputs.length - 2]
-
-    expect(outputToCheck).toEqual(expectedOutput)
+    expect(result.exitCode).toEqual(100)
+    expect(result.stderr).toEqual(`Error: In section sass, the path '/sass/_step-by-step-navigation.scss' does not exist
+Error: In section sass, the path '/sass/_step-by-step-navigation-header.scss' does not exist
+Error: In section sass, the path '/sass/_step-by-step-navigation-related.scss' does not exist
+Error: In section scripts, the path 'javascripts/step-by-step-navigation.js' does not start with a '/'
+Error: In section scripts, the path 'javascripts/step-by-step-polyfills.js' does not start with a '/'
+Error: In section scripts, the path 'javascripts/modules/foo-module-one.js' does not start with a '/'
+Error: In section templates, the path '/templates/step-by-step-navigation.html' does not exist
+Error: In section templates, the path '/templates/start-with-step-by-step.html' does not exist
+`)
   })
 
   it('should return list of invalid keys', async () => {
-    const expectedOutput = 'The following invalid keys exist in your config: scss,unknown-key'
-    const fixtureProjectDirectory = path.join(__dirname, '..', 'fixtures', 'mockPlugins', 'plugin-invalid-keys')
+    const result = await runShellCommand('plugin-invalid-keys')
 
-    const result = await runShellCommand(fixtureProjectDirectory)
-    const outputs = result.split('\n')
-    const outputToCheck = outputs[outputs.length - 2]
-
-    expect(outputToCheck).toEqual(expectedOutput)
+    expect(result.exitCode).toEqual(100)
+    expect(result.stderr).toEqual('Error: The following invalid keys exist in your config: scss,unknown-key\n')
   })
 
   it('should return error because config does not exist', async () => {
-    const fixtureProjectDirectory = path.join(__dirname, '..', 'fixtures', 'mockPlugins', 'plugin-no-config')
-    const result = await runShellCommand(fixtureProjectDirectory)
-    const outputs = result.split('\n')
-    const outputToCheck = outputs[outputs.length - 2]
+    const result = await runShellCommand('plugin-no-config')
 
-    expect(outputToCheck).toEqual('The plugin does not have a govuk-prototype-kit.config.json file, all plugins must have this file to be valid.')
+    expect(result.exitCode).toEqual(100)
+    expect(result.stderr).toEqual('Error: The plugin does not have a govuk-prototype-kit.config.json file, all plugins must have this file to be valid.\n')
   })
 
   it('should return error because config is not a valid json', async () => {
-    const fixtureProjectDirectory = path.join(__dirname, '..', 'fixtures', 'mockPlugins', 'plugin-invalid-json')
-    const result = await runShellCommand(fixtureProjectDirectory)
-    const outputs = result.split('\n')
-    const outputToCheck = outputs[outputs.length - 2]
+    const result = await runShellCommand('plugin-invalid-json')
 
-    expect(outputToCheck).toEqual('Your govuk-prototype-kit.config.json file is not valid json.')
+    expect(result.exitCode).toEqual(100)
+    expect(result.stderr).toEqual('Error: Your govuk-prototype-kit.config.json file is not valid json.\n')
   })
 
   it('should return error because config is empty', async () => {
-    const fixtureProjectDirectory = path.join(__dirname, '..', 'fixtures', 'mockPlugins', 'plugin-empty-config')
-    const result = await runShellCommand(fixtureProjectDirectory)
-    const outputs = result.split('\n')
-    const outputToCheck = outputs[outputs.length - 2]
+    const result = await runShellCommand('plugin-empty-config')
 
-    expect(outputToCheck).toEqual('There are no contents in your govuk-prototype.config file!')
+    expect(result.exitCode).toEqual(100)
+    expect(result.stderr).toEqual('Error: There are no contents in your govuk-prototype.config file!\n')
   })
 })

--- a/bin/cli
+++ b/bin/cli
@@ -408,7 +408,7 @@ function runServe () {
 }
 
 async function runValidatePlugin () {
-  return validatePlugin()
+  return validatePlugin(getInstallLocation())
 }
 
 ;(async () => {

--- a/lib/plugins/plugin-validator.js
+++ b/lib/plugins/plugin-validator.js
@@ -78,8 +78,7 @@ function validateConfigPaths (pluginConfig, executionPath) {
   })
 }
 
-async function validatePlugin () {
-  const executionPath = process.cwd()
+async function validatePlugin (executionPath) {
   const configPath = path.join(executionPath, 'govuk-prototype-kit.config.json')
   await fse.exists(configPath).then(exists => {
     if (exists) {
@@ -112,9 +111,11 @@ async function validatePlugin () {
     }
   })
   if (!errors.length > 0) {
-    errors.push('The plugin config is valid.')
+    console.log('The plugin config is valid.')
+  } else {
+    process.exitCode = 100
+    errors.forEach(err => console.error('Error:', err))
   }
-  console.log(errors.toString())
 }
 
 module.exports = {

--- a/lib/plugins/plugin-validator.js
+++ b/lib/plugins/plugin-validator.js
@@ -1,5 +1,6 @@
 const fse = require('fs-extra')
 const path = require('path')
+const ansiColors = require('ansi-colors')
 
 const errors = []
 
@@ -60,7 +61,7 @@ function validateConfigPaths (pluginConfig, executionPath) {
         if (typeof configEntry === 'string' && configEntry[0] === '/') {
           checkPathExists(executionPath, configEntry, key)
         } else if ((key === 'templates' && configEntry.path[0] === '/') ||
-                  (key === 'scripts' && configEntry.path !== undefined && configEntry.path[0] === '/')) {
+          (key === 'scripts' && configEntry.path !== undefined && configEntry.path[0] === '/')) {
           checkPathExists(executionPath, configEntry.path, key)
         } else if ((key === 'nunjucksMacros')) {
           checkPathExists(executionPath, configEntry.importFrom, key)
@@ -111,15 +112,16 @@ async function validatePlugin (executionPath) {
       errors.push('The plugin does not have a govuk-prototype-kit.config.json file, all plugins must have this file to be valid.')
     }
   })
+  console.log()
   if (!errors.length > 0) {
-    console.log('The plugin config is valid.')
-    console.log()
+    console.log(ansiColors.green('The plugin config is valid.'))
   } else {
     process.exitCode = 100
     console.error()
-    errors.forEach(err => console.error('Error:', err))
+    errors.forEach(err => console.error(ansiColors.red(`Error: ${err}`)))
     console.error()
   }
+  console.log()
 }
 
 module.exports = {

--- a/lib/plugins/plugin-validator.js
+++ b/lib/plugins/plugin-validator.js
@@ -79,6 +79,7 @@ function validateConfigPaths (pluginConfig, executionPath) {
 }
 
 async function validatePlugin (executionPath) {
+  console.log()
   const configPath = path.join(executionPath, 'govuk-prototype-kit.config.json')
   await fse.exists(configPath).then(exists => {
     if (exists) {
@@ -112,9 +113,12 @@ async function validatePlugin (executionPath) {
   })
   if (!errors.length > 0) {
     console.log('The plugin config is valid.')
+    console.log()
   } else {
     process.exitCode = 100
+    console.error()
     errors.forEach(err => console.error('Error:', err))
+    console.error()
   }
 }
 

--- a/lib/plugins/plugin-validator.js
+++ b/lib/plugins/plugin-validator.js
@@ -112,16 +112,16 @@ async function validatePlugin (executionPath) {
       errors.push('The plugin does not have a govuk-prototype-kit.config.json file, all plugins must have this file to be valid.')
     }
   })
-  console.log()
   if (!errors.length > 0) {
+    console.log()
     console.log(ansiColors.green('The plugin config is valid.'))
+    console.log()
   } else {
     process.exitCode = 100
     console.error()
     errors.forEach(err => console.error(ansiColors.red(`Error: ${err}`)))
     console.error()
   }
-  console.log()
 }
 
 module.exports = {


### PR DESCRIPTION
- Spaced out the output
- Put each error on its own line
- Added red & green output for fail/pass
- Allowed the user to specify the location, defaulting to current working directory
- Exit with a non-zero exit code if there are errors (important for CI environments and command chaining)
- Separated out stderr and stdout