### PR TITLE
Preparing for release 13.13.4 (automated).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 13.13.4
+
 ### Fixes
 
 - [#2306: Locate GOV.UK Frontend using `require.resolve()`](https://github.com/alphagov/govuk-prototype-kit/pull/2306)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "govuk-prototype-kit",
-  "version": "13.13.3",
+  "version": "13.13.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-prototype-kit",
-      "version": "13.13.3",
+      "version": "13.13.4",
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "body-parser": "^1.20.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-prototype-kit",
   "description": "Rapidly create HTML prototypes of GOV.UK services",
-  "version": "13.13.3",
+  "version": "13.13.4",
   "engines": {
     "node": "^16.x || >= 18.x"
   },


### PR DESCRIPTION

### Fixes

- [#2306: Locate GOV.UK Frontend using `require.resolve()`](https://github.com/alphagov/govuk-prototype-kit/pull/2306)
- [#2349: Fix GOV.UK Frontend `initAll()` on management pages](https://github.com/alphagov/govuk-prototype-kit/pull/2349)