### PR TITLE
Use GOV.UK Frontend v5 on management pages and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- [#2327: Use GOV.UK Frontend v5 on management pages and tests](https://github.com/alphagov/govuk-prototype-kit/pull/2327)
+
 ## 13.16.0
 
 ### New features

--- a/cypress/e2e/dev/5-management-tests/no-autodatastore-on-management-pages.cypress.js
+++ b/cypress/e2e/dev/5-management-tests/no-autodatastore-on-management-pages.cypress.js
@@ -55,9 +55,9 @@ describe('clear data page', () => {
 
     cy.task('log', 'Add some data')
     cy.visit(`/question-check?most-impressive-trick=${encodeURIComponent(answer)}`)
-    cy.get('.govuk-header__logotype-text')
+    cy.get('.govuk-header__logotype')
     cy.visit('/manage-prototype/plugins?abc=def')
-    cy.get('.govuk-header__logotype-text')
+    cy.get('.govuk-header__logotype')
 
     cy.task('log', 'Check data has been saved')
     cy.visit('/question-check')

--- a/cypress/e2e/smoke/0-smoke-tests/index-page.cypress.js
+++ b/cypress/e2e/smoke/0-smoke-tests/index-page.cypress.js
@@ -9,9 +9,9 @@ describe('smoke test', () => {
   })
 
   it('GOV.UK Frontend fonts loaded', () => {
-    waitForApplication('/')
+    waitForApplication('/manage-prototype')
 
-    const fontUrl = '/plugin-assets/govuk-frontend/govuk/assets/fonts/bold-b542beb274-v2.woff2'
+    const fontUrl = '/manage-prototype/dependencies/govuk-frontend/dist/govuk/assets/fonts/bold-b542beb274-v2.woff2'
 
     cy.task('log', 'Requesting govuk-frontend font')
     cy.request(`/${fontUrl}`, { retryOnStatusCodeFailure: true })

--- a/cypress/e2e/utils.js
+++ b/cypress/e2e/utils.js
@@ -15,7 +15,7 @@ const waitForApplication = async (path = '/index') => {
   log(`Waiting for app to restart and load ${path} page`)
   cy.task('waitUntilAppRestarts')
   cy.visit(path)
-  cy.get('.govuk-header__logotype-text')
+  cy.get('.govuk-header__logotype')
     .contains('GOV.UK')
 }
 

--- a/lib/nunjucks/views/manage-prototype/scripts.njk
+++ b/lib/nunjucks/views/manage-prototype/scripts.njk
@@ -1,3 +1,3 @@
 <script src="/plugin-assets/govuk-prototype-kit/lib/assets/javascripts/kit.js"></script>
-<script src="/manage-prototype/dependencies/govuk-frontend/govuk/all.js"></script>
-<script src="/manage-prototype/dependencies/govuk-frontend/govuk-prototype-kit/init.js"></script>
+<script src="/manage-prototype/dependencies/govuk-frontend/dist/govuk/govuk-frontend.min.js" type="module"></script>
+<script src="/manage-prototype/dependencies/govuk-frontend/dist/govuk-prototype-kit/init.js" type="module"></script>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -20,7 +20,7 @@
         "express": "^4.18.2",
         "express-session": "^1.17.3",
         "fs-extra": "^11.1.1",
-        "govuk-frontend": "4.7.0",
+        "govuk-frontend": "5.0.0",
         "inquirer": "^8.2.6",
         "lodash": "^4.17.21",
         "marked": "^4.3.0",
@@ -6149,9 +6149,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
-      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.0.0.tgz",
+      "integrity": "sha512-3WSfvQ+3kw/q/m8jrq/t8XnMUA8D2r0uhGyZaDbIh1gWTJBQzJBHbHiKYI9nc9ixIXdCFsc9RozkgEm57a795g==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -16452,9 +16452,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
-      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.0.0.tgz",
+      "integrity": "sha512-3WSfvQ+3kw/q/m8jrq/t8XnMUA8D2r0uhGyZaDbIh1gWTJBQzJBHbHiKYI9nc9ixIXdCFsc9RozkgEm57a795g=="
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "express": "^4.18.2",
     "express-session": "^1.17.3",
     "fs-extra": "^11.1.1",
-    "govuk-frontend": "4.7.0",
+    "govuk-frontend": "5.0.0",
     "inquirer": "^8.2.6",
     "lodash": "^4.17.21",
     "marked": "^4.3.0",


### PR DESCRIPTION
PR to use **GOV.UK Frontend v5** on management pages including the error server

Plugins can [freely use GOV.UK Frontend v5](https://github.com/alphagov/govuk-prototype-kit/issues/2293) already but internal pages still use v4 and fail some tests

## Test fixes
This PR also unblocks status checks on `main` where we know some tests install the latest `govuk-frontend` plugin. Current CSS selectors for the logo were incompatible between v4 and v5 so have been fixed

`.govuk-header__logotype-text` → `.govuk-header__logotype`