### PR TITLE
Apply brand updates manage prototype pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New features
+
+- [#2434: Apply brand updates manage prototype pages](https://github.com/alphagov/govuk-prototype-kit/pull/2434)
+
 ### Fixes
 
 - [#2437: Fix version logic for showing whether a plugin has updates](https://github.com/alphagov/govuk-prototype-kit/pull/2437)

--- a/lib/assets/sass/includes/_error-page.scss
+++ b/lib/assets/sass/includes/_error-page.scss
@@ -1,10 +1,3 @@
-
-.govuk-prototype-kit-error-page-header {
-  .govuk-header__container {
-    border-color: govuk-colour("red");
-  }
-}
-
 .govuk-prototype-kit-error-info {
   strong {
     min-width: 4em;

--- a/lib/assets/sass/manage-prototype.scss
+++ b/lib/assets/sass/manage-prototype.scss
@@ -1,3 +1,5 @@
+$govuk-new-typography-scale: true;
+
 // Import GOV.UK Frontend within the kit dependency
 @import ".tmp/sass/kit-frontend-dependency";
 

--- a/lib/errorServer.js
+++ b/lib/errorServer.js
@@ -8,6 +8,7 @@ const { packageDir, projectDir } = require('./utils/paths')
 const { govukFrontendPaths } = require('./govukFrontendPaths')
 const syncChanges = require('./sync-changes')
 const { flagError } = require('./sync-changes')
+const config = require('./config.js')
 
 function runErrorServer (error) {
   flagError(error)
@@ -18,7 +19,7 @@ function runErrorServer (error) {
   verboseLog('- - - Raw Error End - - -')
 
   try {
-    port = require('./config.js').getConfig().port
+    port = config.getConfig().port
   } catch (e) {
     port = process.env.PORT || 3000
   }
@@ -109,6 +110,10 @@ function runErrorServer (error) {
         [path.join(__dirname, 'nunjucks')],
         govukFrontendInternal // Add GOV.UK Frontend paths to Nunjucks views
       )
+
+      // Set `govukRebrand` based on app config
+      nunjucksAppEnv.addGlobal('govukRebrand', config.getConfig()?.plugins?.['govuk-frontend']?.rebrand)
+
       res.end(nunjucksAppEnv.render('views/error-handling/server-error', {
         govukFrontendInternal, // Add GOV.UK Frontend paths to Nunjucks context
         ...getErrorModel(error)

--- a/lib/govukFrontendPaths.js
+++ b/lib/govukFrontendPaths.js
@@ -4,6 +4,8 @@ const path = require('path')
 // npm dependencies
 const fse = require('fs-extra')
 
+const config = require('./config').getConfig()
+
 /**
  * Find GOV.UK Frontend via search paths
  *
@@ -21,12 +23,15 @@ function govukFrontendPaths (searchPaths = []) {
   const dependencyPath = path.join('node_modules/govuk-frontend')
   const baseDir = path.join(entryPath.split(dependencyPath)[0], dependencyPath)
   const includeDir = path.dirname(entryPath)
+  // fragment of the complete asset path. Is either 'assets' or 'assets/rebrand'
+  // depending on if the app config rebrand options are set
+  const assetPathFragment = config?.plugins?.['govuk-frontend']?.rebrand ? 'assets/rebrand' : 'assets'
 
   return {
     baseDir,
 
     includePath: `/${path.relative(baseDir, includeDir)}`,
-    assetPath: `/${path.relative(baseDir, path.join(includeDir, 'assets'))}`,
+    assetPath: `/${path.relative(baseDir, path.join(includeDir, assetPathFragment))}`,
 
     // GOV.UK Frontend plugin config
     config: fse.readJsonSync(path.join(baseDir, 'govuk-prototype-kit.config.json'), { throws: false }) ?? {

--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -39,6 +39,9 @@ const nunjucksManagementEnv = nunjucksConfiguration.getNunjucksAppEnv(
   govukFrontendPaths([packageDir, projectDir])
 )
 
+// Sets the govuk brand updates to true for management pages
+nunjucksManagementEnv.addGlobal('govukRebrand', true)
+
 let kitRestarted = false
 
 const {

--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -292,6 +292,9 @@ function getTemplatesViewHandler (req, res) {
   // add plugins including GOV.UK Frontend views via project package
   const nunjucksAppEnv = nunjucksConfiguration.getNunjucksAppEnv(appViews)
 
+  // Set `govukRebrand` for the template nunjucks env based on app config
+  nunjucksAppEnv.addGlobal('govukRebrand', config.getConfig()?.plugins?.['govuk-frontend']?.rebrand)
+
   // Use GOV.UK Frontend paths from Express.js locals
   const { govukFrontend, govukFrontendInternal } = req.app.locals
 

--- a/lib/manage-prototype-handlers.test.js
+++ b/lib/manage-prototype-handlers.test.js
@@ -307,6 +307,16 @@ describe('manage-prototype-handlers', () => {
     })
 
     describe('getTemplatesViewHandler', () => {
+      beforeEach(() => {
+        jest.spyOn(config, 'getConfig').mockImplementation(() => ({
+          plugins: {
+            'govuk-frontend': {
+              rebrand: true
+            }
+          }
+        }))
+      })
+
       it('template found', async () => {
         await getTemplatesViewHandler(req, res)
         expect(res.status).not.toHaveBeenCalled()
@@ -325,6 +335,14 @@ describe('manage-prototype-handlers', () => {
         expect(res.status).toHaveBeenCalledWith(404)
         expect(res.send).toHaveBeenCalledWith('Template not found.')
       })
+    })
+
+    it('sets `govukRebrand` based on the app config', async () => {
+      await getTemplatesViewHandler(req, res)
+      expect(mockNunjucksAddGlobal).toHaveBeenCalledWith(
+        'govukRebrand',
+        true
+      )
     })
 
     describe('getTemplatesInstallHandler', () => {

--- a/lib/manage-prototype-handlers.test.js
+++ b/lib/manage-prototype-handlers.test.js
@@ -16,8 +16,10 @@ const projectPackage = require('../package.json')
 const knownPlugins = require('../known-plugins.json')
 
 const mockNunjucksRender = jest.fn()
+const mockNunjucksAddGlobal = jest.fn()
 const mockNunjucksAppEnv = jest.fn(() => ({
-  render: mockNunjucksRender
+  render: mockNunjucksRender,
+  addGlobal: mockNunjucksAddGlobal
 }))
 
 // Avoid hoisting with `jest.doMock()` to ensure

--- a/lib/nunjucks/views/error-handling/server-error.njk
+++ b/lib/nunjucks/views/error-handling/server-error.njk
@@ -4,12 +4,6 @@
   Error {% if serviceName %}– {{ serviceName }}{% endif %} – GOV.UK Prototype Kit
 {% endblock %}
 
-{% block header %}
-  <div class="govuk-prototype-kit-error-page-header">
-  {{ super() }}
-  </div>
-{% endblock %}
-
 {% block content %}
 
   <div class="govuk-grid-row">

--- a/lib/nunjucks/views/manage-prototype/layout.njk
+++ b/lib/nunjucks/views/manage-prototype/layout.njk
@@ -1,5 +1,8 @@
-{%- set assetPath = '/manage-prototype/dependencies/govuk-frontend' + govukFrontendInternal.assetPath -%}
-{% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}
+{% set assetPath = '/manage-prototype/dependencies/govuk-frontend' + govukFrontendInternal.assetPath -%}
+{% if not 'assets/rebrand' in assetPath %}
+  {% set assetPath = assetPath + '/rebrand' %}
+{% endif %}
+{% extends "govuk-prototype-kit/layouts/govuk-branded.njk" -%}
 
 {% block pageTitle %}
   {% if pageName %}

--- a/lib/nunjucks/views/manage-prototype/layout.njk
+++ b/lib/nunjucks/views/manage-prototype/layout.njk
@@ -25,26 +25,28 @@
 {% endblock %}
 
 {% block beforeContent %}
-  <nav id="govuk-prototype-kit-manage-prototype-navigation" class="govuk-prototype-kit-manage-prototype-navigation js-govuk-prototype-kit-manage-prototype-navigation govuk-clearfix" role="navigation"
-       aria-labelledby="govuk-prototype-kit-manage-prototype-navigation-heading">
-    <h2 class="govuk-visually-hidden" id="govuk-prototype-kit-manage-prototype-navigation-heading">Menu</h2>
-    <ul class="govuk-prototype-kit-manage-prototype-navigation__list govuk-prototype-kit-manage-prototype-width-container">
+  {% if links | length %}
+    <nav id="govuk-prototype-kit-manage-prototype-navigation" class="govuk-prototype-kit-manage-prototype-navigation js-govuk-prototype-kit-manage-prototype-navigation govuk-clearfix" role="navigation"
+        aria-labelledby="govuk-prototype-kit-manage-prototype-navigation-heading">
+      <h2 class="govuk-visually-hidden" id="govuk-prototype-kit-manage-prototype-navigation-heading">Menu</h2>
+      <ul class="govuk-prototype-kit-manage-prototype-navigation__list govuk-prototype-kit-manage-prototype-width-container">
 
-      
-      {% for link in links %}
-
-        <li class="govuk-prototype-kit-manage-prototype-navigation__list-item {{ "govuk-prototype-kit-manage-prototype-navigation__list-item--current" if link.text === currentSection }}">
-          <a
-            class="govuk-link govuk-link--no-visited-state govuk-link--no-underline govuk-prototype-kit-manage-prototype-navigation__link js-govuk-prototype-kit-manage-prototype-navigation__link"
-            href="{{ link.url }}">
-            {{ link.text }}
-          </a>
-        </li>
         
-      {% endfor %}
-      
-    </ul>
-  </nav>
+        {% for link in links %}
+
+          <li class="govuk-prototype-kit-manage-prototype-navigation__list-item {{ "govuk-prototype-kit-manage-prototype-navigation__list-item--current" if link.text === currentSection }}">
+            <a
+              class="govuk-link govuk-link--no-visited-state govuk-link--no-underline govuk-prototype-kit-manage-prototype-navigation__link js-govuk-prototype-kit-manage-prototype-navigation__link"
+              href="{{ link.url }}">
+              {{ link.text }}
+            </a>
+          </li>
+          
+        {% endfor %}
+        
+      </ul>
+    </nav>
+  {% endif %}
   
   {{ super() }}
 {% endblock %}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -20,7 +20,7 @@
         "express": "^4.18.2",
         "express-session": "^1.18.0",
         "fs-extra": "^11.2.0",
-        "govuk-frontend": "5.2.0",
+        "govuk-frontend": "5.10.2",
         "inquirer": "^8.2.6",
         "lodash": "^4.17.21",
         "marked": "^4.3.0",
@@ -6144,9 +6144,10 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.2.0.tgz",
-      "integrity": "sha512-beD3wztHpkKz6JUpPwnwop1ejb4rTFMPLCutKLCIDmUS4BPpW59ggVUfctsRqHd2Zjw9wxljdRdeIJ8AZFyyTw==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.10.2.tgz",
+      "integrity": "sha512-eVYB2rfUCihehZFHQyylt12/OuXq2JLs+70igcrB1FmbepcDqs1XwKiq96hsPbPF9Vn2f6QXO1OatyD3bq5c9Q==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -16362,9 +16363,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.2.0.tgz",
-      "integrity": "sha512-beD3wztHpkKz6JUpPwnwop1ejb4rTFMPLCutKLCIDmUS4BPpW59ggVUfctsRqHd2Zjw9wxljdRdeIJ8AZFyyTw=="
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.10.2.tgz",
+      "integrity": "sha512-eVYB2rfUCihehZFHQyylt12/OuXq2JLs+70igcrB1FmbepcDqs1XwKiq96hsPbPF9Vn2f6QXO1OatyD3bq5c9Q=="
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "express": "^4.18.2",
     "express-session": "^1.18.0",
     "fs-extra": "^11.2.0",
-    "govuk-frontend": "5.2.0",
+    "govuk-frontend": "5.10.2",
     "inquirer": "^8.2.6",
     "lodash": "^4.17.21",
     "marked": "^4.3.0",


### PR DESCRIPTION
## Change

Updates the prototype kit to govuk-frontend 5.10.2 and apples the brand refresh to the management pages.

Resolves https://github.com/alphagov/govuk-prototype-kit/issues/2430

This also updates a few things within protptypes themselves:

- Applies the brand updates to template previews if the rebrand config options are present
- Applies the brand updates to error pages if the rebrand config options are present
- Sets the govuk frontend asset path to `assets/rebrand` instead of `assets` if the rebrand config options are present, and amends this in the template for management pages to ensure that they're always using the rebrand assets. This resolves both https://github.com/alphagov/govuk-prototype-kit/issues/2431 and https://github.com/alphagov/govuk-prototype-kit/issues/2427.

## Notes

As part of the update, I snuck in applying the new type scale in https://github.com/alphagov/govuk-prototype-kit/commit/b1b5f7694261d2a3d892c0630bceffaa9b27a740 introduced in https://github.com/alphagov/govuk-frontend/releases/tag/v5.2.0. This'll get turned on by default anyway in 6.0 so we might as well turn it on now.