### PR TITLE
Restore the plugins after each test

### DIFF
--- a/cypress/e2e/dev/2-page-component-tests/checkboxes.cypress.js
+++ b/cypress/e2e/dev/2-page-component-tests/checkboxes.cypress.js
@@ -3,7 +3,7 @@
 const path = require('path')
 
 // local dependencies
-const { waitForApplication } = require('../../utils')
+const { waitForApplication, restoreStarterFiles } = require('../../utils')
 
 const templatesView = path.join(Cypress.config('fixturesFolder'), 'views', 'checkbox-test.html')
 const appView = path.join(Cypress.env('projectFolder'), 'app', 'views', 'checkbox-test.html')
@@ -15,6 +15,8 @@ describe('checkbox tests', () => {
     cy.task('log', `Copy ${templatesView} to ${appView}`)
     cy.task('copyFile', { source: templatesView, target: appView })
   })
+
+  after(restoreStarterFiles)
 
   const loadTestView = async () => {
     cy.task('log', 'The checkbox-test page should be displayed')

--- a/cypress/e2e/dev/4-step-by-step-tests/step-by-step-journey.cypress.js
+++ b/cypress/e2e/dev/4-step-by-step-tests/step-by-step-journey.cypress.js
@@ -3,7 +3,7 @@
 const path = require('path')
 
 // local dependencies
-const { copyFile, waitForApplication, installPlugin } = require('../../utils')
+const { copyFile, waitForApplication, installPlugin, restoreStarterFiles } = require('../../utils')
 const {
   assertHidden,
   assertVisible,
@@ -39,6 +39,8 @@ stepByStepTestData.forEach(({ name, heading, title1, title2 }) => {
     before(() => {
       copyFile(stepByStepTemplateView, stepByStepView)
     })
+
+    after(restoreStarterFiles)
 
     const loadPage = async () => {
       cy.visit(stepByStepPath)

--- a/cypress/e2e/dev/5-management-tests/clear-data-page.cypress.js
+++ b/cypress/e2e/dev/5-management-tests/clear-data-page.cypress.js
@@ -7,7 +7,7 @@ const {
   copyFile,
   createFile,
   replaceInFile,
-  waitForApplication
+  waitForApplication, restoreStarterFiles
 } = require('../../utils')
 
 const appViews = path.join(Cypress.env('projectFolder'), 'app', 'views')
@@ -54,6 +54,8 @@ describe('clear data page', () => {
     createFile(questionCheckView, { data: questionTestMarkUp })
     cy.task('copyFromStarterFiles', { filename: 'app/data/session-data-defaults.js' })
   })
+
+  after(restoreStarterFiles)
 
   it('save and clear data', () => {
     waitForApplication()

--- a/cypress/e2e/dev/5-management-tests/no-autodatastore-on-management-pages.cypress.js
+++ b/cypress/e2e/dev/5-management-tests/no-autodatastore-on-management-pages.cypress.js
@@ -6,7 +6,7 @@ const path = require('path')
 const {
   copyFile,
   createFile,
-  waitForApplication
+  waitForApplication, restoreStarterFiles
 } = require('../../utils')
 
 const appViews = path.join(Cypress.env('projectFolder'), 'app', 'views')
@@ -41,6 +41,8 @@ describe('clear data page', () => {
     createFile(questionCheckView, { data: dataOutputNjk })
     cy.task('copyFromStarterFiles', { filename: 'app/data/session-data-defaults.js' })
   })
+
+  after(restoreStarterFiles)
 
   it('add data from query string, but not in magnagement pages', () => {
     waitForApplication()

--- a/cypress/e2e/plugins/0-mock-plugin-tests/install-plugin-via-cli-test.cypress.js
+++ b/cypress/e2e/plugins/0-mock-plugin-tests/install-plugin-via-cli-test.cypress.js
@@ -3,7 +3,7 @@
 const path = require('path')
 
 // local dependencies
-const { waitForApplication, installPlugin, uninstallPlugin, createFile, restoreStarterFiles } = require('../../utils')
+const { waitForApplication, installPlugin, createFile, restoreStarterFiles } = require('../../utils')
 
 const appViews = path.join(Cypress.env('projectFolder'), 'app', 'views')
 const pluginBazView = path.join(appViews, 'plugin-baz.html')
@@ -31,7 +31,6 @@ const pluginBazViewMarkup = `
 
 describe('Install Plugin via CLI Test', async () => {
   before(() => {
-    uninstallPlugin('plugin-baz')
     createFile(pluginBazView, { data: pluginBazViewMarkup })
     installPlugin(`file:${pluginLocation}`)
   })

--- a/cypress/e2e/plugins/0-mock-plugin-tests/install-plugin-via-ui-test.cypress.js
+++ b/cypress/e2e/plugins/0-mock-plugin-tests/install-plugin-via-ui-test.cypress.js
@@ -1,6 +1,11 @@
 const { restoreStarterFiles } = require('../../utils')
 const path = require('path')
-const { loadTemplatesPage, managePluginsPagePath, performPluginAction, loadPluginsPage } = require('../plugin-utils')
+const {
+  loadTemplatesPage,
+  managePluginsPagePath,
+  performPluginAction,
+  loadPluginsPage
+} = require('../plugin-utils')
 
 const panelCompleteQuery = '[aria-live="polite"] #panel-complete'
 const fixtures = path.join(Cypress.config('fixturesFolder'))

--- a/cypress/e2e/plugins/0-mock-plugin-tests/multi-plugin-test.cypress.js
+++ b/cypress/e2e/plugins/0-mock-plugin-tests/multi-plugin-test.cypress.js
@@ -1,4 +1,3 @@
-
 // core dependencies
 const path = require('path')
 

--- a/cypress/e2e/plugins/0-mock-plugin-tests/single-plugin-test.cypress.js
+++ b/cypress/e2e/plugins/0-mock-plugin-tests/single-plugin-test.cypress.js
@@ -1,4 +1,3 @@
-
 // core dependencies
 const path = require('path')
 

--- a/cypress/e2e/plugins/1-available-plugins-tests/install-available-plugin.cypress.js
+++ b/cypress/e2e/plugins/1-available-plugins-tests/install-available-plugin.cypress.js
@@ -93,8 +93,6 @@ describe('Management plugins: ', () => {
       .contains('Update')
       .click()
 
-    cy.get('#plugin-action-button').click()
-
     performPluginAction('update', plugin, pluginName)
   })
 

--- a/cypress/e2e/plugins/1-available-plugins-tests/preview-template-view.cypress.js
+++ b/cypress/e2e/plugins/1-available-plugins-tests/preview-template-view.cypress.js
@@ -32,5 +32,7 @@ describe('Management plugins: ', () => {
     cy.get(showHideAllLinkQuery).contains('Show all').click()
     assertVisible(1)
     assertVisible(2)
+
+    cy.wait(2000) // Delay before restore otherwise restore fails in this test
   })
 })

--- a/cypress/e2e/plugins/2-prototype-kit-plugin-tests/allow-upgrade-in-url.cypress.js
+++ b/cypress/e2e/plugins/2-prototype-kit-plugin-tests/allow-upgrade-in-url.cypress.js
@@ -1,4 +1,4 @@
-const { replaceInFile, waitForApplication, uninstallPlugin, log } = require('../../utils')
+const { replaceInFile, waitForApplication, restoreStarterFiles, log } = require('../../utils')
 const path = require('path')
 const { performPluginAction } = require('../plugin-utils')
 const plugin = '@govuk-prototype-kit/task-list'
@@ -7,13 +7,8 @@ const originalText = '"dependencies": {'
 const replacementText = `"dependencies": { "${plugin}": "${pluginVersion}",`
 const pkgJsonFile = path.join(Cypress.env('projectFolder'), 'package.json')
 
-function restore () {
-  uninstallPlugin(plugin)
-}
-
 describe('Allow upgrade in URLs', () => {
-  before(restore)
-  after(restore)
+  after(restoreStarterFiles)
 
   it('When updating the old upgrade URL should still work', () => {
     waitForApplication()

--- a/cypress/e2e/plugins/2-prototype-kit-plugin-tests/handle-plugin-installation-mismatch.cypress.js
+++ b/cypress/e2e/plugins/2-prototype-kit-plugin-tests/handle-plugin-installation-mismatch.cypress.js
@@ -1,4 +1,4 @@
-const { replaceInFile, waitForApplication, uninstallPlugin, log } = require('../../utils')
+const { replaceInFile, waitForApplication, restoreStarterFiles, log } = require('../../utils')
 const path = require('path')
 const plugin = '@govuk-prototype-kit/task-list'
 const pluginVersion = '1.1.1'
@@ -7,13 +7,8 @@ const replacementText = `"dependencies": { "${plugin}": "${pluginVersion}",`
 const pkgJsonFile = path.join(Cypress.env('projectFolder'), 'package.json')
 const pluginsPage = '/manage-prototype/plugins'
 
-function restore () {
-  uninstallPlugin(plugin)
-}
-
 describe('Handle a plugin installation mismatch', () => {
-  before(restore)
-  after(restore)
+  after(restoreStarterFiles)
 
   it('where the prototype package.json specifies a dependency that has not been installed', () => {
     waitForApplication()

--- a/cypress/e2e/plugins/2-prototype-kit-plugin-tests/handle-plugin-update-when-a-dependency-is-now-required.cypress.js
+++ b/cypress/e2e/plugins/2-prototype-kit-plugin-tests/handle-plugin-update-when-a-dependency-is-now-required.cypress.js
@@ -1,4 +1,4 @@
-import { installPlugin, uninstallPlugin, waitForApplication } from '../../utils'
+import { installPlugin, restoreStarterFiles, uninstallPlugin, waitForApplication } from '../../utils'
 
 const plugin = '@govuk-prototype-kit/common-templates'
 const pluginVersion = '1.1.1'
@@ -8,6 +8,8 @@ const dependencyPlugin = 'govuk-frontend'
 const dependencyPluginName = 'GOV.UK Frontend'
 
 describe('Handle a plugin update', () => {
+  after(restoreStarterFiles)
+
   it('when a dependency is now required', () => {
     installPlugin(plugin, pluginVersion)
     uninstallPlugin(dependencyPlugin)

--- a/cypress/e2e/plugins/2-prototype-kit-plugin-tests/remove-govuk-frontend.cypress.js
+++ b/cypress/e2e/plugins/2-prototype-kit-plugin-tests/remove-govuk-frontend.cypress.js
@@ -6,13 +6,11 @@ const pluginName = 'GOV.UK Frontend'
 const dependentPlugin = '@govuk-prototype-kit/common-templates'
 
 describe('Manage prototype pages without govuk-frontend', () => {
-  beforeEach(() => {
-    cy.task('addToConfigJson', { allowGovukFrontendUninstall: true })
-  })
-
   afterEach(restoreStarterFiles)
 
   it('Uninstall govuk-frontend', () => {
+    cy.task('addToConfigJson', { allowGovukFrontendUninstall: true })
+
     uninstallPlugin(dependentPlugin)
 
     cy.task('waitUntilAppRestarts')

--- a/cypress/events/index.js
+++ b/cypress/events/index.js
@@ -25,6 +25,8 @@ const https = require('https')
 const { starterDir } = require('../../lib/utils/paths')
 const { sleep } = require('../e2e/utils')
 const { requestHttpsJson } = require('../../lib/utils/requestHttps')
+const { getFileHash } = require('../../migrator/file-helpers')
+const { exec } = require('../../lib/exec')
 
 const log = (message) => console.log(`${new Date().toLocaleTimeString()} => ${message}`)
 
@@ -186,40 +188,84 @@ module.exports = function setupNodeEvents (on, config) {
     }
 
     const retry = async () => {
-      console.log(`Will retry in ${delay} milliseconds`)
+      log(`Will retry in ${delay} milliseconds`)
       await sleep(delay)
       await pluginInstalled(plugin, version, timeout - delay)
     }
 
     return new Promise((resolve) => {
       const pkgFilePath = pathToPackageFile(plugin)
-      console.log(`Waiting for ${pkgFilePath} to exist`)
+      log(`Waiting for ${pkgFilePath} to exist`)
       return existsFile(pkgFilePath, timeout).then(() => {
         if (version) {
           const packageContent = fs.readFileSync(pkgFilePath, 'utf8')
           const { version: currentVersion } = JSON.parse(packageContent)
-          console.log(`Current version of ${plugin} is @${currentVersion}`)
+          log(`Current version of ${plugin} is @${currentVersion}`)
           if (version === '@' + currentVersion) {
             resolve(makeSureCypressCanInterpretTheResult)
           } else {
             retry().then(() => resolve(makeSureCypressCanInterpretTheResult))
           }
         } else {
-          console.log('Skip version test')
+          log('Skip version test')
           resolve(makeSureCypressCanInterpretTheResult)
         }
       })
     })
   }
 
-  const restoreStarterFiles = () => {
-    const { projectFolder } = config.env
-    const appDir = path.join(projectFolder, 'app')
-    return fse.emptyDir(appDir)
-      .then(() => fse.copy(starterDir, projectFolder))
-      .then(() => waitUntilAppRestarts())
+  const backupStarterFiles = () => {
+    const projectDir = path.join(config.env.projectFolder)
+    const backupDir = path.join(config.env.tempFolder, 'backupStarterFiles')
+
+    // Define the filter function
+    const filter = (dir) => !dir.includes('node_modules')
+
+    return fse.emptyDir(backupDir)
+      // Copy the files using the filter
+      .then(() => fse.copy(projectDir, backupDir, { filter }))
+      // Do not back up the package json
+      .then(() => fse.remove(path.join(backupDir, 'package-lock.json')))
       .then(makeSureCypressCanInterpretTheResult)
   }
+
+  const restoreStarterFiles = async (retries = 0) => {
+    retries = typeof retries === 'number' ? retries + 1 : 0
+    try {
+      const tmpDir = path.join(config.env.projectFolder, '.tmp')
+      const appDir = path.join(config.env.projectFolder, 'app')
+      const backupDir = path.join(config.env.tempFolder, 'backupStarterFiles')
+      const projectDir = path.join(config.env.projectFolder)
+
+      const originalPackageJsonHash = await getFileHash(path.join(backupDir, 'package.json'))
+      const currentPackageJsonHash = await getFileHash(path.join(projectDir, 'package.json'))
+
+      // Copy the files
+      await fse.emptyDir(tmpDir)
+      await fse.emptyDir(appDir)
+      await fse.copy(backupDir, projectDir)
+      if (originalPackageJsonHash !== currentPackageJsonHash) {
+        log('Restoring to starter plugins')
+        const command = 'npm prune && npm install'
+        await exec(command, { cwd: config.env.projectFolder })
+        await sleep(1000)
+        log(`Completed ${command}`)
+      }
+      await waitUntilAppRestarts()
+      await sleep(2000)
+      return makeSureCypressCanInterpretTheResult()
+    } catch (error) {
+      if (retries < 4) {
+        await sleep(1000)
+        log('Trying again')
+        return restoreStarterFiles(retries)
+      } else {
+        console.error(JSON.stringify({ error }, null, 2))
+      }
+    }
+  }
+
+  on('before:browser:launch', backupStarterFiles)
 
   on('task', {
     copyFile: ({ source, target }) => createFolderForFile(target)

--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -113,7 +113,7 @@ function runNodemon (port) {
     ignore: [
       'app/assets/*'
     ],
-    delay: 1000 // debounce multiple restarts in quick succession
+    delay: 2000 // debounce multiple restarts in quick succession
   }
 
   const linkedDependencyDirectories = fs.readdirSync(nodeModulesPath).map(dirName => {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "cypress:e2e:styles": "cypress run --spec \"cypress/e2e/styles/*/*\"",
     "cypress:e2e:plugins": "cypress run --spec \"cypress/e2e/plugins/*/*\"",
     "cypress:e2e:errors": "cypress run --spec \"cypress/e2e/errors/*/*\"",
-    "test:heroku": "start-server-and-test start:test:heroku 3000 cypress:e2e:smoke",
+    "test:heroku": "cross-env KIT_TEST_DIR=tmp/test-prototype start-server-and-test start:test:heroku 3000 cypress:e2e:smoke",
     "test:acceptance:dev": "cross-env KIT_TEST_DIR=tmp/test-prototype start-server-and-test start:test 3000 cypress:e2e:dev",
     "test:acceptance:prod": "cross-env PASSWORD=password KIT_TEST_DIR=tmp/test-prototype start-server-and-test start:test:prod 3000 cypress:e2e:prod",
     "test:acceptance:smoke": "cross-env KIT_TEST_DIR=tmp/test-prototype start-server-and-test start:test 3000 cypress:e2e:smoke",


### PR DESCRIPTION
See: [Create generic clean-up functions for cypress tests](https://github.com/alphagov/govuk-prototype-kit/issues/2237)

This PR extends the restoreToStarterFiles functionality to also restore to the installed plugins.

