### PR TITLE
Fix errors.json logging `ENOENT: no such file or directory`

### DIFF
--- a/lib/sync-changes.js
+++ b/lib/sync-changes.js
@@ -5,6 +5,7 @@ const EventEmitter = require('events')
 const browserSync = require('browser-sync')
 const { ensureDirSync, writeJsonSync } = require('fs-extra')
 const path = require('path')
+const util = require('util')
 const { tmpDir } = require('./utils/paths')
 const fs = require('fs')
 
@@ -19,8 +20,15 @@ function hasRestartedAfterError () {
 }
 
 function flagError (error) {
+  const errorFormatted = util.inspect(error, {
+    compact: false,
+    depth: Infinity,
+    maxArrayLength: Infinity,
+    maxStringLength: Infinity
+  })
+
   ensureDirSync(path.dirname(errorsFile))
-  writeJsonSync(errorsFile, { error })
+  writeJsonSync(errorsFile, { error: errorFormatted })
 }
 
 function unflagError () {

--- a/lib/sync-changes.js
+++ b/lib/sync-changes.js
@@ -3,7 +3,7 @@ const EventEmitter = require('events')
 
 // npm dependencies
 const browserSync = require('browser-sync')
-const { writeJsonSync } = require('fs-extra')
+const { ensureDirSync, writeJsonSync } = require('fs-extra')
 const path = require('path')
 const { tmpDir } = require('./utils/paths')
 const fs = require('fs')
@@ -19,7 +19,8 @@ function hasRestartedAfterError () {
 }
 
 function flagError (error) {
-  writeJsonSync(path.join(tmpDir, 'errors.json'), { error })
+  ensureDirSync(path.dirname(errorsFile))
+  writeJsonSync(errorsFile, { error })
 }
 
 function unflagError () {

--- a/lib/sync-changes.test.js
+++ b/lib/sync-changes.test.js
@@ -23,11 +23,12 @@ describe('sync-changes', () => {
 
   it('flags error correctly', () => {
     const error = { data: true }
+    const errorFormatted = '{\n  data: true\n}'
 
     syncChanges.flagError(error)
 
     expect(fse.writeJsonSync).toHaveBeenCalledTimes(1)
-    expect(fse.writeJsonSync).toHaveBeenCalledWith(errorsFile, { error })
+    expect(fse.writeJsonSync).toHaveBeenCalledWith(errorsFile, { error: errorFormatted })
   })
 
   it('syncs correctly', () => {


### PR DESCRIPTION
This PR helped me find and fix an issue in https://github.com/alphagov/govuk-prototype-kit/pull/2306

Before that I was stuck with this error in the terminal:

```console
Error: ENOENT: no such file or directory, open '/private/var/folders/2k/ws6lqbf57d75yf8xt7tt_bqc0000gn/T/test-prototype/.tmp/errors.json'
```

My issue had crashed early enough to confirm:

1. The helper `flagError()` can run before **.tmp** directory exists
2. Errors can be written as empty strings by `writeJsonSync(errorPath, { error })`

This PR stops that from happening