### PR TITLE
Fix GOV.UK Frontend `initAll()` on management pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - [#2306: Locate GOV.UK Frontend using `require.resolve()`](https://github.com/alphagov/govuk-prototype-kit/pull/2306)
+- [#2349: Fix GOV.UK Frontend `initAll()` on management pages](https://github.com/alphagov/govuk-prototype-kit/pull/2349)
 
 ## 13.13.3
 

--- a/lib/nunjucks/views/manage-prototype/scripts.njk
+++ b/lib/nunjucks/views/manage-prototype/scripts.njk
@@ -1,3 +1,3 @@
+<script src="/plugin-assets/govuk-prototype-kit/lib/assets/javascripts/kit.js"></script>
 <script src="/manage-prototype/dependencies/govuk-frontend/govuk/all.js"></script>
 <script src="/manage-prototype/dependencies/govuk-frontend/govuk-prototype-kit/init.js"></script>
-<script src="/plugin-assets/govuk-prototype-kit/lib/assets/javascripts/kit.js"></script>


### PR DESCRIPTION
On management pages, `window.GOVUKPrototypeKit` is unavailable when GOV.UK Frontend `init.js` runs

This PR loads `kit.js` first to ensure `window.GOVUKPrototypeKit` is available

Fixes https://github.com/alphagov/govuk-prototype-kit/issues/2348