### PR TITLE
Suppress Sass warnings for `$legacy` deprecated colour palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - [#2355: Prevent management pages using "plugin" GOV.UK Frontend views](https://github.com/alphagov/govuk-prototype-kit/pull/2355)
+- [#2358: Suppress Sass warnings for `$legacy` deprecated colour palette](https://github.com/alphagov/govuk-prototype-kit/pull/2358)
 
 ## 13.13.4
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -140,6 +140,7 @@ function sassVariables (contextPath = '', isLegacyGovukFrontend = false) {
   fileContents += `$govuk-extensions-url-context: "${contextPath}";\n`
   fileContents += `$govuk-plugins-url-context: "${contextPath}";\n`
   fileContents += '$govuk-prototype-kit-major-version: 13;\n'
+  fileContents += '$govuk-suppressed-warnings: (legacy-colour-param);\n'
 
   // Patch missing 'init.scss' before GOV.UK Frontend v4.4.0
   // in plugin versions, but will default to false for internal


### PR DESCRIPTION
This PR suppresses Sass `$legacy` colour palette deprecation warnings logged by GOV.UK Frontend v5 until the following files and packages can be updated from issue https://github.com/alphagov/govuk-prototype-kit/issues/2293:

>* `govuk-prototype-kit/lib/assets/sass/patterns/_pagination.scss`
>* `govuk-prototype-kit-step-by-step/sass/_step-by-step-navigation.scss`
>* `govuk-prototype-kit-step-by-step/sass/_step-by-step-navigation-header.scss`

This completes GOV.UK Frontend v5 plugin support in https://github.com/alphagov/govuk-prototype-kit/issues/2293

### Legacy colour palette

The legacy palette was replaced in GOV.UK Frontend v3.0.0:
https://designnotes.blog.gov.uk/2019/07/29/weve-updated-the-gov-uk-colours-and-font/

Support has continued throughout v4.0.0 but is deprecated in v5.0.0