### PR TITLE
Causing an error when session-data-defaults is malformed.

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -1,5 +1,6 @@
 // core dependencies
 const path = require('path')
+const fs = require('fs')
 
 // npm dependencies
 const session = require('express-session')
@@ -84,14 +85,12 @@ function storeData (input, data) {
 
 // Get session default data from file
 
-let sessionDataDefaults
+let sessionDataDefaults = {}
 
 const sessionDataDefaultsFile = path.join(projectDir, 'app', 'data', 'session-data-defaults.js')
 
-try {
+if (fs.existsSync(sessionDataDefaultsFile)) {
   sessionDataDefaults = require(sessionDataDefaultsFile)
-} catch (e) {
-  sessionDataDefaults = {}
 }
 // Middleware - store any data sent in session, and pass it to all views
 


### PR DESCRIPTION
This resolves the reported issue https://github.com/alphagov/govuk-prototype-kit/issues/2416

![The error showing in the browser](https://github.com/user-attachments/assets/178f24b3-ccd4-4dfc-81c4-b178cdb12ac5)

![The error showing in the terminal](https://github.com/user-attachments/assets/21122a07-8059-43d0-8ab2-ea475e8b9452)

To reproduce this, edit the file `app/data/session-data-defaults.js` in a way that breaks it.  My test file contents was to add one line containing a syntax error to the default file:

```
module.exports = {
  'broken'
  // Insert values here

}
```

If that file is then deleted then the default value of `{}` is used.