### PR TITLE
Simplify and improve acceptance tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [#2355: Prevent management pages using "plugin" GOV.UK Frontend views](https://github.com/alphagov/govuk-prototype-kit/pull/2355)
 - [#2356: Only allow plugin update functionality when installed from npm](https://github.com/alphagov/govuk-prototype-kit/pull/2356)
+- [#2357: Simplify and improve acceptance tests](https://github.com/alphagov/govuk-prototype-kit/pull/2357)
 - [#2358: Suppress Sass warnings for `$legacy` deprecated colour palette](https://github.com/alphagov/govuk-prototype-kit/pull/2358)
 - [#2359: Update application.js to `<script type"module">`](https://github.com/alphagov/govuk-prototype-kit/pull/2359)
 

--- a/cypress/e2e/plugins/0-mock-plugin-tests/install-plugin-via-ui-test.cypress.js
+++ b/cypress/e2e/plugins/0-mock-plugin-tests/install-plugin-via-ui-test.cypress.js
@@ -3,7 +3,11 @@ const path = require('path')
 const {
   loadTemplatesPage,
   managePluginsPagePath,
-  performPluginAction
+  performPluginAction,
+  initiatePluginAction,
+  provePluginInstalled,
+  provePluginTemplatesInstalled,
+  provePluginTemplatesUninstalled
 } = require('../plugin-utils')
 
 const panelCompleteQuery = '[aria-live="polite"] #panel-complete'
@@ -20,7 +24,7 @@ describe('Install and uninstall Local Plugin via UI Test', async () => {
   it(`The ${dependentPlugin} plugin will be installed`, () => {
     log(`The ${dependentPlugin} plugin templates are not available`)
     loadTemplatesPage()
-    cy.get(`[data-plugin-package-name="${dependentPlugin}"]`).should('not.exist')
+    provePluginTemplatesUninstalled(dependentPlugin)
 
     //   ------------------------
 
@@ -33,41 +37,32 @@ describe('Install and uninstall Local Plugin via UI Test', async () => {
       .should('be.visible')
     cy.get('a').contains('Back to plugins').click()
 
-    cy.get('#installed-plugins-link').click()
-
-    cy.get(`[data-plugin-package-name="${dependentPlugin}"] button`).contains('Uninstall')
+    provePluginInstalled(dependentPlugin, dependentPluginName)
 
     //   ------------------------
 
     log(`The ${dependentPlugin} plugin templates are available`)
     cy.get('a').contains('Templates').click()
-    cy.get(`[data-plugin-package-name="${dependentPlugin}"]`).should('exist')
+    provePluginTemplatesInstalled(dependentPlugin)
 
     //   ------------------------
 
     log('Uninstall the local plugin')
     cy.get('a').contains('Plugins').click()
-    cy.get('#installed-plugins-link').click()
 
-    cy.get(`[data-plugin-package-name="${dependentPlugin}"]`)
-      .scrollIntoView()
-      .find('button')
-      .contains('Uninstall')
-      .click()
-
-    performPluginAction('uninstall', dependentPlugin, dependentPluginName)
+    initiatePluginAction('uninstall', dependentPlugin, dependentPluginName)
 
     //   ------------------------
 
     log(`The ${dependentPlugin} plugin templates are not available`)
     cy.get('a').contains('Templates').click()
-    cy.get(`[data-plugin-package-name="${dependentPlugin}"]`).should('not.exist')
+    provePluginTemplatesUninstalled(dependentPlugin)
   })
 
   it(`The ${dependentPlugin} plugin and ${dependencyPlugin} will be installed`, () => {
     log(`The ${dependentPlugin} plugin templates are not available`)
     loadTemplatesPage()
-    cy.get(`[data-plugin-package-name="${dependentPlugin}"]`).should('not.exist')
+    provePluginTemplatesUninstalled(dependentPlugin)
 
     //   ------------------------
 
@@ -91,7 +86,7 @@ describe('Install and uninstall Local Plugin via UI Test', async () => {
 
     log(`The ${dependentPlugin} plugin templates are available`)
     cy.get('a').contains('Templates').click()
-    cy.get(`[data-plugin-package-name="${dependentPlugin}"]`).should('exist')
+    provePluginTemplatesInstalled(dependentPlugin)
 
     //   ------------------------
 
@@ -107,6 +102,6 @@ describe('Install and uninstall Local Plugin via UI Test', async () => {
 
     log(`The ${dependentPlugin} plugin templates are not available`)
     cy.get('a').contains('Templates').click()
-    cy.get(`[data-plugin-package-name="${dependentPlugin}"]`).should('not.exist')
+    provePluginTemplatesUninstalled(dependentPlugin)
   })
 })

--- a/cypress/e2e/plugins/1-available-plugins-tests/available-plugins.cypress.js
+++ b/cypress/e2e/plugins/1-available-plugins-tests/available-plugins.cypress.js
@@ -5,7 +5,11 @@ const {
   loadTemplatesPage,
   loadPluginsPage,
   manageTemplatesPagePath,
-  manageInstalledPluginsPagePath
+  provePluginUninstalled,
+  performPluginAction,
+  initiatePluginAction,
+  provePluginTemplatesUninstalled,
+  provePluginTemplatesInstalled
 } = require('../plugin-utils')
 
 const panelCompleteQuery = '[aria-live="polite"] #panel-complete'
@@ -18,7 +22,7 @@ async function installPluginTests ({ plugin, templates, version }) {
       log(`The ${plugin} plugin templates are not available`)
       uninstallPlugin(plugin)
       loadTemplatesPage()
-      cy.get(`[data-plugin-package-name="${plugin}"]`).should('not.exist')
+      provePluginTemplatesUninstalled(plugin)
 
       //   ------------------------
 
@@ -30,22 +34,21 @@ async function installPluginTests ({ plugin, templates, version }) {
         cy.get('#plugin-action-button').click()
       } else {
         loadPluginsPage()
+        provePluginUninstalled(plugin)
         log(`Install the ${plugin} plugin`)
-        cy.get(`[data-plugin-package-name="${plugin}"] button`).contains('Install').click()
+        performPluginAction('install', plugin)
       }
 
       cy.get(panelCompleteQuery, { timeout: 20000 })
         .should('be.visible')
       cy.get('a').contains('Back to plugins').click()
 
-      cy.get('#installed-plugins-link').click()
-      cy.get(`[data-plugin-package-name="${plugin}"] button`).contains('Uninstall')
-
       //   ------------------------
 
       log(`The ${plugin} plugin templates are available`)
       cy.get('a').contains('Templates').click()
-      cy.get(`[data-plugin-package-name="${plugin}"]`).should('exist')
+
+      provePluginTemplatesInstalled(plugin)
 
       //   ------------------------
 
@@ -59,15 +62,11 @@ async function installPluginTests ({ plugin, templates, version }) {
       //   ------------------------
 
       log(`Uninstall the ${plugin} plugin`)
-      cy.visit(manageInstalledPluginsPagePath)
+      cy.visit(managePluginsPagePath)
 
-      cy.get(`[data-plugin-package-name="${plugin}"] button`).contains('Uninstall').click()
+      initiatePluginAction('uninstall', plugin)
 
-      cy.get(panelCompleteQuery, { timeout: 20000 })
-        .should('be.visible')
-      cy.get('a').contains('Back to plugins').click()
-
-      cy.get(`[data-plugin-package-name="${plugin}"] button`).contains('Install')
+      provePluginUninstalled(plugin)
     })
   })
 }

--- a/cypress/e2e/plugins/1-available-plugins-tests/install-available-plugin.cypress.js
+++ b/cypress/e2e/plugins/1-available-plugins-tests/install-available-plugin.cypress.js
@@ -10,7 +10,9 @@ const {
   getTemplateLink,
   loadInstalledPluginsPage,
   loadPluginsPage,
-  manageInstalledPluginsPagePath
+  manageInstalledPluginsPagePath,
+  initiatePluginAction,
+  provePluginUpdated
 } = require('../plugin-utils')
 const { showHideAllLinkQuery, assertVisible, assertHidden } = require('../../step-by-step-utils')
 
@@ -98,14 +100,8 @@ describe('Management plugins: ', () => {
     loadInstalledPluginsPage()
 
     log(`Update the ${plugin} plugin`)
-
-    cy.get(`[data-plugin-package-name="${plugin}"]`)
-      .scrollIntoView()
-      .find('button')
-      .contains('Update')
-      .click()
-
-    performPluginAction('update', plugin, pluginName)
+    initiatePluginAction('update', plugin, pluginName)
+    provePluginUpdated(plugin)
 
     cy.get('#plugins-updates-available-message').should('not.exist')
   })
@@ -141,14 +137,7 @@ describe('Management plugins: ', () => {
     log(`Uninstall the ${plugin} plugin`)
 
     cy.visit(manageInstalledPluginsPagePath)
-
-    cy.get(`[data-plugin-package-name="${plugin}"]`)
-      .scrollIntoView()
-      .find('button')
-      .contains('Uninstall')
-      .click()
-
-    performPluginAction('uninstall', plugin, pluginName)
+    initiatePluginAction('uninstall', plugin, pluginName)
 
     provePluginFunctionalityFails()
 
@@ -157,14 +146,7 @@ describe('Management plugins: ', () => {
     log(`Reinstall the ${plugin} plugin`)
 
     cy.visit(managePluginsPagePath)
-
-    cy.get(`[data-plugin-package-name="${plugin}"]`)
-      .scrollIntoView()
-      .find('button')
-      .contains('Install')
-      .click()
-
-    performPluginAction('install', plugin, pluginName)
+    initiatePluginAction('install', plugin, pluginName)
 
     provePluginFunctionalityWorks()
   })

--- a/cypress/e2e/plugins/1-available-plugins-tests/install-common-templates-plugin-from-templates-page.cypress.js
+++ b/cypress/e2e/plugins/1-available-plugins-tests/install-common-templates-plugin-from-templates-page.cypress.js
@@ -1,4 +1,5 @@
 const { waitForApplication, uninstallPlugin, restoreStarterFiles } = require('../../utils')
+const { provePluginTemplatesInstalled } = require('../plugin-utils')
 
 const manageTemplatesPagePath = '/manage-prototype/templates'
 const panelCompleteQuery = '[aria-live="polite"] #panel-complete'
@@ -25,7 +26,7 @@ describe('Install common templates from templates page', () => {
 
     cy.get('a').contains('Back to templates').click()
 
-    cy.get(`[data-plugin-package-name="${plugin}"]`).contains('Common Templates')
+    provePluginTemplatesInstalled(plugin)
 
     cy.get('a.govuk-button').should('not.exist')
   })

--- a/cypress/e2e/plugins/2-prototype-kit-plugin-tests/handle-plugin-installation-mismatch.cypress.js
+++ b/cypress/e2e/plugins/2-prototype-kit-plugin-tests/handle-plugin-installation-mismatch.cypress.js
@@ -1,11 +1,19 @@
-const { replaceInFile, waitForApplication, restoreStarterFiles, log } = require('../../utils')
+const {
+  replaceInFile,
+  waitForApplication,
+  restoreStarterFiles,
+  log
+} = require('../../utils')
 const path = require('path')
+const {
+  provePluginUninstalled,
+  provePluginInstalledOldVersion
+} = require('../plugin-utils')
 const plugin = '@govuk-prototype-kit/task-list'
 const pluginVersion = '1.1.1'
 const originalText = '"dependencies": {'
 const replacementText = `"dependencies": { "${plugin}": "${pluginVersion}",`
 const pkgJsonFile = path.join(Cypress.env('projectFolder'), 'package.json')
-const pluginsPage = '/manage-prototype/plugins'
 
 describe('Handle a plugin installation mismatch', () => {
   after(restoreStarterFiles)
@@ -17,24 +25,14 @@ describe('Handle a plugin installation mismatch', () => {
     replaceInFile(pkgJsonFile, originalText, '', replacementText)
 
     log(`Make sure ${plugin} is displayed as not installed`)
-    cy.visit(pluginsPage)
-
-    cy.get(`[data-plugin-package-name="${plugin}"]`)
-      .scrollIntoView()
-      .find('button')
-      .contains('Install')
+    provePluginUninstalled(plugin)
 
     log('Force the plugins to be installed with an npm install')
     cy.exec(`cd ${Cypress.env('projectFolder')} && npm install`)
 
     log(`Make sure ${plugin} is displayed as installed`)
     waitForApplication()
-    cy.visit(pluginsPage)
 
-    cy.get('#installed-plugins-link').click()
-    cy.get(`[data-plugin-package-name="${plugin}"]`)
-      .scrollIntoView()
-      .find('button')
-      .contains('Uninstall')
+    provePluginInstalledOldVersion(plugin)
   })
 })

--- a/cypress/e2e/plugins/2-prototype-kit-plugin-tests/handle-plugin-update-when-a-dependency-is-now-required.cypress.js
+++ b/cypress/e2e/plugins/2-prototype-kit-plugin-tests/handle-plugin-update-when-a-dependency-is-now-required.cypress.js
@@ -1,5 +1,17 @@
-import { installPlugin, restoreStarterFiles, uninstallPlugin, waitForApplication } from '../../utils'
 import path from 'path'
+
+import {
+  installPlugin,
+  restoreStarterFiles,
+  uninstallPlugin,
+  waitForApplication
+} from '../../utils'
+
+import {
+  initiatePluginAction,
+  provePluginInstalled,
+  provePluginUninstalled
+} from '../plugin-utils'
 
 const plugin = '@govuk-prototype-kit/common-templates'
 const pluginVersion = '1.1.1'
@@ -30,39 +42,19 @@ describe('Handle a plugin update', () => {
 
     waitForApplication(pluginsPage)
 
-    cy.get('[data-plugin-group-status="search"]')
-      .find(`[data-plugin-package-name="${dependencyPlugin}"]`)
-      .find('button')
-      .contains('Install')
+    provePluginUninstalled(dependencyPlugin)
 
-    cy.get('#installed-plugins-link').click()
+    initiatePluginAction('update', plugin, null, {
+      confirmation: () => {
+        cy.get('#plugin-action-confirmation')
+          .find('ul')
+          .contains(dependencyPluginName)
 
-    cy.get('[data-plugin-group-status="installed"]')
-      .find(`[data-plugin-package-name="${plugin}"]`)
-      .find('button')
-      .contains('Update')
-      .click()
+        cy.get('#plugin-action-button').click()
+      }
+    })
 
-    cy.get('#plugin-action-confirmation')
-      .find('ul')
-      .contains(dependencyPluginName)
-
-    cy.get('#plugin-action-button').click()
-
-    cy.get('#panel-complete', { timeout: 20000 })
-      .should('be.visible')
-      .contains('Update complete')
-
-    cy.get('#instructions-complete a')
-      .contains('Back to plugins')
-      .click()
-
-    cy.get('#installed-plugins-link').click()
-
-    cy.get('[data-plugin-group-status="installed"]')
-      .find(`[data-plugin-package-name="${dependencyPlugin}"]`)
-
-    cy.get('[data-plugin-group-status="installed"]')
-      .find(`[data-plugin-package-name="${plugin}"]`)
+    provePluginInstalled(plugin)
+    provePluginInstalled(dependencyPlugin, dependencyPluginName)
   })
 })

--- a/cypress/e2e/plugins/2-prototype-kit-plugin-tests/remove-govuk-frontend.cypress.js
+++ b/cypress/e2e/plugins/2-prototype-kit-plugin-tests/remove-govuk-frontend.cypress.js
@@ -1,4 +1,10 @@
-const { managePluginsPagePath, performPluginAction } = require('../plugin-utils')
+const {
+  managePluginsPagePath,
+  performPluginAction,
+  provePluginInstalled,
+  provePluginUninstalled,
+  initiatePluginAction
+} = require('../plugin-utils')
 const { uninstallPlugin, restoreStarterFiles } = require('../../utils')
 
 const plugin = 'govuk-frontend'
@@ -21,9 +27,8 @@ describe('Manage prototype pages without govuk-frontend', () => {
     performPluginAction('uninstall', plugin, pluginName)
 
     cy.task('log', 'Make sure govuk-frontend is uninstalled')
-    cy.get(`[data-plugin-package-name="${plugin}"]`)
-      .find('button')
-      .contains('Install')
+
+    provePluginUninstalled(plugin)
 
     cy.task('log', 'Test home page')
     cy.get('a').contains('Home').click()
@@ -39,19 +44,10 @@ describe('Manage prototype pages without govuk-frontend', () => {
 
     cy.task('log', `Install the ${plugin} plugin`)
 
-    cy.get(`[data-plugin-package-name="${plugin}"]`)
-      .scrollIntoView()
-      .find('button')
-      .contains('Install')
-      .click()
-
-    performPluginAction('install', plugin, pluginName)
-
-    cy.get('#installed-plugins-link').click()
+    initiatePluginAction('install', plugin, pluginName)
 
     cy.task('log', 'Make sure govuk-frontend is installed')
-    cy.get(`[data-plugin-package-name="${plugin}"]`)
-      .find('button')
-      .contains('Uninstall')
+
+    provePluginInstalled(plugin, pluginName)
   })
 })


### PR DESCRIPTION
Simplify plugins tests with reusable functions that will meke it is easier to change the functionality (In future adding the plugin details page) without affecting the main acceptance test structure.  This also makes it easeir to fix any bugs.