### PR TITLE
Enable JavaScript code autocomplete using `jsconfig.json`

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,5 +1,15 @@
 {
+  "exclude": [
+    "**/*.spec.*",
+    "**/*.test.*",
+    "__tests__",
+    "cypress",
+    "lib/assets",
+    "prototype-starter",
+    "scripts"
+  ],
   "compilerOptions": {
+    "checkJs": true,
     "module": "NodeNext",
     "resolveJsonModule": true
   }


### PR DESCRIPTION
For recent contributions I've been running with a [**jsconfig.json**](https://code.visualstudio.com/docs/languages/jsconfig) file

It's helped me find and fix a few things but there's no necessity to merge

### Code autocomplete

This PR will automatically pick up JSDoc annotations in IntelliJ, WebStorm, Visual Studio, Visual Studio Code and Sublime Text (via the TypeScript plugin) so you can see tooltips like:

<img width="814" alt="JSDoc types in autocomplete" src="https://github.com/alphagov/govuk-prototype-kit/assets/415517/232a8695-765d-4cae-a701-6e48da222abe">

### Code checking

Optionally you can enable `"checkJs": true` when needed as a good way to spot bugs

```patch
  {
    "compilerOptions": {
+    "checkJs": true,
      "module": "NodeNext",
      "resolveJsonModule": true
    }
  }
```