### PR TITLE
Do not compile sass files with an underscore prefix

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -192,7 +192,11 @@ function _generateCssSync (sassPath, cssPath, options = {}) {
   if (!fse.existsSync(sassPath)) return
   fse.mkdirSync(cssPath, { recursive: true })
   fse.readdirSync(sassPath)
-    .filter(file => ((file.endsWith('.scss') && !filesToSkip.includes(file))))
+    .filter(file => ((
+      file.endsWith('.scss') &&
+      !file.startsWith('_') &&
+      !filesToSkip.includes(file)
+    )))
     .forEach(file => {
       const result = sass.compile(path.join(sassPath, file), {
         quietDeps: true,


### PR DESCRIPTION
This fixes the error behind the misleading error in https://github.com/alphagov/govuk-prototype-kit/issues/2335