### PR TITLE
Only show Clear search link if there's a search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- [#2318: Only show Clear search link if there's a search](https://github.com/alphagov/govuk-prototype-kit/pull/2318)
+
 ## 13.13.0
 
 ### New features

--- a/lib/nunjucks/views/manage-prototype/plugins.njk
+++ b/lib/nunjucks/views/manage-prototype/plugins.njk
@@ -69,12 +69,14 @@
                                 attributes: { id: "search-button", formaction: "#" }
                             }) }}
 
-                            <a class="govuk-link govuk-link--no-visited-state" href="?">Clear search</a>
+                            {% if search %}
+                                <a class="govuk-link govuk-link--no-visited-state" href="?">Clear search</a>
+                            {% endif %}
                         </div>
                     </div>
-                    <h4 class="govuk-body govuk-!-font-weight-bold">
+                    <h3 class="govuk-body govuk-!-font-weight-bold">
                         {{ foundMessage }}
-                    </h4>
+                    </h3>
                 </div>
                 {% endif %}
 


### PR DESCRIPTION
also fixes the heading hierarchy - now we have h1, h2, h3, h4