### PR TITLE
Add format items filter to core filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- [#2384: Add format items filter to core filters](https://github.com/alphagov/govuk-prototype-kit/pull/2384)
 - [#2382: Make any npm module a plugin via a proxy plugin config](https://github.com/alphagov/govuk-prototype-kit/pull/2382)
 
 ## 13.15.3

--- a/lib/filters/core-filters.js
+++ b/lib/filters/core-filters.js
@@ -13,7 +13,7 @@ runWhenEnvIsAvailable(() => {
      * @example {{ "hello world" | log }}
      * @example {{ "hello world" | log | safe }}  [for environments with autoescaping turned on]
      * @param  {any} a - any type
-     * @return {String} a script tag with a console.log call.
+     * @returns {string} a script tag with a console.log call.
      */
     (a) => nunjucksSafe('<script>console.log(' + JSON.stringify(a, null, '\t') + ');</script>')
   )
@@ -41,7 +41,7 @@ runWhenEnvIsAvailable(() => {
      * }) }}
      * ```
      * @param  {string[]} items - an array of strings.
-     * @returns {Object[]} an array of objects with text and value properties.
+     * @returns {{ text: string, value: string }[]} an array of objects with text and value properties.
      */
     (items = []) => Array.isArray(items)
       ? items.map((item) => ({ text: item, value: item }))

--- a/lib/filters/core-filters.js
+++ b/lib/filters/core-filters.js
@@ -5,36 +5,46 @@ const { addFilter, getFilter } = external
 runWhenEnvIsAvailable(() => {
   const nunjucksSafe = getFilter('safe')
 
-  /**
-   * Logs an object in the template to the console in the browser.
-   * @param  {any} a - any type
-   * @return {String} a script tag with a console.log call.
-   * @example {{ "hello world" | log }}
-   * @example {{ "hello world" | log | safe }}  [for environments with autoescaping turned on]
-   */
-  addFilter('log', a => nunjucksSafe('<script>console.log(' + JSON.stringify(a, null, '\t') + ');</script>'))
+  addFilter(
+    'log',
+    /**
+     * Logs an object in the template to the console in the browser.
+     *
+     * @example {{ "hello world" | log }}
+     * @example {{ "hello world" | log | safe }}  [for environments with autoescaping turned on]
+     * @param  {any} a - any type
+     * @return {String} a script tag with a console.log call.
+     */
+    (a) => nunjucksSafe('<script>console.log(' + JSON.stringify(a, null, '\t') + ');</script>')
+  )
 
-  /**
-   * Returns an array of objects for use in a macro that requires a list of items
-   * @param  {string[]} items - an array of strings.
-   * @return {Object[]} an array of objects with each object containing text and value properties.
-   * @example
-   * ```njk
-   * {{ govukCheckboxes({
-   *   name: "waste",
-   *   fieldset: {
-   *     legend: {
-   *       text: "Which types of waste do you transport?",
-   *       isPageHeading: true,
-   *       classes: "govuk-fieldset__legend--l"
-   *     }
-   *   },
-   *   hint: {
-   *     text: "Select all that apply."
-   *   },
-   *   items: ["Rubble", "Oil", "Card"] | formatItems
-   * }) }}
-   * ```
-   */
-  addFilter('formatItems', (items = []) => Array.isArray(items) ? items.map(item => ({ text: item, value: item })) : [])
+  addFilter(
+    'formatItems',
+    /**
+     * Returns an array of objects for use in a macro that requires a list of items
+     *
+     * @example
+     * ```njk
+     * {{ govukCheckboxes({
+     *   name: "waste",
+     *   fieldset: {
+     *     legend: {
+     *       text: "Which types of waste do you transport?",
+     *       isPageHeading: true,
+     *       classes: "govuk-fieldset__legend--l"
+     *     }
+     *   },
+     *   hint: {
+     *     text: "Select all that apply."
+     *   },
+     *   items: ["Rubble", "Oil", "Card"] | formatItems
+     * }) }}
+     * ```
+     * @param  {string[]} items - an array of strings.
+     * @returns {Object[]} an array of objects with text and value properties.
+     */
+    (items = []) => Array.isArray(items)
+      ? items.map((item) => ({ text: item, value: item }))
+      : []
+  )
 })

--- a/lib/filters/core-filters.js
+++ b/lib/filters/core-filters.js
@@ -7,7 +7,7 @@ runWhenEnvIsAvailable(() => {
 
   /**
    * Logs an object in the template to the console in the browser.
-   * @param  {Any} a any type
+   * @param  {any} a - any type
    * @return {String} a script tag with a console.log call.
    * @example {{ "hello world" | log }}
    * @example {{ "hello world" | log | safe }}  [for environments with autoescaping turned on]

--- a/lib/filters/core-filters.js
+++ b/lib/filters/core-filters.js
@@ -2,14 +2,39 @@
 const { runWhenEnvIsAvailable, external } = require('./api')
 const { addFilter, getFilter } = external
 
-/**
- * Logs an object in the template to the console in the browser.
- * @param  {Any} a any type
- * @return {String} a script tag with a console.log call.
- * @example {{ "hello world" | log }}
- * @example {{ "hello world" | log | safe }}  [for environments with autoescaping turned on]
- */
 runWhenEnvIsAvailable(() => {
   const nunjucksSafe = getFilter('safe')
+
+  /**
+   * Logs an object in the template to the console in the browser.
+   * @param  {Any} a any type
+   * @return {String} a script tag with a console.log call.
+   * @example {{ "hello world" | log }}
+   * @example {{ "hello world" | log | safe }}  [for environments with autoescaping turned on]
+   */
   addFilter('log', a => nunjucksSafe('<script>console.log(' + JSON.stringify(a, null, '\t') + ');</script>'))
+
+  /**
+   * Returns an array of objects for use in a macro that requires a list of items
+   * @param  {String[]} an array of strings.
+   * @return {Object[]} an array of objects with each object containing text and value properties.
+   * @example
+   * ```njk
+   * {{ govukCheckboxes({
+   *   name: "waste",
+   *   fieldset: {
+   *     legend: {
+   *       text: "Which types of waste do you transport?",
+   *       isPageHeading: true,
+   *       classes: "govuk-fieldset__legend--l"
+   *     }
+   *   },
+   *   hint: {
+   *     text: "Select all that apply."
+   *   },
+   *   items: ["Rubble", "Oil", "Card"] | formatItems
+   * }) }}
+   * ```
+   */
+  addFilter('formatItems', (items = []) => Array.isArray(items) ? items.map(item => ({ text: item, value: item })) : [])
 })

--- a/lib/filters/core-filters.js
+++ b/lib/filters/core-filters.js
@@ -16,7 +16,7 @@ runWhenEnvIsAvailable(() => {
 
   /**
    * Returns an array of objects for use in a macro that requires a list of items
-   * @param  {String[]} an array of strings.
+   * @param  {string[]} items - an array of strings.
    * @return {Object[]} an array of objects with each object containing text and value properties.
    * @example
    * ```njk

--- a/lib/filters/core-filters.js
+++ b/lib/filters/core-filters.js
@@ -10,9 +10,11 @@ runWhenEnvIsAvailable(() => {
     /**
      * Logs an object in the template to the console in the browser.
      *
-     * @example {{ "hello world" | log }}
-     * @example {{ "hello world" | log | safe }}  [for environments with autoescaping turned on]
-     * @param  {any} a - any type
+     * @example
+     * ```njk
+     * {{ "hello world" | log }}
+     * ```
+     * @param {any} a - any type
      * @returns {string} a script tag with a console.log call.
      */
     (a) => nunjucksSafe('<script>console.log(' + JSON.stringify(a, null, '\t') + ');</script>')


### PR DESCRIPTION
Allow users to simplify entering items when the text and value are the same.

The following: 
```njk
["Rubble", "Oil", "Card"] | formatItems
```

will return: 
```njk
[
  { text: "Rubble", value: "Rubble" },
  { text: "Oil", value: "Oil" },
  { text: "Card", value: "Card" },
]
```