### PR TITLE
Defer prototype `application.js` to load after plugin scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [#2355: Prevent management pages using "plugin" GOV.UK Frontend views](https://github.com/alphagov/govuk-prototype-kit/pull/2355)
 - [#2358: Suppress Sass warnings for `$legacy` deprecated colour palette](https://github.com/alphagov/govuk-prototype-kit/pull/2358)
+- [#2359: Update application.js to `<script type"module">`](https://github.com/alphagov/govuk-prototype-kit/pull/2359)
 
 ## 13.13.4
 

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -36,7 +36,10 @@ marked.use({
 
 const scripts = []
 if (existsSync(path.join(projectDir, 'app', 'assets', 'javascripts', 'application.js'))) {
-  scripts.push('/public/javascripts/application.js')
+  scripts.push({
+    src: '/public/javascripts/application.js',
+    type: 'module'
+  })
 }
 if (plugins.legacyGovukFrontendFixesNeeded()) {
   scripts.push('/plugin-assets/govuk-prototype-kit/lib/assets/javascripts/optional/legacy-govuk-frontend-init.js')


### PR DESCRIPTION
This PR switches `application.js` to `<script type"module">` to fix:

* https://github.com/alphagov/govuk-prototype-kit/issues/2353

This change defers script load by default and also ensures:

1. ES module `import { Accordion } from` syntax support in GOV.UK Frontend v5
2. Load order compatibility with other plugins that update to ES modules

### Browser support
This follows GOV.UK Frontend to protect browsers without [ES6 modules support](https://caniuse.com/es6-module) from script errors, such as:

* Internet Explorer 11
* Edge 15
* Chrome 60
* Firefox 59
* Safari 9