### PR TITLE
Preparing for release 13.13.1 (automated).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 13.13.1
+
 ### Fixes
 
 - [#2318: Only show Clear search link if there's a search](https://github.com/alphagov/govuk-prototype-kit/pull/2318)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "govuk-prototype-kit",
-  "version": "13.13.0",
+  "version": "13.13.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-prototype-kit",
-      "version": "13.13.0",
+      "version": "13.13.1",
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "body-parser": "^1.20.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-prototype-kit",
   "description": "Rapidly create HTML prototypes of GOV.UK services",
-  "version": "13.13.0",
+  "version": "13.13.1",
   "engines": {
     "node": "^16.x || >= 18.x"
   },


### PR DESCRIPTION

### Fixes

- [#2318: Only show Clear search link if there's a search](https://github.com/alphagov/govuk-prototype-kit/pull/2318)
- [#2321: Update hint for create page](https://github.com/alphagov/govuk-prototype-kit/pull/2321)
- [#2317: Using internal GOV.UK Frontend more widely](https://github.com/alphagov/govuk-prototype-kit/pull/2317) - this makes error pages, password pages etc. more reliable.