### PR TITLE
Bump govuk-frontend from 4.5.0 to 4.7.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -20,7 +20,7 @@
         "express": "^4.18.2",
         "express-session": "^1.17.3",
         "fs-extra": "^11.1.0",
-        "govuk-frontend": "^4.5.0",
+        "govuk-frontend": "4.7.0",
         "inquirer": "^8.2.0",
         "lodash": "^4.17.21",
         "marked": "^4.2.5",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "express": "^4.18.2",
     "express-session": "^1.17.3",
     "fs-extra": "^11.1.0",
-    "govuk-frontend": "^4.5.0",
+    "govuk-frontend": "4.7.0",
     "inquirer": "^8.2.0",
     "lodash": "^4.17.21",
     "marked": "^4.2.5",


### PR DESCRIPTION
Putting my colinbot hat on 🤖

Updates `govuk-frontend` from 4.5.0 to 4.7.0

- [Release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v4.7.0)
- [Changelog](https://github.com/alphagov/govuk-frontend/blob/v4.7.0/CHANGELOG.md)
- [Commits](https://github.com/alphagov/govuk-frontend/commits/v4.7.0)

Applies to internal pages only as plugins are updated separately since:

* https://github.com/alphagov/govuk-prototype-kit/pull/2118