### PR TITLE
Remove old zlib in favour of built in

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -32,8 +32,7 @@
         "sync-request": "^6.1.0",
         "tar-stream": "^3.1.7",
         "universal-analytics": "^0.5.3",
-        "uuid": "^9.0.1",
-        "zlib": "^1.0.5"
+        "uuid": "^9.0.1"
       },
       "bin": {
         "govuk-prototype-kit": "bin/cli"
@@ -11835,15 +11834,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/zlib": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/zlib/-/zlib-1.0.5.tgz",
-      "integrity": "sha512-40fpE2II+Cd3k8HWTWONfeKE2jL+P42iWJ1zzps5W51qcTsOUKM5Q5m2PFb0CLxlmFAaUuUdJGc3OfZy947v0w==",
-      "hasInstallScript": true,
-      "engines": {
-        "node": ">=0.2.0"
-      }
     }
   },
   "dependencies": {
@@ -20586,11 +20576,6 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
-    },
-    "zlib": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/zlib/-/zlib-1.0.5.tgz",
-      "integrity": "sha512-40fpE2II+Cd3k8HWTWONfeKE2jL+P42iWJ1zzps5W51qcTsOUKM5Q5m2PFb0CLxlmFAaUuUdJGc3OfZy947v0w=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -84,8 +84,7 @@
     "sync-request": "^6.1.0",
     "tar-stream": "^3.1.7",
     "universal-analytics": "^0.5.3",
-    "uuid": "^9.0.1",
-    "zlib": "^1.0.5"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "cheerio": "^1.0.0-rc.12",


### PR DESCRIPTION
the kit had a dependency of `zlib` 1.0.5 - this is 13 years old, and is replaced by the built in `zlib` in node itself

this should fix this issue that users have reported:

https://github.com/kkaefer/DEPRECATED-node-zlib/issues/14