### PR TITLE
Amend style cypress tests to use standard restore function

### DIFF
--- a/cypress/e2e/styles/1-watch-styles/watch-custom-styles.cypress.js
+++ b/cypress/e2e/styles/1-watch-styles/watch-custom-styles.cypress.js
@@ -3,7 +3,7 @@
 const path = require('path')
 
 // local dependencies
-const { waitForApplication } = require('../../utils')
+const { waitForApplication, restoreStarterFiles } = require('../../utils')
 
 const customStylesFixture = 'custom-styles'
 const customStylesFixtureName = `${customStylesFixture}.scss`
@@ -16,15 +16,9 @@ const pageFixtureName = `${pageFixture}.html`
 const pageFixturePath = path.join(Cypress.config('fixturesFolder'), 'views', pageFixtureName)
 const pageAppPath = path.join(Cypress.env('projectFolder'), 'app', 'views', pageFixtureName)
 
-function restore () {
-  cy.task('deleteFile', { filename: path.join(Cypress.env('projectFolder'), customStylesPublicPath) })
-  cy.task('deleteFile', { filename: customStylesAppPath })
-  cy.task('deleteFile', { filename: pageAppPath })
-}
-
 describe('watch custom sass files', () => {
   describe(`sass file ${customStylesFixtureName} should be created and linked within ${pageFixturePath} and accessible from the browser as /${customStylesPublicPath}`, () => {
-    after(restore)
+    afterEach(restoreStarterFiles)
 
     it('The colour of the paragraph should be changed to green', () => {
       waitForApplication()

--- a/cypress/e2e/styles/1-watch-styles/watch-settings-styles.cypress.js
+++ b/cypress/e2e/styles/1-watch-styles/watch-settings-styles.cypress.js
@@ -2,7 +2,7 @@
 const path = require('path')
 
 // local dependencies
-const { waitForApplication, createFile, deleteFile, replaceInFile } = require('../../utils')
+const { waitForApplication, createFile, deleteFile, replaceInFile, restoreStarterFiles } = require('../../utils')
 
 const appStylesPath = path.join('app', 'assets', 'sass')
 const appStylesFolder = path.join(Cypress.env('projectFolder'), appStylesPath)
@@ -15,12 +15,8 @@ const GREEN = 'rgb(0, 255, 0)'
 const settingsContent = `$govuk-brand-colour: ${RED}`
 const changedSettingsContent = `$govuk-brand-colour: ${GREEN}`
 
-function restore () {
-  cy.task('deleteFile', { filename: settingsStyle })
-}
-
 describe('watching settings.scss', () => {
-  after(restore)
+  afterEach(restoreStarterFiles)
 
   it('Successfully reload settings changes', () => {
     waitForApplication()

--- a/cypress/e2e/styles/1-watch-styles/watch-styles.cypress.js
+++ b/cypress/e2e/styles/1-watch-styles/watch-styles.cypress.js
@@ -3,7 +3,7 @@
 const path = require('path')
 
 // local dependencies
-const { waitForApplication } = require('../../utils')
+const { waitForApplication, restoreStarterFiles } = require('../../utils')
 
 const appStylesPath = path.join('app', 'assets', 'sass')
 const appStylesheetPath = path.join(appStylesPath, 'application.scss')
@@ -17,20 +17,13 @@ const publicStylesheet = 'public/stylesheets/application.css'
 const RED = 'rgb(255, 0, 0)'
 const BLACK = 'rgb(11, 12, 12)'
 
-function restore () {
-  cy.task('deleteFile', { filename: cypressTestStylePattern })
-
-  // Restore application.scss from prototype starter
-  cy.task('copyFromStarterFiles', { filename: appStylesheetPath })
-}
-
 describe('watch sass files', () => {
   describe(`sass file ${cypressTestStylePattern} should be created and included within the ${appStylesheet} and accessible from the browser as /${publicStylesheet}`, () => {
     const cssStatement = `
     .govuk-header { background: red; }
     `
 
-    after(restore)
+    afterEach(restoreStarterFiles)
 
     it('The colour of the header should be changed to red then back to black', () => {
       waitForApplication()

--- a/cypress/events/index.js
+++ b/cypress/events/index.js
@@ -231,15 +231,27 @@ module.exports = function setupNodeEvents (on, config) {
     try {
       const tmpDir = path.join(config.env.projectFolder, '.tmp')
       const appDir = path.join(config.env.projectFolder, 'app')
+      const appViewsDir = path.join(appDir, 'views')
+      const appDataDir = path.join(appDir, 'data')
+      const appAssetsDir = path.join(appDir, 'assets')
+      const appSassDir = path.join(appAssetsDir, 'sass')
+      const appJSDir = path.join(appAssetsDir, 'javascripts')
       const backupDir = path.join(config.env.tempFolder, 'backupStarterFiles')
       const projectDir = path.join(config.env.projectFolder)
 
       const originalPackageJsonHash = await getFileHash(path.join(backupDir, 'package.json'))
       const currentPackageJsonHash = await getFileHash(path.join(projectDir, 'package.json'))
 
+      // Delete the files
+      await Promise.all([
+        tmpDir,
+        appViewsDir,
+        appDataDir,
+        appJSDir,
+        appSassDir
+      ].map(async dir => fse.emptyDir(dir)))
+
       // Copy the files
-      await fse.emptyDir(tmpDir)
-      await fse.emptyDir(appDir)
       await fse.copy(backupDir, projectDir)
       if (originalPackageJsonHash !== currentPackageJsonHash) {
         log('Restoring to starter plugins')

--- a/lib/build.js
+++ b/lib/build.js
@@ -24,6 +24,7 @@ const {
 } = require('./utils/paths')
 const { recursiveDirectoryContentsSync } = require('./utils')
 const { startPerformanceTimer, endPerformanceTimer } = require('./utils/performance')
+const { verboseLog } = require('./utils/verboseLogger')
 
 const appSassOptions = {
   filesToSkip: [
@@ -37,7 +38,8 @@ const libSassOptions = {
   }
 }
 
-function generateAssetsSync ({ verbose } = {}) {
+function generateAssetsSync () {
+  verboseLog('************************ GENERATE ASSETS ***************************')
   const timer = startPerformanceTimer()
   plugins.setPluginsByType()
   clean()
@@ -180,7 +182,9 @@ function _generateCssSync (sassPath, cssPath, options = {}) {
     })
 }
 
-function generateCssSync () {
+function generateCssSync (options) {
+  verboseLog('************************ GENERATE SASS ***************************')
+  verboseLog(JSON.stringify(options, 2, null))
   const timer = startPerformanceTimer()
   _generateCssSync(appSassDir, publicCssDir, appSassOptions)
   _generateCssSync(libSassDir, publicCssDir, libSassOptions)


### PR DESCRIPTION
The restore is implemented by copying backed up files at the start of each test.

Please note that this is an interim solution and will hopefully be replaced with the PR: [Use git restore to restore cypress tests](https://github.com/alphagov/govuk-prototype-kit/pull/2286) currently in development which is designed to use a git reset to achieve the above.