### PR TITLE
Ignore and destroy corrupt session files

### DIFF
--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -56,6 +56,7 @@ function watchSass (sassPath) {
   if (!fse.existsSync(sassPath)) return
   chokidar.watch(sassPath, {
     ignoreInitial: true,
+    awaitWriteFinish: true,
     disableGlobbing: true // Prevents square brackets from being mistaken for globbing characters
   }).on('add', proxyAndGenerateCssSync)
     .on('unlink', proxyAndGenerateCssSync)

--- a/lib/nunjucks/nunjucksLoader.js
+++ b/lib/nunjucks/nunjucksLoader.js
@@ -27,8 +27,7 @@ const NunjucksLoader = nunjucks.Loader.extend({
 
     if (this.noCache) {
       appViews.forEach((viewDir) => chokidarInstances.push(chokidar.watch(viewDir, {
-        ignoreInitial: true,
-        disableGlobbing: true // Prevents square brackets from being mistaken for globbing characters
+        ignoreInitial: true, awaitWriteFinish: true, disableGlobbing: true // Prevents square brackets from being mistaken for globbing characters
       })
         .on('add', updateHandler)
         .on('change', updateHandler)

--- a/lib/nunjucks/nunjucksLoader.test.js
+++ b/lib/nunjucks/nunjucksLoader.test.js
@@ -183,7 +183,11 @@ describe('Nunjucks Loader', () => {
   it('should watch the first app view in dev mode', () => {
     new NunjucksLoader([path.join(testScope.viewsDir), 'do not watch', 'another not to watch'])
 
-    expect(chokidar.watch).toHaveBeenCalledWith(testScope.viewsDir, { ignoreInitial: true, disableGlobbing: true })
+    expect(chokidar.watch).toHaveBeenCalledWith(testScope.viewsDir, {
+      ignoreInitial: true,
+      awaitWriteFinish: true,
+      disableGlobbing: true
+    })
     expect(testScope.chokidarOn).toHaveBeenCalledWith('add', expect.any(Function))
     expect(testScope.chokidarOn).toHaveBeenCalledWith('unlink', expect.any(Function))
     expect(testScope.chokidarOn).toHaveBeenCalledWith('change', expect.any(Function))

--- a/lib/session-file-store.js
+++ b/lib/session-file-store.js
@@ -11,14 +11,22 @@ class FileStore extends Store {
   }
 
   async set (sessionId, session, callback = noop) {
+    let storedSessionId
     try {
       // Delete any expired sessions before creating a new session
       const storedSessionFiles = await fse.readdir(this.path)
       await Promise.all(storedSessionFiles.map(async sessionFile => {
-        const storedSession = await fse.readJson(path.join(this.path, sessionFile))
-        const storedSessionId = sessionFile.replace('.json', '')
-        if (isExpired(storedSession)) {
-          await this.destroy(storedSessionId, callback)
+        storedSessionId = sessionFile.replace('.json', '')
+        try {
+          const storedSession = await fse.readJson(path.join(this.path, sessionFile))
+          if (isExpired(storedSession)) {
+            await this.destroy(storedSessionId)
+          }
+        } catch (err) {
+          if (storedSessionId) {
+            // destroy broken sessions
+            await this.destroy(storedSessionId)
+          }
         }
       }))
     } catch (err) {
@@ -44,7 +52,10 @@ class FileStore extends Store {
       const session = await fse.readJson(filename)
       callback(null, session)
     } catch (err) {
-      if (err.code === 'ENOENT') {
+      if (!err.code) {
+        // destroy broken session
+        await this.destroy(sessionId, () => callback(null, null))
+      } else if (err.code === 'ENOENT') {
         callback(null, null)
       } else {
         callback(err)


### PR DESCRIPTION
See: [Prototype failed due to corrupt session files](https://github.com/alphagov/govuk-prototype-kit/issues/2269)
- Delete corrupt session files to prevent prototype failing to load correctly