### PR TITLE
Project board automation

### DIFF
--- a/.github/workflows/move-issue-into-ready-for-release.yaml
+++ b/.github/workflows/move-issue-into-ready-for-release.yaml
@@ -1,0 +1,20 @@
+name: Move issues into 'Ready for release' when they are closed by a PR
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  move-issue-into-ready-for-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.8.3
+        with:
+          project: GOV.UK Prototype Team Sprintboard
+          column: Ready for release
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  ORGANIZATION: alphagov
+  PROJECT_NUMBER: 67


### PR DESCRIPTION
- Added a workflow to move issues that are automatically closed by a linked PR to the 'Ready for release' column

closes #2202 