### PR TITLE
Make any npm module a plugin via a proxy plugin config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New features
+
+- [#2382: Make any npm module a plugin via a proxy plugin config](https://github.com/alphagov/govuk-prototype-kit/pull/2382)
+
 ## 13.15.3
 
 ### Fixes

--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -439,7 +439,8 @@ function buildPluginData (pluginData) {
 async function prepareForPluginPage (isInstalledPage, search) {
   const allPackages = await getAllPackages()
   const allPlugins = allPackages.filter(({ pluginConfig }) => !!pluginConfig)
-  const installedPlugins = await getInstalledPackages()
+  const installedPackages = await getInstalledPackages()
+  const installedPlugins = installedPackages.filter(({ pluginConfig }) => !!pluginConfig)
 
   const plugins = isInstalledPage
     ? installedPlugins

--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -444,7 +444,11 @@ async function prepareForPluginPage (isInstalledPage, search) {
   const plugins = isInstalledPage
     ? installedPlugins
     : allPlugins.filter(plugin => {
-      const pluginName = plugin.packageName?.toLowerCase()
+      const { packageName, available, installed } = plugin || {}
+      const pluginName = packageName?.toLowerCase()
+      if (!pluginName || (!available && !installed)) {
+        return false
+      }
       return pluginName.indexOf(search.toLowerCase()) >= 0
     })
 

--- a/lib/manage-prototype-handlers.test.js
+++ b/lib/manage-prototype-handlers.test.js
@@ -60,6 +60,7 @@ jest.mock('../known-plugins.json', () => {
     plugins: {}
   }
 })
+
 jest.mock('fs-extra', () => {
   return {
     readFile: jest.fn().mockResolvedValue(''),
@@ -87,6 +88,12 @@ jest.mock('./plugins/plugins', () => {
     getAppViews: jest.fn(),
     getAppConfig: jest.fn(),
     getByType: jest.fn()
+  }
+})
+
+jest.mock('./plugins/plugin-utils', () => {
+  return {
+    getProxyPluginConfig: jest.fn().mockReturnValue({})
   }
 })
 

--- a/lib/plugins/plugin-utils.js
+++ b/lib/plugins/plugin-utils.js
@@ -1,6 +1,12 @@
 // This allows npm modules to act as if they are plugins by providing the plugin config for them
+const fs = require('fs')
+const fse = require('fs-extra')
+const { projectDir } = require('../utils/paths')
+const path = require('path')
+
+let proxyPluginError = false
 function getProxyPluginConfig (packageName) {
-  const proxyPluginConfig = {
+  let proxyPluginConfig = {
     jquery: {
       scripts: ['/dist/jquery.js'],
       assets: ['/dist'],
@@ -11,6 +17,23 @@ function getProxyPluginConfig (packageName) {
     'notifications-node-client': {
       meta: {
         description: 'GOV.UK Notify makes it easy for public sector service teams to send emails, text messages and letters.'
+      }
+    }
+  }
+  const proxyPluginsPath = path.join(projectDir, 'app', 'plugin-proxy.json')
+  if (fse.existsSync(proxyPluginsPath)) {
+    let userProxyPluginsContent
+    try {
+      userProxyPluginsContent = fs.readFileSync(proxyPluginsPath, 'utf8')
+      const userProxyPlugins = JSON.parse(userProxyPluginsContent)
+      proxyPluginConfig = { ...proxyPluginConfig, ...userProxyPlugins }
+      proxyPluginError = false
+    } catch (err) {
+      if (!proxyPluginError) {
+        console.error(err.message)
+        console.error(proxyPluginsPath)
+        console.error(userProxyPluginsContent)
+        proxyPluginError = true
       }
     }
   }

--- a/lib/plugins/plugin-utils.spec.js
+++ b/lib/plugins/plugin-utils.spec.js
@@ -1,0 +1,40 @@
+/* eslint-env jest */
+
+// npm dependencies
+const fs = require('fs')
+
+// local dependencies
+const { getProxyPluginConfig } = require('./plugin-utils')
+
+const testPluginConfig = {
+  scripts: './dist/test-script.js'
+}
+jest.mock('fs-extra', () => {
+  return {
+    existsSync: jest.fn().mockReturnValue(true)
+  }
+})
+
+describe('getProxyPluginConfig', () => {
+  beforeEach(() => {
+    jest.spyOn(fs, 'readFileSync').mockImplementation(() => {
+      return JSON.stringify({
+        'test-plugin-config': testPluginConfig
+      })
+    })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('get jquery proxy plugin config', () => {
+    const pluginConfig = getProxyPluginConfig('jquery')
+    expect(Object.keys(pluginConfig)).toEqual(['scripts', 'assets', 'meta'])
+  })
+
+  it('get test script proxy plugin config', () => {
+    const pluginConfig = getProxyPluginConfig('test-plugin-config')
+    expect(pluginConfig).toEqual(testPluginConfig)
+  })
+})

--- a/lib/plugins/plugins.js
+++ b/lib/plugins/plugins.js
@@ -173,7 +173,11 @@ let pluginsByType
  * @private
  */
 function setPluginsByType () {
-  pluginsByType = getPluginsByType()
+  try {
+    pluginsByType = getPluginsByType()
+  } catch (err) {
+    pluginsByType = {}
+  }
 }
 
 setPluginsByType()


### PR DESCRIPTION
I've had a several requests from people to allow npm modules to load their script, sass files and assets as they would a plugin.

A designer was trying to use the npm module `browser-fs-access` but was having difficulty loading the scripts from node_modules.  This PR adds support for a new json file `/app/plugin-proxy.json` that contains a proxy plugin config for the module that treats the npm module as a plugin which solved his issue neatly:
```
{
    "browser-fs-access": {
        "scripts": {
            "type": "module",
            "path": "/dist/index.modern.js"
        }
    }
}
```

I'm suggesting this be introduced as it will not affect anyone who has not created the `/app/plugin-proxy.json` file with a view to documenting the use of this at a later date.  For now it gets over the issue of wanting something to be a plugin without hard coding it for everyone.