### PR TITLE
Support no internet connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- [#2370: Support no internet connection](https://github.com/alphagov/govuk-prototype-kit/pull/2370)
+
 ## 13.14.0
 
 ### New features

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -268,9 +268,13 @@ function sortByObjectKey (key) {
 }
 
 function hasNewVersion (installedVersion, latestVersion) {
+  if (!latestVersion) {
+    return false
+  }
+
   const matcher = /^(\d+)\.(\d+)\.(\d+)(.+)?/
-  const [, installedMajor, installedMinor, installedPatch, installedSuffix] = installedVersion.match(matcher)
-  const [, latestMajor, latestMinor, latestPatch, latestSuffix] = latestVersion.match(matcher)
+  const [, installedMajor, installedMinor, installedPatch, installedSuffix] = installedVersion?.match(matcher) || []
+  const [, latestMajor, latestMinor, latestPatch, latestSuffix] = latestVersion?.match(matcher) || []
 
   if (installedMajor < latestMajor) return true
   if (installedMajor > latestMajor) return false

--- a/lib/utils/utils.test.js
+++ b/lib/utils/utils.test.js
@@ -29,6 +29,7 @@ describe('sessionFileStoreQuietLogFn', () => {
 
 describe('hasNewVersion', () => {
   [
+    { installed: '13.1.0', latest: undefined, result: false },
     { installed: '13.1.0', latest: '13.1.0', result: false },
     { installed: '13.1.1', latest: '13.1.0', result: false },
     { installed: '13.2.0', latest: '13.1.0', result: false },


### PR DESCRIPTION
This fixes the issue detected by a user as below:

This was detected by a user posting the following:

```
Environment:

OSX 12.6.9
npm -v 8.19.3
node -v v18.13.0


Error. Kit will not run with internet connection disabled.

Error message:


Node.js v18.13.0
[nodemon] For missing modules try running `npm install`
Restarting kit...

You can manage your prototype at:
http://localhost:3000/manage-prototype

The Prototype Kit is now running at:
http://localhost:3000/

/Users/ian/Sites/xd/node_modules/govuk-prototype-kit/lib/utils/index.js:273
  const [, latestMajor, latestMinor, latestPatch, latestSuffix] = latestVersion.match(matcher)
                                                                                ^

TypeError: Cannot read properties of undefined (reading 'match')
    at hasNewVersion (/Users/ian/Sites/xd/node_modules/govuk-prototype-kit/lib/utils/index.js:273:81)
    at refreshPackageInfo (/Users/ian/Sites/xd/node_modules/govuk-prototype-kit/lib/plugins/packages.js:122:85)
    at async Promise.all (index 0)
    at async startPackageTracker (/Users/ian/Sites/xd/node_modules/govuk-prototype-kit/lib/plugins/packages.js:24:3)

Node.js v18.13.0
[nodemon] For missing modules try running `npm install`
```