### PR TITLE
Fix kit version update link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@
 
 ### Fixes
 
+- [#2408: Fix kit version update link](https://github.com/alphagov/govuk-prototype-kit/pull/2408)
 - [#2420: Fixing the default homepage](https://github.com/alphagov/govuk-prototype-kit/pull/2420)
 - [#2425: Fix open redirect vuln in login page](https://github.com/alphagov/govuk-prototype-kit/pull/2425)
 - [#2437: Fix version logic for showing whether a plugin has updates](https://github.com/alphagov/govuk-prototype-kit/pull/2437)
+
 
 ## 13.16.2
 

--- a/lib/nunjucks/views/manage-prototype/index.njk
+++ b/lib/nunjucks/views/manage-prototype/index.njk
@@ -13,7 +13,7 @@
         </p>
         {% if kitUpdateAvailable %}
           <p>
-            <a href="{{ currentUrl }}/plugins">
+            <a href="{{ currentUrl }}/plugins-installed">
               New version available: {{ latestAvailableKit }}
             </a>
           </p>


### PR DESCRIPTION
It used to go to Find plugins, it should go to Installed Plugins where you click the update button

fixes #2409 