### PR TITLE
Associate the plugin search input with its label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#2327: Use GOV.UK Frontend v5 on management pages and tests](https://github.com/alphagov/govuk-prototype-kit/pull/2327)
 - [#2394: Update Browsersync to resolve `axios` vulnerability](https://github.com/alphagov/govuk-prototype-kit/pull/2394)
 - [#2395: Update to GOV.UK Frontend v5.2.0 on management pages](https://github.com/alphagov/govuk-prototype-kit/pull/2395)
+- [#2398: Associate the plugin search input with its label](https://github.com/alphagov/govuk-prototype-kit/pull/2398)
 - [#2399: Stop accidentally cleaning up non-expired sessions](https://github.com/alphagov/govuk-prototype-kit/pull/2399)
 
 ## 13.16.0

--- a/lib/nunjucks/views/manage-prototype/plugins.njk
+++ b/lib/nunjucks/views/manage-prototype/plugins.njk
@@ -1,6 +1,5 @@
 {% extends "views/manage-prototype/layout.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/label/macro.njk" import govukLabel %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
@@ -48,13 +47,12 @@
                 {% if isSearchPage %}
                 <div class="govuk-!-margin-bottom-5">
                     <div id="search-container">
-                        {{ govukLabel({
-                            text:"Search",
-                            classes:"govuk-!-font-weight-bold"
-                        }) }}
-
                         {{ govukInput({
                             id: "search",
+                            label: {
+                                text: "Search",
+                                classes: "govuk-label--s"
+                            },
                             classes: "govuk-!-width-one-half",
                             formGroup: {
                                 classes: "govuk-!-margin-bottom-3"


### PR DESCRIPTION
I was having a quick look to see if any issues were listed in developer tools for #2393 and noticed this was being flagged.

The search input on the plugin list page does not have a programatically label because the label is not currently associated with the input.

Rather than using the separate `govukLabel` macro, pass the label options to the  `govukInput` macro and let it take care of associating the label for us.

We can also use the `govuk-label--s` modifier rather than a font weight override.