### PR TITLE
Make tests more stable

### DIFF
--- a/cypress/e2e/dev/1-watch-files/watch-routes.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-routes.cypress.js
@@ -20,7 +20,7 @@ describe('watch route file', () => {
     cy.task('log', 'The cypress test page should not be found')
     cy.visit(pagePath, { failOnStatusCode: false })
     cy.get('body')
-      .should('contains.text', `There is no page at ${pagePath}`)
+      .contains(`There is no page at ${pagePath}`)
 
     cy.task('log', `Replace ${appRoutes} with Cypress routes`)
     cy.task('copyFile', { source: routesFixture, target: appRoutes })
@@ -30,7 +30,7 @@ describe('watch route file', () => {
     cy.task('log', 'The cypress test page should be displayed')
     cy.visit(pagePath)
     cy.get('h1')
-      .should('contains.text', 'CYPRESS TEST PAGE')
+      .contains('CYPRESS TEST PAGE')
 
     cy.task('log', `Restore ${appRoutesPath}`)
     cy.task('copyFromStarterFiles', { filename: appRoutesPath })
@@ -40,6 +40,6 @@ describe('watch route file', () => {
     cy.task('log', 'The cypress test page should not be found')
     cy.visit(pagePath, { failOnStatusCode: false })
     cy.get('body')
-      .should('contains.text', `There is no page at ${pagePath}`)
+      .contains(`There is no page at ${pagePath}`)
   })
 })

--- a/cypress/e2e/dev/1-watch-files/watch-views.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-views.cypress.js
@@ -18,7 +18,7 @@ describe('watching start page', () => {
     cy.task('log', 'The start page should not be found')
     cy.visit(pagePath, { failOnStatusCode: false })
     cy.get('body')
-      .should('contains.text', `There is no page at ${pagePath}`)
+      .contains(`There is no page at ${pagePath}`)
 
     cy.task('log', `Copy ${templatesView} to ${appView}`)
     cy.task('copyFile', { source: templatesView, target: appView })
@@ -26,6 +26,6 @@ describe('watching start page', () => {
     cy.task('log', 'The start page should be displayed')
     cy.visit(pagePath)
     cy.get('.govuk-button--start')
-      .should('contains.text', 'Start now')
+      .contains('Start now')
   })
 })

--- a/cypress/e2e/dev/2-page-component-tests/checkboxes.cypress.js
+++ b/cypress/e2e/dev/2-page-component-tests/checkboxes.cypress.js
@@ -20,13 +20,13 @@ describe('checkbox tests', () => {
     cy.task('log', 'The checkbox-test page should be displayed')
     cy.visit(pagePath)
     cy.get('h1')
-      .should('contains.text', 'Checkbox tests')
+      .contains('Checkbox tests')
   }
 
   const submitAndCheck = async (matchData) => {
     cy.intercept('POST', pagePath).as('submitPage')
     cy.get('button[data-module="govuk-button"]')
-      .should('contains.text', 'Continue')
+      .contains('Continue')
       .click()
     cy.wait('@submitPage').its('request.body')
       .then((body) => {

--- a/cypress/e2e/dev/3-link-page-tests/link-index-to-start.cypress.js
+++ b/cypress/e2e/dev/3-link-page-tests/link-index-to-start.cypress.js
@@ -34,6 +34,6 @@ describe('Link index page to start page', async () => {
     waitForApplication()
     cy.get('a[href="/start"]').contains(startText).click()
     cy.get('a[role="button"]')
-      .should('contains.text', 'Start')
+      .contains('Start')
   })
 })

--- a/cypress/e2e/plugins/0-mock-plugin-tests/install-plugin-via-cli-test.cypress.js
+++ b/cypress/e2e/plugins/0-mock-plugin-tests/install-plugin-via-cli-test.cypress.js
@@ -41,7 +41,7 @@ describe('Install Plugin via CLI Test', async () => {
   it('Loads plugin-baz view correctly', () => {
     waitForApplication('/plugin-baz')
     cy.get('.plugin-baz')
-      .should('contains.text', 'Plugin Baz')
+      .contains('Plugin Baz')
   })
 
   it('Loads plugin-baz style correctly', () => {

--- a/cypress/e2e/plugins/0-mock-plugin-tests/multi-combined-plugin-test.cypress.js
+++ b/cypress/e2e/plugins/0-mock-plugin-tests/multi-combined-plugin-test.cypress.js
@@ -45,7 +45,7 @@ describe('Multiple Plugin test', async () => {
       waitForApplication()
       cy.visit('/plugin-foo-bar')
       cy.get('.plugin-bar')
-        .should('contains.text', 'Plugin Foo Bar')
+        .contains('Plugin Foo Bar')
     })
 
     it('Loads plugin-bar style correctly', () => {
@@ -77,7 +77,7 @@ describe('Multiple Plugin test', async () => {
       waitForApplication()
       cy.visit('/plugin-foo-bar')
       cy.get('.plugin-foo')
-        .should('contains.text', 'Plugin Foo Bar')
+        .contains('Plugin Foo Bar')
     })
 
     it('Loads plugin-foo style correctly', () => {

--- a/cypress/e2e/plugins/0-mock-plugin-tests/multi-plugin-test.cypress.js
+++ b/cypress/e2e/plugins/0-mock-plugin-tests/multi-plugin-test.cypress.js
@@ -44,7 +44,7 @@ describe('Plugins test', async () => {
       waitForApplication()
       cy.visit('/plugin-foo-bar')
       cy.get('.plugin-bar')
-        .should('contains.text', 'Plugin Bar')
+        .contains('Plugin Bar')
     })
 
     it('Loads plugin-bar style correctly', () => {
@@ -69,7 +69,7 @@ describe('Plugins test', async () => {
       waitForApplication()
       cy.visit('/plugin-foo-bar')
       cy.get('.plugin-foo')
-        .should('contains.text', 'Plugin Foo')
+        .contains('Plugin Foo')
     })
 
     it('Loads plugin-foo style correctly', () => {

--- a/cypress/e2e/plugins/0-mock-plugin-tests/single-plugin-test.cypress.js
+++ b/cypress/e2e/plugins/0-mock-plugin-tests/single-plugin-test.cypress.js
@@ -42,7 +42,7 @@ describe('Single Plugin Test', async () => {
     waitForApplication()
     cy.visit('/plugin-foo')
     cy.get('.plugin-foo')
-      .should('contains.text', 'Plugin Foo')
+      .contains('Plugin Foo')
   })
 
   it('Loads plugin-foo style correctly', () => {

--- a/cypress/e2e/plugins/2-prototype-kit-plugin-tests/prevent-uninstalling-kit-from-ui.cypress.js
+++ b/cypress/e2e/plugins/2-prototype-kit-plugin-tests/prevent-uninstalling-kit-from-ui.cypress.js
@@ -12,7 +12,7 @@ describe('Prevent uninstalling kit from ui', () => {
     cy.task('waitUntilAppRestarts')
     cy.visit(`${managePluginsPagePath}/uninstall?package=${plugin}`)
     cy.get('h2')
-      .should('contains.text', `Uninstall ${pluginName}`)
+      .contains(`Uninstall ${pluginName}`)
     failAction('uninstall')
   })
 })

--- a/cypress/e2e/utils.js
+++ b/cypress/e2e/utils.js
@@ -16,7 +16,7 @@ const waitForApplication = async (path = '/index') => {
   cy.task('waitUntilAppRestarts')
   cy.visit(path)
   cy.get('.govuk-header__logotype-text')
-    .should('contains.text', 'GOV.UK')
+    .contains('GOV.UK')
 }
 
 const copyFile = (source, target) => {

--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -56,6 +56,7 @@ function watchSass (sassPath) {
   if (!fse.existsSync(sassPath)) return
   chokidar.watch(sassPath, {
     ignoreInitial: true,
+    awaitWriteFinish: true,
     disableGlobbing: true // Prevents square brackets from being mistaken for globbing characters
   }).on('add', proxyAndGenerateCssSync)
     .on('unlink', proxyAndGenerateCssSync)

--- a/lib/nunjucks/nunjucksLoader.js
+++ b/lib/nunjucks/nunjucksLoader.js
@@ -27,8 +27,7 @@ const NunjucksLoader = nunjucks.Loader.extend({
 
     if (this.noCache) {
       appViews.forEach((viewDir) => chokidarInstances.push(chokidar.watch(viewDir, {
-        ignoreInitial: true,
-        disableGlobbing: true // Prevents square brackets from being mistaken for globbing characters
+        ignoreInitial: true, awaitWriteFinish: true, disableGlobbing: true // Prevents square brackets from being mistaken for globbing characters
       })
         .on('add', updateHandler)
         .on('change', updateHandler)

--- a/lib/nunjucks/nunjucksLoader.test.js
+++ b/lib/nunjucks/nunjucksLoader.test.js
@@ -183,7 +183,11 @@ describe('Nunjucks Loader', () => {
   it('should watch the first app view in dev mode', () => {
     new NunjucksLoader([path.join(testScope.viewsDir), 'do not watch', 'another not to watch'])
 
-    expect(chokidar.watch).toHaveBeenCalledWith(testScope.viewsDir, { ignoreInitial: true, disableGlobbing: true })
+    expect(chokidar.watch).toHaveBeenCalledWith(testScope.viewsDir, {
+      ignoreInitial: true,
+      awaitWriteFinish: true,
+      disableGlobbing: true
+    })
     expect(testScope.chokidarOn).toHaveBeenCalledWith('add', expect.any(Function))
     expect(testScope.chokidarOn).toHaveBeenCalledWith('unlink', expect.any(Function))
     expect(testScope.chokidarOn).toHaveBeenCalledWith('change', expect.any(Function))


### PR DESCRIPTION
Make tests more stable by:
- replacing all occurences of `.should('contains.text',` with `.contains`
- adding the property `awaitWriteFinish: true` to chokidar settings