### PR TITLE
Build the enhanced plugin page

### DIFF
--- a/.github/workflows/test-acceptance.yaml
+++ b/.github/workflows/test-acceptance.yaml
@@ -19,7 +19,7 @@ jobs:
 
     name: Acceptance ${{ matrix.type }} test kit on Node v${{ matrix.node-version }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 25
+    timeout-minutes: 30
 
     env:
       CYPRESS_CACHE_FOLDER: ~/.cache/Cypress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-## New features
+### New features
 
+- [#2305: Build the enhanced plugin page](https://github.com/alphagov/govuk-prototype-kit/pull/2305)
 - [#2314: Plugin validator allows the user to specify unknown keys](https://github.com/alphagov/govuk-prototype-kit/pull/2314)
 
 ## 13.12.2

--- a/cypress/e2e/plugins/0-mock-plugin-tests/install-plugin-via-ui-test.cypress.js
+++ b/cypress/e2e/plugins/0-mock-plugin-tests/install-plugin-via-ui-test.cypress.js
@@ -1,10 +1,9 @@
-const { restoreStarterFiles } = require('../../utils')
+const { restoreStarterFiles, log } = require('../../utils')
 const path = require('path')
 const {
   loadTemplatesPage,
   managePluginsPagePath,
-  performPluginAction,
-  loadPluginsPage
+  performPluginAction
 } = require('../plugin-utils')
 
 const panelCompleteQuery = '[aria-live="polite"] #panel-complete'
@@ -16,14 +15,16 @@ const dependencyPlugin = 'govuk-frontend'
 const dependencyPluginName = 'GOV.UK Frontend'
 
 describe('Install and uninstall Local Plugin via UI Test', async () => {
-  after(restoreStarterFiles)
+  afterEach(restoreStarterFiles)
 
-  it(`The ${dependentPlugin} plugin templates are not available`, () => {
+  it(`The ${dependentPlugin} plugin will be installed`, () => {
+    log(`The ${dependentPlugin} plugin templates are not available`)
     loadTemplatesPage()
     cy.get(`[data-plugin-package-name="${dependentPlugin}"]`).should('not.exist')
-  })
 
-  it(`Install the ${dependentPlugin} plugin`, () => {
+    //   ------------------------
+
+    log(`Install the ${dependentPlugin} plugin`)
     cy.task('waitUntilAppRestarts')
     cy.visit(`${managePluginsPagePath}/install?package=${encodeURIComponent(dependentPlugin)}&version=${encodeURIComponent(dependentPluginLocation)}`)
     cy.get('#plugin-action-button').click()
@@ -32,16 +33,21 @@ describe('Install and uninstall Local Plugin via UI Test', async () => {
       .should('be.visible')
     cy.get('a').contains('Back to plugins').click()
 
+    cy.get('#installed-plugins-link').click()
+
     cy.get(`[data-plugin-package-name="${dependentPlugin}"] button`).contains('Uninstall')
-  })
 
-  it(`The ${dependentPlugin} plugin templates are available`, () => {
-    loadTemplatesPage()
+    //   ------------------------
+
+    log(`The ${dependentPlugin} plugin templates are available`)
+    cy.get('a').contains('Templates').click()
     cy.get(`[data-plugin-package-name="${dependentPlugin}"]`).should('exist')
-  })
 
-  it('Uninstall the local plugin', () => {
-    loadPluginsPage()
+    //   ------------------------
+
+    log('Uninstall the local plugin')
+    cy.get('a').contains('Plugins').click()
+    cy.get('#installed-plugins-link').click()
 
     cy.get(`[data-plugin-package-name="${dependentPlugin}"]`)
       .scrollIntoView()
@@ -50,54 +56,57 @@ describe('Install and uninstall Local Plugin via UI Test', async () => {
       .click()
 
     performPluginAction('uninstall', dependentPlugin, dependentPluginName)
-  })
 
-  it(`The ${dependentPlugin} plugin templates are not available`, () => {
-    loadTemplatesPage()
-    cy.get(`[data-plugin-package-name="${dependentPlugin}"]`).should('not.exist')
-  })
-})
+    //   ------------------------
 
-describe('Install and uninstall Local Dependent Plugin via UI Test', async () => {
-  after(restoreStarterFiles)
-
-  it(`The ${dependentPlugin} plugin templates are not available`, () => {
-    loadTemplatesPage()
+    log(`The ${dependentPlugin} plugin templates are not available`)
+    cy.get('a').contains('Templates').click()
     cy.get(`[data-plugin-package-name="${dependentPlugin}"]`).should('not.exist')
   })
 
-  it(`Uninstall the ${dependencyPlugin} to force the UI to ask for it later`, () => {
+  it(`The ${dependentPlugin} plugin and ${dependencyPlugin} will be installed`, () => {
+    log(`The ${dependentPlugin} plugin templates are not available`)
+    loadTemplatesPage()
+    cy.get(`[data-plugin-package-name="${dependentPlugin}"]`).should('not.exist')
+
+    //   ------------------------
+
+    log(`Uninstall the ${dependencyPlugin} to force the UI to ask for it later`)
     cy.task('waitUntilAppRestarts')
     cy.visit(`${managePluginsPagePath}/uninstall?package=${encodeURIComponent(dependencyPlugin)}`)
     cy.get('#plugin-action-button').click()
     performPluginAction('uninstall', dependencyPlugin, dependencyPluginName)
-  })
 
-  it(`Install the ${dependentPlugin} plugin and the ${dependencyPlugin}`, () => {
+    //   ------------------------
+
+    log(`Install the ${dependentPlugin} plugin and the ${dependencyPlugin}`)
     cy.task('waitUntilAppRestarts')
     cy.visit(`${managePluginsPagePath}/install?package=${encodeURIComponent(dependentPlugin)}&version=${encodeURIComponent(dependentPluginLocation)}`)
     // Should list the dependency plugin
     cy.get('li').contains(dependencyPluginName)
     cy.get('#plugin-action-button').click()
     performPluginAction('install', dependentPlugin, dependentPluginName)
-  })
 
-  it(`The ${dependentPlugin} plugin templates are available`, () => {
-    loadTemplatesPage()
+    //   ------------------------
+
+    log(`The ${dependentPlugin} plugin templates are available`)
+    cy.get('a').contains('Templates').click()
     cy.get(`[data-plugin-package-name="${dependentPlugin}"]`).should('exist')
-  })
 
-  it('Uninstall the dependency plugin', () => {
+    //   ------------------------
+
+    log('Uninstall the dependency plugin')
     cy.task('waitUntilAppRestarts')
     cy.visit(`${managePluginsPagePath}/uninstall?package=${encodeURIComponent(dependencyPlugin)}`)
     // Should list the dependent plugin
     cy.get('li').contains(dependentPluginName)
     cy.get('#plugin-action-button').click()
     performPluginAction('uninstall', dependencyPlugin, dependencyPluginName)
-  })
 
-  it(`The ${dependentPlugin} plugin templates are not available`, () => {
-    loadTemplatesPage()
+    //   ------------------------
+
+    log(`The ${dependentPlugin} plugin templates are not available`)
+    cy.get('a').contains('Templates').click()
     cy.get(`[data-plugin-package-name="${dependentPlugin}"]`).should('not.exist')
   })
 })

--- a/cypress/e2e/plugins/1-available-plugins-tests/install-available-plugin.cypress.js
+++ b/cypress/e2e/plugins/1-available-plugins-tests/install-available-plugin.cypress.js
@@ -9,7 +9,8 @@ const {
   managePluginsPagePath,
   getTemplateLink,
   loadInstalledPluginsPage,
-  loadPluginsPage, manageInstalledPluginsPagePath
+  loadPluginsPage,
+  manageInstalledPluginsPagePath
 } = require('../plugin-utils')
 const { showHideAllLinkQuery, assertVisible, assertHidden } = require('../../step-by-step-utils')
 

--- a/cypress/e2e/plugins/1-available-plugins-tests/install-available-plugin.cypress.js
+++ b/cypress/e2e/plugins/1-available-plugins-tests/install-available-plugin.cypress.js
@@ -2,13 +2,14 @@
 const path = require('path')
 
 // local dependencies
-const { deleteFile, uninstallPlugin, installPlugin, restoreStarterFiles } = require('../../utils')
+const { deleteFile, uninstallPlugin, installPlugin, restoreStarterFiles, log } = require('../../utils')
 const {
   failAction,
   performPluginAction,
   managePluginsPagePath,
   getTemplateLink,
-  loadPluginsPage
+  loadInstalledPluginsPage,
+  loadPluginsPage, manageInstalledPluginsPagePath
 } = require('../plugin-utils')
 const { showHideAllLinkQuery, assertVisible, assertHidden } = require('../../step-by-step-utils')
 
@@ -22,7 +23,7 @@ const pluginPageTitle = 'Step by step navigation'
 const pluginPagePath = '/step-by-step-navigation'
 
 const provePluginFunctionalityWorks = () => {
-  cy.task('log', `Prove ${pluginName} functionality works`)
+  log(`Prove ${pluginName} functionality works`)
 
   cy.visit(pluginPagePath)
 
@@ -45,7 +46,7 @@ const provePluginFunctionalityFails = () => {
     return false
   })
 
-  cy.task('log', `Prove ${pluginName} functionality fails`)
+  log(`Prove ${pluginName} functionality fails`)
 
   cy.visit(pluginPagePath)
 
@@ -53,14 +54,14 @@ const provePluginFunctionalityFails = () => {
 }
 
 describe('Management plugins: ', () => {
-  after(restoreStarterFiles)
+  afterEach(restoreStarterFiles)
 
   it('CSRF Protection on POST action', () => {
     // Load the plugins page, so we don't get any network errors when running the test
     loadPluginsPage()
     // Now run the test
     const installUrl = `${managePluginsPagePath}/install`
-    cy.task('log', `Posting to ${installUrl} without csrf protection`)
+    log(`Posting to ${installUrl} without csrf protection`)
     cy.request({
       url: `${managePluginsPagePath}/install`,
       method: 'POST',
@@ -72,7 +73,8 @@ describe('Management plugins: ', () => {
     })
   })
 
-  it(`Install ${plugin}@${version1} directly`, () => {
+  it(`Update the ${plugin} plugin`, () => {
+    log(`Install ${plugin}@${version1} directly`)
     uninstallPlugin(plugin)
 
     loadPluginsPage()
@@ -82,13 +84,14 @@ describe('Management plugins: ', () => {
     cy.get('#plugin-action-button').click()
 
     performPluginAction('install', plugin, pluginName)
-  })
 
-  it(`Update the ${plugin}@${version1} plugin to ${plugin}@${version2}`, () => {
+    //   ------------------------
+
+    log(`Update the ${plugin}@${version1} plugin to ${plugin}@${version2}`)
     installPlugin(plugin, version1)
 
-    loadPluginsPage()
-    cy.task('log', `Update the ${plugin} plugin`)
+    loadInstalledPluginsPage()
+    log(`Update the ${plugin} plugin`)
 
     cy.get(`[data-plugin-package-name="${plugin}"]`)
       .scrollIntoView()
@@ -99,90 +102,89 @@ describe('Management plugins: ', () => {
     performPluginAction('update', plugin, pluginName)
   })
 
-  describe(`Create a page using a template from the ${plugin} plugin`, () => {
-    it('Install the plugin, create the page, and test the functionality', () => {
-      deleteFile(path.join(appViews, 'step-by-step-navigation.html'))
-      installPlugin(plugin, version2)
+  it(`Create a page using a template from the ${plugin} plugin`, () => {
+    log('Install the plugin, create the page, and test the functionality')
+    deleteFile(path.join(appViews, 'step-by-step-navigation.html'))
+    installPlugin(plugin, version2)
 
-      loadPluginsPage()
-      cy.get('a[href*="/templates"]')
-        .contains('Templates').click()
+    loadInstalledPluginsPage()
+    cy.get('a[href*="/templates"]')
+      .contains('Templates').click()
 
-      cy.get('h2').contains(pluginName)
+    cy.get('h2').contains(pluginName)
 
-      cy.task('log', `Create a new ${pluginPageTitle} page`)
+    //   ------------------------
 
-      cy.get(`a[href="${getTemplateLink('install', '@govuk-prototype-kit/step-by-step', pluginPageTemplate)}"]`).click()
+    log(`Create a new ${pluginPageTitle} page`)
 
-      // create step-by-step-navigation page
-      cy.get('.govuk-heading-l')
-        .contains(`Create new ${pluginPageTitle} page`)
-      cy.get('#chosen-url')
-        .type(pluginPagePath)
-      cy.get('.govuk-button').contains('Create page').click()
+    cy.get(`a[href="${getTemplateLink('install', '@govuk-prototype-kit/step-by-step', pluginPageTemplate)}"]`).click()
 
-      provePluginFunctionalityWorks()
+    // create step-by-step-navigation page
+    cy.get('.govuk-heading-l')
+      .contains(`Create new ${pluginPageTitle} page`)
+    cy.get('#chosen-url')
+      .type(pluginPagePath)
+    cy.get('.govuk-button').contains('Create page').click()
 
-      cy.task('log', `Uninstall the ${plugin} plugin`)
+    provePluginFunctionalityWorks()
 
-      loadPluginsPage()
-      cy.task('log', `Uninstall the ${plugin} plugin`)
+    //   ------------------------
 
-      cy.get(`[data-plugin-package-name="${plugin}"]`)
-        .scrollIntoView()
-        .find('button')
-        .contains('Uninstall')
-        .click()
+    log(`Uninstall the ${plugin} plugin`)
 
-      performPluginAction('uninstall', plugin, pluginName)
+    cy.visit(manageInstalledPluginsPagePath)
 
-      provePluginFunctionalityFails()
+    cy.get(`[data-plugin-package-name="${plugin}"]`)
+      .scrollIntoView()
+      .find('button')
+      .contains('Uninstall')
+      .click()
 
-      cy.task('log', `Reinstall the ${plugin} plugin`)
+    performPluginAction('uninstall', plugin, pluginName)
 
-      loadPluginsPage()
-      cy.task('log', `Install the ${plugin} plugin`)
+    provePluginFunctionalityFails()
 
-      cy.get(`[data-plugin-package-name="${plugin}"]`)
-        .scrollIntoView()
-        .find('button')
-        .contains('Install')
-        .click()
+    //   ------------------------
 
-      performPluginAction('install', plugin, pluginName)
+    log(`Reinstall the ${plugin} plugin`)
 
-      provePluginFunctionalityWorks()
-    })
+    cy.visit(managePluginsPagePath)
+
+    cy.get(`[data-plugin-package-name="${plugin}"]`)
+      .scrollIntoView()
+      .find('button')
+      .contains('Install')
+      .click()
+
+    performPluginAction('install', plugin, pluginName)
+
+    provePluginFunctionalityWorks()
   })
 
-  describe('Get plugin page directly', () => {
-    it('Pass when installing a plugin already installed', () => {
-      cy.task('waitUntilAppRestarts')
-      cy.task('log', `Simulate refreshing the install ${plugin} plugin confirmation page`)
-      cy.visit(`${managePluginsPagePath}/install?package=${encodeURIComponent(plugin)}`)
+  it('Get plugin page directly', () => {
+    log('Pass when installing a plugin already installed')
+    cy.task('waitUntilAppRestarts')
+    log(`Simulate refreshing the install ${plugin} plugin confirmation page`)
+    cy.visit(`${managePluginsPagePath}/install?package=${encodeURIComponent(plugin)}`)
 
-      cy.get('#plugin-action-button').click()
+    cy.get('#plugin-action-button').click()
 
-      performPluginAction('install', plugin, pluginName)
-    })
+    performPluginAction('install', plugin, pluginName)
 
-    describe('fail', () => {
-      it('Fail when installing a non existent plugin', () => {
-        cy.task('waitUntilAppRestarts')
-        const pkg = 'invalid-prototype-kit-plugin'
-        const pluginName = 'Invalid Prototype Kit Plugin'
-        cy.visit(`${managePluginsPagePath}/install?package=${encodeURIComponent(pkg)}`)
-        cy.get('h2').contains(`Install ${pluginName}`)
-        failAction('install')
-      })
+    //   ------------------------
 
-      it('Fail when installing a plugin with a non existent version', () => {
-        cy.task('waitUntilAppRestarts')
-        cy.visit(`${managePluginsPagePath}/install?package=${encodeURIComponent(plugin)}&version=0.0.1`)
-        cy.get('h2')
-          .contains(`Install ${pluginName}`)
-        failAction('install')
-      })
-    })
+    log('Fail when installing a non existent plugin')
+    const pkg = 'invalid-prototype-kit-plugin'
+    const invalidPluginName = 'Invalid Prototype Kit Plugin'
+    cy.visit(`${managePluginsPagePath}/install?package=${encodeURIComponent(pkg)}`)
+    cy.get('h2').contains(`Install ${invalidPluginName}`)
+    failAction('install')
+
+    //   ------------------------
+
+    log('Fail when installing a plugin with a non existent version')
+    cy.visit(`${managePluginsPagePath}/install?package=${encodeURIComponent(plugin)}&version=0.0.1`)
+    cy.get('h2').contains(`Install ${pluginName}`)
+    failAction('install')
   })
 })

--- a/cypress/e2e/plugins/2-prototype-kit-plugin-tests/handle-plugin-installation-mismatch.cypress.js
+++ b/cypress/e2e/plugins/2-prototype-kit-plugin-tests/handle-plugin-installation-mismatch.cypress.js
@@ -18,6 +18,7 @@ describe('Handle a plugin installation mismatch', () => {
 
     log(`Make sure ${plugin} is displayed as not installed`)
     cy.visit(pluginsPage)
+
     cy.get(`[data-plugin-package-name="${plugin}"]`)
       .scrollIntoView()
       .find('button')
@@ -29,6 +30,8 @@ describe('Handle a plugin installation mismatch', () => {
     log(`Make sure ${plugin} is displayed as installed`)
     waitForApplication()
     cy.visit(pluginsPage)
+
+    cy.get('#installed-plugins-link').click()
     cy.get(`[data-plugin-package-name="${plugin}"]`)
       .scrollIntoView()
       .find('button')

--- a/cypress/e2e/plugins/2-prototype-kit-plugin-tests/handle-plugin-update-when-a-dependency-is-now-required.cypress.js
+++ b/cypress/e2e/plugins/2-prototype-kit-plugin-tests/handle-plugin-update-when-a-dependency-is-now-required.cypress.js
@@ -30,7 +30,7 @@ describe('Handle a plugin update', () => {
 
     waitForApplication(pluginsPage)
 
-    cy.get('[data-plugin-group-status="available"]')
+    cy.get('[data-plugin-group-status="search"]')
       .find(`[data-plugin-package-name="${dependencyPlugin}"]`)
       .find('button')
       .contains('Install')

--- a/cypress/e2e/plugins/2-prototype-kit-plugin-tests/handle-plugin-update-when-a-dependency-is-now-required.cypress.js
+++ b/cypress/e2e/plugins/2-prototype-kit-plugin-tests/handle-plugin-update-when-a-dependency-is-now-required.cypress.js
@@ -35,6 +35,8 @@ describe('Handle a plugin update', () => {
       .find('button')
       .contains('Install')
 
+    cy.get('#installed-plugins-link').click()
+
     cy.get('[data-plugin-group-status="installed"]')
       .find(`[data-plugin-package-name="${plugin}"]`)
       .find('button')
@@ -54,6 +56,8 @@ describe('Handle a plugin update', () => {
     cy.get('#instructions-complete a')
       .contains('Back to plugins')
       .click()
+
+    cy.get('#installed-plugins-link').click()
 
     cy.get('[data-plugin-group-status="installed"]')
       .find(`[data-plugin-package-name="${dependencyPlugin}"]`)

--- a/cypress/e2e/plugins/2-prototype-kit-plugin-tests/remove-govuk-frontend.cypress.js
+++ b/cypress/e2e/plugins/2-prototype-kit-plugin-tests/remove-govuk-frontend.cypress.js
@@ -1,5 +1,5 @@
 const { managePluginsPagePath, performPluginAction } = require('../plugin-utils')
-const { uninstallPlugin, installPlugin, restoreStarterFiles } = require('../../utils')
+const { uninstallPlugin, restoreStarterFiles } = require('../../utils')
 
 const plugin = 'govuk-frontend'
 const pluginName = 'GOV.UK Frontend'
@@ -47,11 +47,11 @@ describe('Manage prototype pages without govuk-frontend', () => {
 
     performPluginAction('install', plugin, pluginName)
 
+    cy.get('#installed-plugins-link').click()
+
     cy.task('log', 'Make sure govuk-frontend is installed')
     cy.get(`[data-plugin-package-name="${plugin}"]`)
       .find('button')
       .contains('Uninstall')
-
-    installPlugin(dependentPlugin)
   })
 })

--- a/cypress/e2e/plugins/plugin-utils.js
+++ b/cypress/e2e/plugins/plugin-utils.js
@@ -5,6 +5,7 @@ const { waitForApplication } = require('../utils')
 
 const manageTemplatesPagePath = '/manage-prototype/templates'
 const managePluginsPagePath = '/manage-prototype/plugins'
+const manageInstalledPluginsPagePath = '/manage-prototype/plugins-installed'
 
 const panelProcessingQuery = '[aria-live="polite"] #panel-processing'
 const panelCompleteQuery = '[aria-live="polite"] #panel-complete'
@@ -18,6 +19,11 @@ function getTemplateLink (type, packageName, path) {
 async function loadPluginsPage () {
   cy.task('log', 'Visit the manage prototype plugins page')
   await waitForApplication(managePluginsPagePath)
+}
+
+async function loadInstalledPluginsPage () {
+  cy.task('log', 'Visit the manage prototype plugins page')
+  await waitForApplication(manageInstalledPluginsPagePath)
 }
 
 async function loadTemplatesPage () {
@@ -93,8 +99,10 @@ function failAction (action) {
 
 module.exports = {
   managePluginsPagePath,
+  manageInstalledPluginsPagePath,
   manageTemplatesPagePath,
   loadPluginsPage,
+  loadInstalledPluginsPage,
   loadTemplatesPage,
   getTemplateLink,
   performPluginAction,

--- a/lib/assets/sass/manage-prototype.scss
+++ b/lib/assets/sass/manage-prototype.scss
@@ -442,15 +442,16 @@ body .govuk-prototype-kit-manage-prototype-govuk-tag {
   padding-left: 0 !important;
 }
 
-
 .govuk-prototype-kit-manage-prototype-plugin-list-plugin-list {
   border-top: 1px solid #b1b4b6;
   margin-bottom: 2em;
+  display: block;
 }
 
 .govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item {
   border-bottom: 1px solid #b1b4b6;
-  padding: .6em 0
+  padding: .6em 0;
+  display: flex;
 }
 
 .govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item-name {
@@ -485,6 +486,42 @@ body .govuk-prototype-kit-manage-prototype-govuk-tag {
 
 .govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item-version {
   width: 15%
+}
+
+.govuk-prototype-kit-manage-prototype-plugin-badge{
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  background: #1d70b8;
+  border-radius: 10px;
+  color: #fff;
+  display: inline-block;
+  font-family: GDS Transport,arial,sans-serif;
+  font-size: 1.1rem;
+  font-weight: 600;
+  line-height: 1.25;
+  min-width: 10px;
+  padding: 2px 6px 0;
+  text-align: center;
+  white-space: nowrap;
+  margin-left: 10px;
+}
+
+.govuk-prototype-kit-manage-prototype-plugin-updates-message {
+  background: #f3f2f1;
+  color: #505a5f;
+}
+
+.govuk-prototype-kit-manage-prototype-plugin-subnav--current {
+  margin-left: -14px;
+  padding-left: 10px;
+  border-left: 4px solid #1d70b8;
+  background-color: #fff;
+}
+
+.govuk-prototype-kit-manage-prototype-plugin-links-section{
+  border-top: black 1px solid;
+  padding-top: 30px;
+  margin-bottom: 30px;
 }
 
 @media(min-width: 40.0525em) {

--- a/lib/assets/sass/manage-prototype.scss
+++ b/lib/assets/sass/manage-prototype.scss
@@ -526,8 +526,8 @@ body .govuk-prototype-kit-manage-prototype-govuk-tag {
 
 @media(min-width: 40.0525em) {
   .govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item-buttons {
-    .govuk-button {
-      margin: 0
+    .govuk-button, .govuk-link--no-visited-state {
+      margin: 0 15px 0 0;
     }
   }
 }

--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -17,7 +17,7 @@ const syncChanges = require('./sync-changes')
 const {
   lookupPackageInfo,
   getInstalledPackages,
-  getAvailablePackages,
+  getAllPackages,
   getDependentPackages,
   getDependencyPackages,
   waitForPackagesCache
@@ -419,18 +419,18 @@ function buildPluginData (pluginData) {
 }
 
 async function prepareForPluginPage (isInstalledPage, search) {
-  const availablePlugins = await getAvailablePackages()
+  const allPlugins = await getAllPackages()
   const installedPlugins = await getInstalledPackages()
 
   const plugins = isInstalledPage
     ? installedPlugins
-    : availablePlugins.filter(plugin => {
+    : allPlugins.filter(plugin => {
       const pluginName = plugin.packageName?.toLowerCase()
       return pluginName.indexOf(search.toLowerCase()) >= 0
     })
 
   return {
-    status: isInstalledPage ? 'installed' : 'available',
+    status: isInstalledPage ? 'installed' : 'search',
     plugins: plugins.map(buildPluginData),
     found: plugins.length,
     updates: installedPlugins.filter(plugin => plugin.installedVersion !== plugin.latestVersion).length
@@ -510,7 +510,7 @@ async function getPluginsHandler (req, res) {
     currentSection: pageName,
     links: managementLinks,
     isInstalledPage,
-    isAvailablePage: !isInstalledPage,
+    isSearchPage: !isInstalledPage,
     search,
     plugins,
     updatesMessage,
@@ -521,7 +521,7 @@ async function getPluginsHandler (req, res) {
 }
 
 async function postPluginsHandler (req, res) {
-  const query = !req.query?.clear && req.body?.search?.trim() ? `?search=${req.body.search}` : ''
+  const query = req.body?.search?.trim() ? `?search=${req.body.search}` : ''
   res.redirect(contextPath + req.route.path + query)
 }
 

--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -398,11 +398,13 @@ function buildPluginData (pluginData) {
     latestVersion,
     installedVersion,
     required,
-    localVersion
+    localVersion,
+    pluginConfig = {}
   } = pluginData
   const preparedPackageNameForDisplay = plugins.preparePackageNameForDisplay(packageName)
   return {
     ...preparedPackageNameForDisplay,
+    ...pluginConfig.meta,
     packageName,
     latestVersion,
     installedLocally,
@@ -416,22 +418,23 @@ function buildPluginData (pluginData) {
   }
 }
 
-async function prepareForPluginPage () {
-  const installedOut = {}
-  const availableOut = {}
-  const output = [installedOut, availableOut]
-
-  const installedPlugins = await getInstalledPackages()
+async function prepareForPluginPage (isInstalledPage, search) {
   const availablePlugins = await getAvailablePackages()
+  const installedPlugins = await getInstalledPackages()
 
-  installedOut.name = 'Installed'
-  installedOut.plugins = installedPlugins.map(buildPluginData)
-  installedOut.status = 'installed'
-  availableOut.name = 'Available'
-  availableOut.plugins = availablePlugins.map(buildPluginData)
-  availableOut.status = 'available'
+  const plugins = isInstalledPage
+    ? installedPlugins
+    : availablePlugins.filter(plugin => {
+      const pluginName = plugin.packageName?.toLowerCase()
+      return pluginName.indexOf(search.toLowerCase()) >= 0
+    })
 
-  return output
+  return {
+    status: isInstalledPage ? 'installed' : 'available',
+    plugins: plugins.map(buildPluginData),
+    found: plugins.length,
+    updates: installedPlugins.filter(plugin => plugin.installedVersion !== plugin.latestVersion).length
+  }
 }
 
 function getCommand (mode, chosenPlugin) {
@@ -497,24 +500,29 @@ const verbs = {
 }
 
 async function getPluginsHandler (req, res) {
+  const isInstalledPage = req.route.path.endsWith('installed')
+  const { search = '' } = req.query || {}
   const pageName = 'Plugins'
+  const { plugins, status, updates = 0, found = 0 } = await prepareForPluginPage(isInstalledPage, search)
+  const foundMessage = found === 1 ? found + ' Plugin found' : found + ' Plugins found'
+  const updatesMessage = updates ? updates === 1 ? updates + ' UPDATE AVAILABLE' : updates + ' UPDATES AVAILABLE' : ''
   const model = {
     currentSection: pageName,
     links: managementLinks,
-    mode: req.query.mode
+    isInstalledPage,
+    isAvailablePage: !isInstalledPage,
+    search,
+    plugins,
+    updatesMessage,
+    foundMessage,
+    status
   }
-
-  const isSuccessResult = !!req.query.package
-
-  if (isSuccessResult) {
-    model.successBanner = {
-      package: plugins.preparePackageNameForDisplay(req.query.package),
-      mode: req.query.mode,
-      verb: verbs[req.query.mode].status
-    }
-  }
-  model.groupsOfPlugins = await prepareForPluginPage()
   res.render(getManagementView('plugins.njk'), model)
+}
+
+async function postPluginsHandler (req, res) {
+  const query = !req.query?.clear && req.body?.search?.trim() ? `?search=${req.body.search}` : ''
+  res.redirect(contextPath + req.route.path + query)
 }
 
 async function getPluginForRequest (req) {
@@ -734,6 +742,7 @@ module.exports = {
   postTemplatesInstallHandler,
   getTemplatesPostInstallHandler,
   getPluginsHandler,
+  postPluginsHandler,
   getPluginsModeHandler,
   postPluginsStatusHandler,
   postPluginsModeMiddleware,

--- a/lib/manage-prototype-handlers.test.js
+++ b/lib/manage-prototype-handlers.test.js
@@ -33,7 +33,7 @@ const {
   postPluginsStatusHandler,
   postPluginsModeMiddleware,
   getPluginsModeHandler,
-  postPluginsModeHandler
+  postPluginsModeHandler, postPluginsHandler
 } = require('./manage-prototype-handlers')
 const { projectDir } = require('./utils/paths')
 
@@ -131,6 +131,7 @@ describe('manage-prototype-handlers', () => {
       body: {},
       query: {},
       params: {},
+      route: {},
       originalUrl: '/current-url'
     }
     res = {
@@ -432,20 +433,58 @@ describe('manage-prototype-handlers', () => {
       res.json = jest.fn().mockReturnValue({})
     })
 
-    it('getPluginsHandler', async () => {
-      fse.readJsonSync.mockReturnValue(undefined)
-      req.query.mode = 'install'
-      await getPluginsHandler(req, res)
-      expect(res.render).toHaveBeenCalledWith(
-        'views/manage-prototype/plugins.njk',
-        expect.objectContaining({
-          currentSection: 'Plugins',
-          groupsOfPlugins: [
-            { name: 'Installed', plugins: [], status: 'installed' },
-            { name: 'Available', plugins: [availablePlugin], status: 'available' }
-          ]
-        })
-      )
+    describe('getPluginsHandler', () => {
+      it('plugins installed', async () => {
+        fse.readJsonSync.mockReturnValue(undefined)
+        req.route.path = 'plugins-installed'
+        await getPluginsHandler(req, res)
+        expect(res.render).toHaveBeenCalledWith(
+          'views/manage-prototype/plugins.njk',
+          expect.objectContaining({
+            currentSection: 'Plugins',
+            isAvailablePage: false,
+            isInstalledPage: true,
+            plugins: [],
+            status: 'installed'
+          })
+        )
+      })
+      it('plugins available', async () => {
+        fse.readJsonSync.mockReturnValue(undefined)
+        req.route.path = 'plugins'
+        await getPluginsHandler(req, res)
+        expect(res.render).toHaveBeenCalledWith(
+          'views/manage-prototype/plugins.njk',
+          expect.objectContaining({
+            currentSection: 'Plugins',
+            isAvailablePage: true,
+            isInstalledPage: false,
+            plugins: [availablePlugin],
+            status: 'available'
+          })
+        )
+      })
+    })
+
+    describe('postPluginsHandler', () => {
+      const search = 'task list'
+      const routePath = '/plugins-installed'
+      const fullPath = '/manage-prototype' + routePath
+      beforeEach(() => {
+        req.body.search = search
+        req.route.path = routePath
+      })
+
+      it('search', async () => {
+        await postPluginsHandler(req, res)
+        expect(res.redirect).toHaveBeenCalledWith(fullPath + '?search=' + search)
+      })
+
+      it('clear search', async () => {
+        req.query.clear = 'true'
+        await postPluginsHandler(req, res)
+        expect(res.redirect).toHaveBeenCalledWith(fullPath)
+      })
     })
 
     it('getPluginsModeHandler', async () => {

--- a/lib/manage-prototype-handlers.test.js
+++ b/lib/manage-prototype-handlers.test.js
@@ -467,25 +467,14 @@ describe('manage-prototype-handlers', () => {
       })
     })
 
-    describe('postPluginsHandler', () => {
+    it('postPluginsHandler', async () => {
       const search = 'task list'
       const routePath = '/plugins-installed'
       const fullPath = '/manage-prototype' + routePath
-      beforeEach(() => {
-        req.body.search = search
-        req.route.path = routePath
-      })
-
-      it('search', async () => {
-        await postPluginsHandler(req, res)
-        expect(res.redirect).toHaveBeenCalledWith(fullPath + '?search=' + search)
-      })
-
-      it('clear search', async () => {
-        req.query.clear = 'true'
-        await postPluginsHandler(req, res)
-        expect(res.redirect).toHaveBeenCalledWith(fullPath)
-      })
+      req.body.search = search
+      req.route.path = routePath
+      await postPluginsHandler(req, res)
+      expect(res.redirect).toHaveBeenCalledWith(fullPath + '?search=' + search)
     })
 
     it('getPluginsModeHandler', async () => {

--- a/lib/manage-prototype-handlers.test.js
+++ b/lib/manage-prototype-handlers.test.js
@@ -33,7 +33,8 @@ const {
   postPluginsStatusHandler,
   postPluginsModeMiddleware,
   getPluginsModeHandler,
-  postPluginsModeHandler, postPluginsHandler
+  postPluginsModeHandler,
+  postPluginsHandler
 } = require('./manage-prototype-handlers')
 const { projectDir } = require('./utils/paths')
 
@@ -108,7 +109,7 @@ jest.mock('./plugins/packages', () => {
       }
     }),
     getInstalledPackages: jest.fn().mockResolvedValue([]),
-    getAvailablePackages: jest.fn().mockResolvedValue([availablePackage]),
+    getAllPackages: jest.fn().mockResolvedValue([availablePackage]),
     getDependentPackages: jest.fn().mockResolvedValue([]),
     getDependencyPackages: jest.fn().mockResolvedValue([])
   }
@@ -442,7 +443,7 @@ describe('manage-prototype-handlers', () => {
           'views/manage-prototype/plugins.njk',
           expect.objectContaining({
             currentSection: 'Plugins',
-            isAvailablePage: false,
+            isSearchPage: false,
             isInstalledPage: true,
             plugins: [],
             status: 'installed'
@@ -457,10 +458,10 @@ describe('manage-prototype-handlers', () => {
           'views/manage-prototype/plugins.njk',
           expect.objectContaining({
             currentSection: 'Plugins',
-            isAvailablePage: true,
+            isSearchPage: true,
             isInstalledPage: false,
             plugins: [availablePlugin],
-            status: 'available'
+            status: 'search'
           })
         )
       })

--- a/lib/manage-prototype-routes.js
+++ b/lib/manage-prototype-routes.js
@@ -22,7 +22,9 @@ const {
   getPluginsModeHandler,
   postPluginsModeMiddleware,
   postPluginsModeHandler,
-  postPluginsStatusHandler, pluginCacheMiddleware
+  postPluginsStatusHandler,
+  pluginCacheMiddleware,
+  postPluginsHandler
 } = require('./manage-prototype-handlers')
 const path = require('path')
 const { getInternalGovukFrontendDir } = require('./utils')
@@ -69,6 +71,8 @@ router.post('/templates/install', postTemplatesInstallHandler)
 router.get('/templates/post-install', getTemplatesPostInstallHandler)
 
 router.get('/plugins', getPluginsHandler)
+router.post('/plugins', postPluginsHandler)
+router.get('/plugins-installed', getPluginsHandler)
 
 // Be aware that changing this path for monitoring the status of a plugin will affect the
 // kit update process as the browser request and server route would be out of sync.

--- a/lib/nunjucks/views/manage-prototype/plugins.njk
+++ b/lib/nunjucks/views/manage-prototype/plugins.njk
@@ -1,69 +1,145 @@
 {% extends "views/manage-prototype/layout.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/label/macro.njk" import govukLabel %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 
 {% block content %}
-<form method="post">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds-from-desktop">
+    <form method="post" action="">
+        <div class="govuk-grid-row govuk-!-margin-bottom-5">
+            <div class="govuk-grid-column-two-thirds-from-desktop">
+                <h1 class="govuk-heading-l">Plugins</h1>
+                <p class="govuk-body">
+                    Plugins provide you with new components, styles and other features
+                </p>
+            </div>
+        </div>
 
-      <h1 class="govuk-heading-l">Plugins</h1>
-
-      <p class="govuk-body">
-        Plugins provide you with new components, styles and other features
-      </p>
-
-      {% for group in groupsOfPlugins %}
-        <h2 class="govuk-heading-m">{{ group.name }}</h2>
-
-        <ul class="govuk-list govuk-prototype-kit-manage-prototype-plugin-list-plugin-list" data-plugin-group-status="{{ group.status }}">
-          {% for plugin in group.plugins %}
-            <li class="govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item" data-plugin-package-name="{{ plugin.packageName }}">
-              <span class="govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item-name">
-                {{ plugin.name }}
-                {% if plugin.scope %}
-                  <br/>
-                  <span class="govuk-caption-m">From {{ plugin.scope }}</span>
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-quarter">
+                {% if isAvailablePage %}
+                    <div class="sub-nav govuk-!-margin-bottom-6 govuk-prototype-kit-manage-prototype-plugin-subnav--current">
+                        <h2 class="govuk-heading-m">Find plugins</h2>
+                    </div>
+                    <div class="sub-nav">
+                        <a id="installed-plugins-link" href="./plugins-installed" class="govuk-heading-m govuk-link--no-visited-state">
+                            Installed plugins
+                        </a>
+                    </div>
+                {% else %}
+                    <div class="sub-nav govuk-!-margin-bottom-6">
+                        <a id="available-plugins-link" href="./plugins" class="govuk-heading-m govuk-link--no-visited-state">
+                            Find plugins
+                        </a>
+                    </div>
+                    <div class="sub-nav govuk-prototype-kit-manage-prototype-plugin-subnav--current">
+                        <h2 class="govuk-heading-m">Installed plugins</h2>
+                    </div>
                 {% endif %}
-                {% if plugin.updateLink %}
-                  <br/>
-                  v{{ plugin.latestVersion }} available
-                {% endif %}
-              </span>
-              <span class="govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item-version">
-                {{ plugin.installedVersion or plugin.latestVersion }}
-              </span>
-              <span class="govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item-buttons">
-                {% if not plugin.installedVersion %}
-                    {{ govukButton({
-                        html: 'Install <span class="govuk-visually-hidden"> ' + plugin.name + '</span>',
-                        classes: "govuk-button--secondary",
-                        attributes: { id: "install-" + plugin.packageName, formaction: plugin.installLink }
+                {% if updatesMessage %}
+                    {{ govukTag({
+                        text: updatesMessage
                     }) }}
                 {% endif %}
-                {% if plugin.uninstallLink %}
-                    {{ govukButton({
-                        html: 'Uninstall <span class="govuk-visually-hidden"> ' + plugin.name + '</span>',
-                        classes: "govuk-button--secondary",
-                        attributes: { id: "uninstall-" + plugin.packageName, formaction: plugin.uninstallLink }
-                    }) }}
+            </div>
+
+            <div class="govuk-grid-column-three-quarters">
+                {% if isAvailablePage %}
+                <div class="govuk-!-margin-bottom-5">
+                    <div id="search-container">
+                        {{ govukLabel({
+                            text:"Search",
+                            classes:"govuk-!-font-weight-bold"
+                        }) }}
+
+                        {{ govukInput({
+                            id: "search",
+                            classes: "govuk-!-width-one-half",
+                            formGroup: {
+                                classes: "govuk-!-margin-bottom-3"
+                            },
+                            name: "search",
+                            value: search
+                        }) }}
+
+                        {{ govukButton({
+                            text: "Search",
+                            classes: "govuk-button--secondary",
+                            attributes: { id: "search-button", formaction: "#" }
+                        }) }}
+
+                        {{ govukButton({
+                            text: "Clear search",
+                            classes: "govuk-button--secondary",
+                            attributes: { id: "clear-search-button", formaction: "?clear=true" }
+                        }) }}
+                    </div>
+                    <h4 class="govuk-body govuk-!-font-weight-bold">
+                        {{ foundMessage }}
+                    </h4>
+                </div>
                 {% endif %}
-                {% if plugin.updateLink %}
-                    {{ govukButton({
-                        html: 'Update <span class="govuk-visually-hidden"> ' + plugin.name + '</span>',
-                        classes: "govuk-button--secondary",
-                        attributes: { id: "update-" + plugin.packageName, formaction: plugin.updateLink }
-                    }) }}
-                {% endif %}
-                {% if plugin.helpLink %}
-                  <a class=""
-                     href="{{ plugin.helpLink }}">Help<span class="govuk-visually-hidden"> - {{ plugin.name }}</span></a>
-                {% endif %}
-              </span>
-            </li>
-          {% endfor %}
-        </ul>
-      {% endfor %}
-    </div>
-  </div>
-</form>
+
+                <ul class="govuk-list govuk-prototype-kit-manage-prototype-plugin-list-plugin-list"
+                    data-plugin-group-status="{{ status }}">
+                    {% for plugin in plugins %}
+                        <li class="govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item"
+                            data-plugin-package-name="{{ plugin.packageName }}">
+
+                            <div class="govuk-grid-column-one-third govuk-body">
+                                <h4 class="govuk-body govuk-!-font-weight-bold">
+                                    {{ plugin.name }}
+                                </h4>
+                                {% if plugin.scope %}
+                                    <div>
+                                        By {{ plugin.scope }}
+                                    </div>
+                                {% endif %}
+                                {% if isInstalledPage %}
+                                    <div class="govuk-!-margin-top-3">
+                                        v{{ plugin.installedVersion }}
+                                    </div>
+                                {% endif %}
+                            </div>
+                            <div class="govuk-grid-column-two-thirds govuk-body">
+                                {% if plugin.description %}
+                                    <div class="govuk-!-margin-bottom-3">
+                                        {{ plugin.description }}
+                                    </div>
+                                {% endif %}
+                                <div class="govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item-buttons">
+                                {% if not plugin.installedVersion %}
+                                    {{ govukButton({
+                                        html: 'Install <span class="govuk-visually-hidden"> ' + plugin.name + '</span>',
+                                        classes: "govuk-button--secondary",
+                                        attributes: { id: "install-" + plugin.packageName, formaction: plugin.installLink }
+                                    }) }}
+                                {% endif %}
+                                {% if plugin.uninstallLink %}
+                                    {{ govukButton({
+                                        html: 'Uninstall <span class="govuk-visually-hidden"> ' + plugin.name + '</span>',
+                                        classes: "govuk-button--secondary",
+                                        attributes: { id: "uninstall-" + plugin.packageName, formaction: plugin.uninstallLink }
+                                    }) }}
+                                {% endif %}
+                                {% if plugin.updateLink %}
+                                    {{ govukButton({
+                                        html: 'Update <span class="govuk-visually-hidden"> ' + plugin.name + '</span>',
+                                        classes: "govuk-button--secondary",
+                                        attributes: { id: "update-" + plugin.packageName, formaction: plugin.updateLink }
+                                    }) }}
+                                {% endif %}
+                                {% if plugin.helpLink %}
+                                    <a class=""
+                                       href="{{ plugin.helpLink }}">Help<span
+                                                class="govuk-visually-hidden"> - {{ plugin.name }}</span></a>
+                                {% endif %}
+                                </div>
+                            </div>
+                        </li>
+                    {% endfor %}
+                </ul>
+            </div>
+        </div>
+    </form>
 {% endblock %}

--- a/lib/nunjucks/views/manage-prototype/plugins.njk
+++ b/lib/nunjucks/views/manage-prototype/plugins.njk
@@ -17,7 +17,7 @@
 
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-quarter">
-                {% if isAvailablePage %}
+                {% if isSearchPage %}
                     <div class="sub-nav govuk-!-margin-bottom-6 govuk-prototype-kit-manage-prototype-plugin-subnav--current">
                         <h2 class="govuk-heading-m">Find plugins</h2>
                     </div>
@@ -44,7 +44,7 @@
             </div>
 
             <div class="govuk-grid-column-three-quarters">
-                {% if isAvailablePage %}
+                {% if isSearchPage %}
                 <div class="govuk-!-margin-bottom-5">
                     <div id="search-container">
                         {{ govukLabel({
@@ -62,17 +62,15 @@
                             value: search
                         }) }}
 
-                        {{ govukButton({
-                            text: "Search",
-                            classes: "govuk-button--secondary",
-                            attributes: { id: "search-button", formaction: "#" }
-                        }) }}
+                        <div class="govuk-button-group">
+                            {{ govukButton({
+                                text: "Search",
+                                classes: "govuk-button--secondary",
+                                attributes: { id: "search-button", formaction: "#" }
+                            }) }}
 
-                        {{ govukButton({
-                            text: "Clear search",
-                            classes: "govuk-button--secondary",
-                            attributes: { id: "clear-search-button", formaction: "?clear=true" }
-                        }) }}
+                            <a class="govuk-link govuk-link--no-visited-state" href="?">Clear search</a>
+                        </div>
                     </div>
                     <h4 class="govuk-body govuk-!-font-weight-bold">
                         {{ foundMessage }}
@@ -95,45 +93,55 @@
                                         By {{ plugin.scope }}
                                     </div>
                                 {% endif %}
-                                {% if isInstalledPage %}
+                                {% if plugin.installedVersion %}
                                     <div class="govuk-!-margin-top-3">
                                         v{{ plugin.installedVersion }}
                                     </div>
                                 {% endif %}
                             </div>
                             <div class="govuk-grid-column-two-thirds govuk-body">
+                                {% if isSearchPage and plugin.installedVersion %}
+                                    <p>
+                                        {{ govukTag({
+                                            text: "Installed",
+                                            classes: "govuk-tag--grey"
+                                        }) }}
+                                    </p>
+                                {% endif %}
                                 {% if plugin.description %}
                                     <div class="govuk-!-margin-bottom-3">
                                         {{ plugin.description }}
                                     </div>
                                 {% endif %}
                                 <div class="govuk-prototype-kit-manage-prototype-plugin-list-plugin-list__item-buttons">
-                                {% if not plugin.installedVersion %}
-                                    {{ govukButton({
-                                        html: 'Install <span class="govuk-visually-hidden"> ' + plugin.name + '</span>',
-                                        classes: "govuk-button--secondary",
-                                        attributes: { id: "install-" + plugin.packageName, formaction: plugin.installLink }
-                                    }) }}
-                                {% endif %}
-                                {% if plugin.uninstallLink %}
-                                    {{ govukButton({
-                                        html: 'Uninstall <span class="govuk-visually-hidden"> ' + plugin.name + '</span>',
-                                        classes: "govuk-button--secondary",
-                                        attributes: { id: "uninstall-" + plugin.packageName, formaction: plugin.uninstallLink }
-                                    }) }}
-                                {% endif %}
-                                {% if plugin.updateLink %}
-                                    {{ govukButton({
-                                        html: 'Update <span class="govuk-visually-hidden"> ' + plugin.name + '</span>',
-                                        classes: "govuk-button--secondary",
-                                        attributes: { id: "update-" + plugin.packageName, formaction: plugin.updateLink }
-                                    }) }}
-                                {% endif %}
-                                {% if plugin.helpLink %}
-                                    <a class=""
-                                       href="{{ plugin.helpLink }}">Help<span
-                                                class="govuk-visually-hidden"> - {{ plugin.name }}</span></a>
-                                {% endif %}
+                                    <div class="govuk-button-group">
+                                        {% if not plugin.installedVersion %}
+                                            {{ govukButton({
+                                                html: 'Install <span class="govuk-visually-hidden"> ' + plugin.name + '</span>',
+                                                attributes: { id: "install-" + plugin.packageName, formaction: plugin.installLink }
+                                            }) }}
+                                        {% endif %}
+                                        {% if isInstalledPage %}
+                                            {% if plugin.updateLink %}
+                                                {{ govukButton({
+                                                    html: 'Update <span class="govuk-visually-hidden"> ' + plugin.name + '</span>',
+                                                    attributes: { id: "update-" + plugin.packageName, formaction: plugin.updateLink }
+                                                }) }}
+                                            {% endif %}
+                                            {% if plugin.uninstallLink %}
+                                                {{ govukButton({
+                                                    html: 'Uninstall <span class="govuk-visually-hidden"> ' + plugin.name + '</span>',
+                                                    classes: "govuk-button--secondary",
+                                                    attributes: { id: "uninstall-" + plugin.packageName, formaction: plugin.uninstallLink }
+                                                }) }}
+                                            {% endif %}
+                                        {% endif %}
+                                        {% if plugin.helpLink %}
+                                            <a class=""
+                                               href="{{ plugin.helpLink }}">Help<span
+                                                        class="govuk-visually-hidden"> - {{ plugin.name }}</span></a>
+                                        {% endif %}
+                                     </div>
                                 </div>
                             </div>
                         </li>

--- a/lib/plugins/packages.js
+++ b/lib/plugins/packages.js
@@ -176,13 +176,12 @@ async function getInstalledPackages () {
     .reduce(emphasizeBasePlugins, [])
 }
 
-async function getAvailablePackages () {
+async function getAllPackages () {
   if (!Object.keys(packagesCache).length) {
     await startPackageTracker()
   }
   await waitForPackagesCache()
   return Object.values(packagesCache)
-    .filter(({ available, installed }) => available && !installed)
     .sort(packageNameSort)
     .reduce(emphasizeBasePlugins, [])
 }
@@ -274,7 +273,7 @@ module.exports = {
   waitForPackagesCache,
   lookupPackageInfo,
   getInstalledPackages,
-  getAvailablePackages,
+  getAllPackages,
   getDependentPackages,
   getDependencyPackages
 }

--- a/lib/plugins/packages.spec.js
+++ b/lib/plugins/packages.spec.js
@@ -237,7 +237,10 @@ describe('packages', () => {
           ],
           scripts: [
             '/dist/jquery.js'
-          ]
+          ],
+          meta: {
+            description: 'Add the jQuery JavaScript library to your prototype'
+          }
         },
         versions: [
           '1.0.0',

--- a/lib/plugins/packages.spec.js
+++ b/lib/plugins/packages.spec.js
@@ -16,7 +16,7 @@ const requestHttps = require('../utils/requestHttps')
 const {
   getInstalledPackages,
   setPackagesCache,
-  getAvailablePackages,
+  getAllPackages,
   getDependentPackages,
   getDependencyPackages
 } = require('./packages')
@@ -84,10 +84,14 @@ describe('packages', () => {
       })
     })
 
-    describe('getAvailablePackages', () => {
+    describe('getAllPackages', () => {
       it('', async () => {
-        const availablePackages = await getAvailablePackages()
-        expect(availablePackages).toEqual([availableUninstalledPackage])
+        const allPackages = await getAllPackages()
+        expect(allPackages).toEqual([
+          availableInstalledPackage,
+          availableUninstalledPackage,
+          unavailableInstalledPackage,
+          unavailableUninstalledPackage])
       })
     })
 
@@ -239,7 +243,7 @@ describe('packages', () => {
             '/dist/jquery.js'
           ],
           meta: {
-            description: 'Add the jQuery JavaScript library to your prototype'
+            description: 'jQuery is a fast, small, and feature-rich JavaScript library. It makes things like HTML document traversal and manipulation, event handling, animation, and Ajax much simpler with an easy-to-use API that works across a multitude of browsers.'
           }
         },
         versions: [

--- a/lib/plugins/plugin-utils.js
+++ b/lib/plugins/plugin-utils.js
@@ -3,7 +3,15 @@ function getProxyPluginConfig (packageName) {
   const proxyPluginConfig = {
     jquery: {
       scripts: ['/dist/jquery.js'],
-      assets: ['/dist']
+      assets: ['/dist'],
+      meta: {
+        description: 'Add the jQuery JavaScript library to your prototype'
+      }
+    },
+    'notifications-node-client': {
+      meta: {
+        description: 'Send emails and SMS from GOV.UK Notify'
+      }
     }
   }
   return proxyPluginConfig[packageName] ? { ...proxyPluginConfig[packageName] } : undefined

--- a/lib/plugins/plugin-utils.js
+++ b/lib/plugins/plugin-utils.js
@@ -5,12 +5,12 @@ function getProxyPluginConfig (packageName) {
       scripts: ['/dist/jquery.js'],
       assets: ['/dist'],
       meta: {
-        description: 'Add the jQuery JavaScript library to your prototype'
+        description: 'jQuery is a fast, small, and feature-rich JavaScript library. It makes things like HTML document traversal and manipulation, event handling, animation, and Ajax much simpler with an easy-to-use API that works across a multitude of browsers.'
       }
     },
     'notifications-node-client': {
       meta: {
-        description: 'Send emails and SMS from GOV.UK Notify'
+        description: 'GOV.UK Notify makes it easy for public sector service teams to send emails, text messages and letters.'
       }
     }
   }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5665,9 +5665,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.5.0.tgz",
-      "integrity": "sha512-gZHDqf5vdlHjmx0NGJiNT12XLyR3d5KCS4AnlC3xTWOObJ0kQROrkIFyp3w4/PY3EQiYdgacVaJ6lizzygnzYw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -15147,9 +15147,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.5.0.tgz",
-      "integrity": "sha512-gZHDqf5vdlHjmx0NGJiNT12XLyR3d5KCS4AnlC3xTWOObJ0kQROrkIFyp3w4/PY3EQiYdgacVaJ6lizzygnzYw=="
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg=="
     },
     "graceful-fs": {
       "version": "4.2.10",


### PR DESCRIPTION
See https://github.com/alphagov/govuk-prototype-kit/issues/2298

Changes included:
- Change plugins page as per design and changes as requested
- Support plugin config meta data
- Add `/plugins-installed` route
- Add _search_ and _filter_ behaviour for available plugins
- Update Acceptance tests to handle separate _Installed_ and _Find_ Plugin pages
- Added unit tests for the new post route for search
- Cleaned up some Acceptance tests to allow them to retry correctly
- Added meta data for the jquery proxy config
- Added a proxy config for notify so meta data could be added

Changes not included:
- Pagination will be done in a separate PR
