### PR TITLE
Preparing for release 13.12.1 (automated).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 13.12.1
+
 ### Fixes
 
 - [#2287: Support sass errors in error pages](https://github.com/alphagov/govuk-prototype-kit/pull/2287)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "govuk-prototype-kit",
-  "version": "13.12.0",
+  "version": "13.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-prototype-kit",
-      "version": "13.12.0",
+      "version": "13.12.1",
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "body-parser": "^1.20.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-prototype-kit",
   "description": "Rapidly create HTML prototypes of GOV.UK services",
-  "version": "13.12.0",
+  "version": "13.12.1",
   "engines": {
     "node": "^16.x || >= 18.x"
   },


### PR DESCRIPTION

### Fixes

- [#2287: Support sass errors in error pages](https://github.com/alphagov/govuk-prototype-kit/pull/2287)
- [#2297: Adding plugin metadata to validator](https://github.com/alphagov/govuk-prototype-kit/pull/2297)