### PR TITLE
Preparing for release 13.13.3 (automated).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 13.13.3
+
 ### Fixes
 
 - [#2342: Open fewer files at once during migration](https://github.com/alphagov/govuk-prototype-kit/pull/2342)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "govuk-prototype-kit",
-  "version": "13.13.2",
+  "version": "13.13.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-prototype-kit",
-      "version": "13.13.2",
+      "version": "13.13.3",
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "body-parser": "^1.20.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-prototype-kit",
   "description": "Rapidly create HTML prototypes of GOV.UK services",
-  "version": "13.13.2",
+  "version": "13.13.3",
   "engines": {
     "node": "^16.x || >= 18.x"
   },


### PR DESCRIPTION

### Fixes

- [#2342: Open fewer files at once during migration](https://github.com/alphagov/govuk-prototype-kit/pull/2342)
- [#2340: Do not compile sass files with an underscore prefix](https://github.com/alphagov/govuk-prototype-kit/pull/2340)
- [#2334: Making sure Manage Prototype pages use govuk-frontend v4.7.0](https://github.com/alphagov/govuk-prototype-kit/pull/2334)