### PR TITLE
Preparing for release 13.16.2 (automated).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 13.16.2
+
 ### Fixes
 
 - [#2404: Fix issues creating prototypes when using npm v10.4.0 or newer by removing dependency on zlib](https://github.com/alphagov/govuk-prototype-kit/pull/2404)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "govuk-prototype-kit",
-  "version": "13.16.1",
+  "version": "13.16.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-prototype-kit",
-      "version": "13.16.1",
+      "version": "13.16.2",
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "body-parser": "^1.20.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-prototype-kit",
   "description": "Rapidly create HTML prototypes of GOV.UK services",
-  "version": "13.16.1",
+  "version": "13.16.2",
   "engines": {
     "node": "^16.x || ^18.x || >= 20.x"
   },


### PR DESCRIPTION

### Fixes

- [#2404: Fix issues creating prototypes when using npm v10.4.0 or newer by removing dependency on zlib](https://github.com/alphagov/govuk-prototype-kit/pull/2404)