### PR TITLE
Add back to templates link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New features
+
+- [#2264: Add back to templates link](https://github.com/alphagov/govuk-prototype-kit/pull/2264)
+
 ## 13.11.0
 
 ### New features

--- a/lib/nunjucks/views/manage-prototype/template-post-install.njk
+++ b/lib/nunjucks/views/manage-prototype/template-post-install.njk
@@ -9,7 +9,15 @@
       <p class="govuk-body">View your page at
         <a class="govuk-link" href="{{ url }}">{{ url }}</a></p>
 
-      <p class="govuk-body">To edit the file in your code editor, open <strong>{{ filePath }}</strong></p>
+      <p class="govuk-body">
+        To edit the file in your code editor, open <strong>{{ filePath }}</strong>
+      </p>
+
+      <p class="govuk-body">
+        <a href="/manage-prototype/templates">
+          Back to templates
+        </a>
+      </p>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
To make this consistent with the plugin journey, add a link so users can easily return to the Templates page after creating pages