### PR TITLE
Fix error server `/manage-prototype/dependencies`

### DIFF
--- a/lib/assets/sass/manage-prototype.scss
+++ b/lib/assets/sass/manage-prototype.scss
@@ -1,5 +1,3 @@
-$govuk-assets-path: '/manage-prototype/dependencies/govuk-frontend/govuk/assets/';
-
 // Import GOV.UK Frontend within the kit dependency
 @import ".tmp/sass/kit-frontend-dependency";
 

--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -10,7 +10,6 @@ const allowedPathsWhenUnauthenticated = [
   '/manage-prototype/password',
   '/public/stylesheets/unbranded.css',
   '/plugin-assets/govuk-prototype-kit/lib/assets/images/unbranded.ico',
-  '/plugin-assets/govuk-frontend/govuk/all.js',
   // Keep /extension-assets path for backwards compatibility
   // TODO: remove in v14
   '/extension-assets/govuk-prototype-kit/lib/assets/images/unbranded.ico']

--- a/lib/build.js
+++ b/lib/build.js
@@ -141,6 +141,7 @@ function sassVariables (contextPath = '', isLegacyGovukFrontend = false) {
   // Patch missing 'init.scss' before GOV.UK Frontend v4.4.0
   // in plugin versions, but will default to false for internal
   if (isLegacyGovukFrontend) {
+    fileContents += '$govuk-assets-path: $govuk-extensions-url-context + "/govuk-frontend/govuk/assets/";\n'
     fileContents += '$govuk-global-styles: true !default;\n'
     fileContents += '$govuk-new-link-styles: true !default;\n'
   }

--- a/lib/build.js
+++ b/lib/build.js
@@ -198,6 +198,7 @@ function _generateCssSync (sassPath, cssPath, options = {}) {
         quietDeps: true,
         loadPaths: [projectDir],
         sourceMap: true,
+        sourceMapIncludeSources: true,
         style: 'expanded'
       })
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -89,12 +89,18 @@ function sassInclude (filePath) {
 
 function sassKitFrontendDependency () {
   const timer = startPerformanceTimer()
+
   const internalGovUkFrontendDir = getInternalGovukFrontendDir()
   const internalGovUkFrontendConfig = fse.readJsonSync(path.join(internalGovUkFrontendDir, 'govuk-prototype-kit.config.json'))
-  const fileContents = internalGovUkFrontendConfig.sass
+
+  const govukFrontendSass = internalGovUkFrontendConfig.sass
     .map(sassPath => path.join(internalGovUkFrontendDir, sassPath))
-    .map(sassInclude)
-    .join('\n')
+
+  const fileContents = sassVariables('/manage-prototype/dependencies') +
+    govukFrontendSass
+      .map(sassInclude)
+      .join('\n')
+
   ensureTempDirExists(tmpSassDir)
   fse.writeFileSync(path.join(tmpSassDir, '_kit-frontend-dependency.scss'), fileContents)
   endPerformanceTimer('sassKitFrontendDependency', timer)
@@ -116,28 +122,40 @@ function sassLegacyPatterns () {
       .join('\n')
   } else {
     fileContents = `
-/* Legacy patterns not included as govuk-frontend plugin not installed */    
+/* Legacy patterns not included as govuk-frontend plugin not installed */
     `
   }
   fse.writeFileSync(path.join(tmpSassDir, '_legacy-patterns.scss'), fileContents)
   endPerformanceTimer('sassLegacyPatterns', timer)
 }
 
-function sassPlugins () {
-  const timer = startPerformanceTimer()
+function sassVariables (contextPath = '', isLegacyGovukFrontend = false) {
   let fileContents = ''
+
   // Keep $govuk-extensions-url-context for backwards compatibility
   // TODO: remove in v14
-  fileContents += '$govuk-extensions-url-context: "/plugin-assets";\n'
-  fileContents += '$govuk-plugins-url-context: "/plugin-assets";\n'
+  fileContents += `$govuk-extensions-url-context: "${contextPath}";\n`
+  fileContents += `$govuk-plugins-url-context: "${contextPath}";\n`
   fileContents += '$govuk-prototype-kit-major-version: 13;\n'
-  if (plugins.legacyGovukFrontendFixesNeeded()) {
+
+  // Patch missing 'init.scss' before GOV.UK Frontend v4.4.0
+  // in plugin versions, but will default to false for internal
+  if (isLegacyGovukFrontend) {
     fileContents += '$govuk-global-styles: true !default;\n'
     fileContents += '$govuk-new-link-styles: true !default;\n'
   }
-  fileContents += plugins.getFileSystemPaths('sass')
-    .map(sassInclude)
-    .join('\n')
+
+  return fileContents
+}
+
+function sassPlugins () {
+  const timer = startPerformanceTimer()
+
+  const fileContents = sassVariables('/plugin-assets', plugins.legacyGovukFrontendFixesNeeded()) +
+    plugins.getFileSystemPaths('sass')
+      .map(sassInclude)
+      .join('\n')
+
   ensureTempDirExists(tmpSassDir)
   fse.writeFileSync(path.join(tmpSassDir, '_plugins.scss'), fileContents)
   endPerformanceTimer('sassPlugins', timer)
@@ -145,8 +163,11 @@ function sassPlugins () {
 
 function sassErrorPage () {
   const timer = startPerformanceTimer()
+
+  const fileContents = sassVariables('/manage-prototype/dependencies') +
+    sassInclude(path.join(libSassDir, 'includes', '_error-page.scss'))
+
   ensureTempDirExists(tmpSassDir)
-  const fileContents = sassInclude(path.join(libSassDir, 'includes', '_error-page.scss'))
   fse.writeFileSync(path.join(tmpSassDir, 'error-page.scss'), fileContents)
   endPerformanceTimer('sassErrorPage', timer)
 }

--- a/lib/errorServer.js
+++ b/lib/errorServer.js
@@ -37,7 +37,7 @@ function runErrorServer (error) {
   }
 
   const knownPaths = {
-    '/public/stylesheets/application.css': {
+    '/public/stylesheets/manage-prototype.css': {
       type: 'text/css',
       contents: fs.readFileSync(path.join(process.cwd(), '.tmp', 'public', 'stylesheets', 'manage-prototype.css'))
     }

--- a/lib/errorServer.js
+++ b/lib/errorServer.js
@@ -28,6 +28,7 @@ function runErrorServer (error) {
     css: 'text/css',
     ico: 'image/x-icon',
     js: 'text/javascript',
+    map: 'application/json',
     mjs: 'text/javascript',
     png: 'image/png',
     svg: 'image/svg+xml',

--- a/lib/errorServer.js
+++ b/lib/errorServer.js
@@ -25,8 +25,14 @@ function runErrorServer (error) {
   const proxyPort = port - 50
   const http = require('http')
   const fileExtensionsToMimeTypes = {
-    js: 'application/javascript',
-    css: 'text/css'
+    css: 'text/css',
+    ico: 'image/x-icon',
+    js: 'text/javascript',
+    mjs: 'text/javascript',
+    png: 'image/png',
+    svg: 'image/svg+xml',
+    woff: 'application/font-woff',
+    woff2: 'application/font-woff2'
   }
 
   const knownPaths = {

--- a/lib/errorServer.js
+++ b/lib/errorServer.js
@@ -36,6 +36,9 @@ function runErrorServer (error) {
     }
   }
 
+  /**
+   * @type {http.RequestListener}
+   */
   const requestListener = function (req, res) {
     if (req.url.startsWith('/browser-sync')) {
       return
@@ -51,18 +54,27 @@ function runErrorServer (error) {
       res.end(knownPaths[req.url].contents)
       return
     }
-    if (req.url.startsWith('/plugin-assets')) {
-      res.setHeader('Content-Type', fileExtensionsToMimeTypes[req.url.split('.').at(-1)] || 'text/plain')
-      const urlParts = req.url.split('/').slice(2)
-      const pluginName = urlParts.shift()
-      let filePath
-      if (pluginName === 'govuk-frontend') {
-        filePath = path.join(getInternalGovukFrontendDir(), ...urlParts)
-      } else {
-        filePath = path.join(process.cwd(), 'node_modules', pluginName, ...urlParts)
+
+    for (const knownRoute of [
+      '/manage-prototype/dependencies/',
+      '/plugin-assets/'
+    ]) {
+      if (!req.url.startsWith(knownRoute)) {
+        continue
       }
+
+      const filePath = req.url.split(knownRoute).at(-1)
+      const fileExtension = filePath.split('.').at(-1)
+
+      res.setHeader('Content-Type', fileExtensionsToMimeTypes[fileExtension] || 'text/plain')
+
+      // Route GOV.UK Frontend to internal package
+      const modulesDir = filePath.startsWith('govuk-frontend/') && knownRoute.startsWith('/manage-prototype/')
+        ? path.dirname(getInternalGovukFrontendDir())
+        : path.join(process.cwd(), 'node_modules')
+
       try {
-        const contents = fs.readFileSync(filePath)
+        const contents = fs.readFileSync(path.join(modulesDir, filePath))
         res.writeHead(200)
         res.end(contents)
       } catch (e) {
@@ -70,6 +82,7 @@ function runErrorServer (error) {
         res.writeHead(500)
         res.end('500 Server Error')
       }
+
       return
     }
 

--- a/lib/nunjucks/views/error-handling/server-error.njk
+++ b/lib/nunjucks/views/error-handling/server-error.njk
@@ -1,3 +1,4 @@
+{%- set assetPath = '/manage-prototype/dependencies/govuk-frontend/govuk/assets' -%}
 {% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}
 
 {% block pageTitle %}

--- a/lib/nunjucks/views/error-handling/server-error.njk
+++ b/lib/nunjucks/views/error-handling/server-error.njk
@@ -1,5 +1,4 @@
-{%- set assetPath = '/manage-prototype/dependencies/govuk-frontend/govuk/assets' -%}
-{% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}
+{% extends "views/manage-prototype/layout.njk" %}
 
 {% block pageTitle %}
   Error {% if serviceName %}– {{ serviceName }}{% endif %} – GOV.UK Prototype Kit


### PR DESCRIPTION
This PR fixes a few error page issues

It picks up from changes to isolate GOV.UK Frontend versions in:

* https://github.com/alphagov/govuk-prototype-kit/pull/2317

## Sass variables

The error page Sass `$govuk-assets-path` uses **/manage-prototype/dependencies/govuk-frontend**  but we didn't handle error server responses for this route so fonts and background images were missing:

https://github.com/alphagov/govuk-prototype-kit/blob/86fb72a0290af1896dce34472732a778711f6072/lib/assets/sass/manage-prototype.scss#L1

<img width="634" alt="Fonts missing" src="https://github.com/alphagov/govuk-prototype-kit/assets/415517/b8e1dce2-3325-484e-937b-ccce62c03fab">

<img width="532" alt="Fonts missing, errors" src="https://github.com/alphagov/govuk-prototype-kit/assets/415517/26f81e33-67c0-4dbf-8596-a1b61fc472e3">

## Nunjucks assets

The error page Nunjucks `assetPath` uses **/plugin-assets/govuk-frontend** which would typically route to a plugin version of GOV.UK Frontend rather than one internal to the Prototype Kit

This was handled but with different URLs to the CSS:

```html
<link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/plugin-assets/govuk-frontend/govuk/assets/images/favicon.ico" type="image/x-icon">
<link rel="mask-icon" href="/plugin-assets/govuk-frontend/govuk/assets/images/govuk-mask-icon.svg" color="#0b0c0c">
```

https://github.com/alphagov/govuk-prototype-kit/blob/d262239d601e92cc7af138fcf94c7a26172e6bd2/lib/errorServer.js#L59-L61

## Sass variables

The error page shares the [`manage-prototype.scss`](https://github.com/alphagov/govuk-prototype-kit/blob/86fb72a0290af1896dce34472732a778711f6072/lib/assets/sass/manage-prototype.scss#L1) stylesheet which is hard coded to use:

https://github.com/alphagov/govuk-prototype-kit/blob/86fb72a0290af1896dce34472732a778711f6072/lib/assets/sass/manage-prototype.scss#L1

## HTTP content-type headers

GOV.UK Frontend includes fonts (`*.woff`, `*.woff2`), images (`*.png`, `*.svg`) and favicons (`*.ico`)

These have now been added to the error server including `*.mjs` with the [old-but-new `text/javascript` type](https://www.rfc-editor.org/rfc/rfc9239)

https://github.com/alphagov/govuk-prototype-kit/blob/86fb72a0290af1896dce34472732a778711f6072/lib/errorServer.js#L27-L30

## Legacy GOV.UK Frontend

The Prototype Kit currently patches versions of GOV.UK Frontend prior to v4.4.0 (where `nunjucksMacros` and `sass` fields were added to the plugin config) but the `$govuk-assets-path` variable was missing leaving the default as:

```scss
$govuk-assets-path: '/govuk/assets/';
```