### PR TITLE
Replace `$govuk-canvas-background-colour` with `$govuk-template-background-colour`

### DIFF
--- a/lib/assets/sass/unbranded.scss
+++ b/lib/assets/sass/unbranded.scss
@@ -6,7 +6,7 @@
 // Override the default GOV.UK Frontend font stack
 $govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
 
-// Override the canvas background colour, which is normally grey to blend with the GOV.UK footer.
-$govuk-canvas-background-colour: #ffffff;
+// Override the template background colour, which is normally grey to blend with the GOV.UK footer.
+$govuk-template-background-colour: #ffffff;
 
 @import "prototype";


### PR DESCRIPTION
We deprecated `$govuk-canvas-background-colour` in favour of `$govuk-template-background-colour` in [GOV.UK Frontend 5.10.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0).

Closes https://github.com/alphagov/govuk-prototype-kit/issues/2423

Console output before:

```
% npm run start:dev

> govuk-prototype-kit@13.16.2 start:dev
> node scripts/create-prototype-and-run

creating test prototype in /var/folders/y0/j0t3vy_x28b90_qtlqj40vsc0000gq/T/test-prototype
and after changing directory
running prototype using command "npm run dev"

Creating test prototype at /var/folders/y0/j0t3vy_x28b90_qtlqj40vsc0000gq/T/test-prototype

Creating your prototype
 -  Installing dependencies
 -  Setting up your prototype
 -  Initialising git

Prototype created

Change to your prototype directory:
  cd /var/folders/y0/j0t3vy_x28b90_qtlqj40vsc0000gq/T/test-prototype

To run your prototype:
  npm run dev

Kit creation took [4.8] seconds


> dev
> govuk-prototype-kit dev

GOV.UK Prototype Kit 13.16.2

starting...
Warning: $govuk-canvas-background-colour has been deprecated and will be removed in the next major version. To silence this warning, update $govuk-suppressed-warnings with key: "$govuk-canvas-background-colour"
    node_modules/govuk-frontend/dist/govuk/settings/_warnings.scss 51:5                      -warning()
    node_modules/govuk-frontend/dist/govuk/settings/_colours-applied.scss 41:3               @import
    node_modules/govuk-frontend/dist/govuk/settings/_index.scss 13:9                         @import
    node_modules/govuk-frontend/dist/govuk/_base.scss 1:9                                    @import
    node_modules/govuk-frontend/dist/govuk/index.scss 1:9                                    @import
    node_modules/govuk-frontend/dist/govuk-prototype-kit/init.scss 11:9                      @import
    .tmp/sass/_plugins.scss 5:9                                                              @import
    /Users/owen.jones/design-system/govuk-prototype-kit/lib/assets/sass/prototype.scss 5:9   @import
    /Users/owen.jones/design-system/govuk-prototype-kit/lib/assets/sass/unbranded.scss 12:9  root stylesheet

Warning: $govuk-canvas-background-colour has been deprecated and will be removed in the next major version. To silence this warning, update $govuk-suppressed-warnings with key: "$govuk-canvas-background-colour"
    node_modules/govuk-frontend/dist/govuk/settings/_warnings.scss 51:5                      -warning()
    node_modules/govuk-frontend/dist/govuk/settings/_colours-applied.scss 41:3               @import
    node_modules/govuk-frontend/dist/govuk/settings/_index.scss 13:9                         @import
    node_modules/govuk-frontend/dist/govuk/_base.scss 1:9                                    @import
    node_modules/govuk-frontend/dist/govuk/index.scss 1:9                                    @import
    node_modules/govuk-frontend/dist/govuk-prototype-kit/init.scss 11:9                      @import
    .tmp/sass/_plugins.scss 5:9                                                              @import
    /Users/owen.jones/design-system/govuk-prototype-kit/lib/assets/sass/prototype.scss 5:9   @import
    /Users/owen.jones/design-system/govuk-prototype-kit/lib/assets/sass/unbranded.scss 12:9  root stylesheet


Watching dependency govuk-prototype-kit as it's a symbolic link.

Warning: $govuk-canvas-background-colour has been deprecated and will be removed in the next major version. To silence this warning, update $govuk-suppressed-warnings with key: "$govuk-canvas-background-colour"
    node_modules/govuk-frontend/dist/govuk/settings/_warnings.scss 51:5                      -warning()
    node_modules/govuk-frontend/dist/govuk/settings/_colours-applied.scss 41:3               @import
    node_modules/govuk-frontend/dist/govuk/settings/_index.scss 13:9                         @import
    node_modules/govuk-frontend/dist/govuk/_base.scss 1:9                                    @import
    node_modules/govuk-frontend/dist/govuk/index.scss 1:9                                    @import
    node_modules/govuk-frontend/dist/govuk-prototype-kit/init.scss 11:9                      @import
    .tmp/sass/_plugins.scss 5:9                                                              @import
    /Users/owen.jones/design-system/govuk-prototype-kit/lib/assets/sass/prototype.scss 5:9   @import
    /Users/owen.jones/design-system/govuk-prototype-kit/lib/assets/sass/unbranded.scss 12:9  root stylesheet

You can manage your prototype at:
http://localhost:3000/manage-prototype

The Prototype Kit is now running at:
http://localhost:3000
```

Console output after:

```
% npm run start:dev

> govuk-prototype-kit@13.16.2 start:dev
> node scripts/create-prototype-and-run

creating test prototype in /var/folders/y0/j0t3vy_x28b90_qtlqj40vsc0000gq/T/test-prototype
and after changing directory
running prototype using command "npm run dev"

Creating test prototype at /var/folders/y0/j0t3vy_x28b90_qtlqj40vsc0000gq/T/test-prototype

Creating your prototype
 -  Installing dependencies
 -  Setting up your prototype
 -  Initialising git

Prototype created

Change to your prototype directory:
  cd /var/folders/y0/j0t3vy_x28b90_qtlqj40vsc0000gq/T/test-prototype

To run your prototype:
  npm run dev

Kit creation took [4.3] seconds


> dev
> govuk-prototype-kit dev

GOV.UK Prototype Kit 13.16.2

starting...

Watching dependency govuk-prototype-kit as it's a symbolic link.

You can manage your prototype at:
http://localhost:3000/manage-prototype

The Prototype Kit is now running at:
http://localhost:3000
```