### PR TITLE
Preparing for release 13.16.1 (automated).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 13.16.1
+
 ### Fixes
 
 - [#2327: Use GOV.UK Frontend v5 on management pages and tests](https://github.com/alphagov/govuk-prototype-kit/pull/2327)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "govuk-prototype-kit",
-  "version": "13.16.0",
+  "version": "13.16.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-prototype-kit",
-      "version": "13.16.0",
+      "version": "13.16.1",
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "body-parser": "^1.20.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-prototype-kit",
   "description": "Rapidly create HTML prototypes of GOV.UK services",
-  "version": "13.16.0",
+  "version": "13.16.1",
   "engines": {
     "node": "^16.x || ^18.x || >= 20.x"
   },


### PR DESCRIPTION

### Fixes

- [#2327: Use GOV.UK Frontend v5 on management pages and tests](https://github.com/alphagov/govuk-prototype-kit/pull/2327)
- [#2394: Update Browsersync to resolve `axios` vulnerability](https://github.com/alphagov/govuk-prototype-kit/pull/2394)
- [#2395: Update to GOV.UK Frontend v5.2.0 on management pages](https://github.com/alphagov/govuk-prototype-kit/pull/2395)
- [#2398: Associate the plugin search input with its label](https://github.com/alphagov/govuk-prototype-kit/pull/2398)
- [#2399: Stop accidentally cleaning up non-expired sessions](https://github.com/alphagov/govuk-prototype-kit/pull/2399)