### PR TITLE
Update to GOV.UK Frontend v5.2.0 on management pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - [#2327: Use GOV.UK Frontend v5 on management pages and tests](https://github.com/alphagov/govuk-prototype-kit/pull/2327)
+- [#2395: Update to GOV.UK Frontend v5.2.0 on management pages](https://github.com/alphagov/govuk-prototype-kit/pull/2395)
 
 ## 13.16.0
 

--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -283,18 +283,22 @@ function locateTemplateConfig (req) {
 }
 
 function getTemplatesViewHandler (req, res) {
-  const model = {
-    pluginConfig: plugins.getAppConfig({ scripts: prototypeAppScripts }),
-    serviceName: 'Service name goes here'
-  }
   const templateConfig = locateTemplateConfig(req)
 
   // Nunjucks environment for template previews uses `getAppViews()` to
   // add plugins including GOV.UK Frontend views via project package
   const nunjucksAppEnv = nunjucksConfiguration.getNunjucksAppEnv(appViews)
 
+  // Use GOV.UK Frontend paths from Express.js locals
+  const { govukFrontend, govukFrontendInternal } = req.app.locals
+
   if (templateConfig) {
-    res.send(nunjucksAppEnv.render(templateConfig.path, model))
+    res.send(nunjucksAppEnv.render(templateConfig.path, {
+      govukFrontend,
+      govukFrontendInternal,
+      pluginConfig: plugins.getAppConfig({ scripts: prototypeAppScripts }),
+      serviceName: 'Service name goes here'
+    }))
   } else {
     res.status(404).send('Template not found.')
   }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -20,7 +20,7 @@
         "express": "^4.18.2",
         "express-session": "^1.17.3",
         "fs-extra": "^11.1.1",
-        "govuk-frontend": "5.0.0",
+        "govuk-frontend": "5.2.0",
         "inquirer": "^8.2.6",
         "lodash": "^4.17.21",
         "marked": "^4.3.0",
@@ -6149,9 +6149,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.0.0.tgz",
-      "integrity": "sha512-3WSfvQ+3kw/q/m8jrq/t8XnMUA8D2r0uhGyZaDbIh1gWTJBQzJBHbHiKYI9nc9ixIXdCFsc9RozkgEm57a795g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.2.0.tgz",
+      "integrity": "sha512-beD3wztHpkKz6JUpPwnwop1ejb4rTFMPLCutKLCIDmUS4BPpW59ggVUfctsRqHd2Zjw9wxljdRdeIJ8AZFyyTw==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -16452,9 +16452,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.0.0.tgz",
-      "integrity": "sha512-3WSfvQ+3kw/q/m8jrq/t8XnMUA8D2r0uhGyZaDbIh1gWTJBQzJBHbHiKYI9nc9ixIXdCFsc9RozkgEm57a795g=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.2.0.tgz",
+      "integrity": "sha512-beD3wztHpkKz6JUpPwnwop1ejb4rTFMPLCutKLCIDmUS4BPpW59ggVUfctsRqHd2Zjw9wxljdRdeIJ8AZFyyTw=="
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "express": "^4.18.2",
     "express-session": "^1.17.3",
     "fs-extra": "^11.1.1",
-    "govuk-frontend": "5.0.0",
+    "govuk-frontend": "5.2.0",
     "inquirer": "^8.2.6",
     "lodash": "^4.17.21",
     "marked": "^4.3.0",


### PR DESCRIPTION
Updates to GOV.UK Frontend v5.2.0 (including the new crown) to close https://github.com/alphagov/govuk-prototype-kit/issues/2395

Also closes https://github.com/alphagov/govuk-prototype-kit/issues/2392 where `assetPath` wasn't fully set for template previews