### PR TITLE
Add support for Node 22

### DIFF
--- a/.github/workflows/test-acceptance.yaml
+++ b/.github/workflows/test-acceptance.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false  # continue other tests if one test in matrix fails
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         os: [macos-latest, windows-latest, ubuntu-latest]
         type: [smoke, plugins, styles, dev, prod, errors]
 

--- a/.github/workflows/test-heroku.yaml
+++ b/.github/workflows/test-heroku.yaml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/setup-node@v4.4.0
       with:
         cache: 'npm'
-        node-version: '20'
+        node-version: '22'
     - name: Cache Cypress binary
       uses: actions/cache@v4.2.3
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false  # continue other tests if one test in matrix fails
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x, 22.x]
         os: [macos-latest, windows-latest, ubuntu-latest]
 
     name: Test kit on Node v${{ matrix.node-version }} (${{ matrix.os }})

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/iron
+lts/jod

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 - [#2434: Apply brand updates manage prototype pages](https://github.com/alphagov/govuk-prototype-kit/pull/2434)
+- [#2443: Add support for Node 22](https://github.com/alphagov/govuk-prototype-kit/pull/2443)
 
 ### Fixes
 

--- a/bin/cli
+++ b/bin/cli
@@ -2,16 +2,16 @@
 
 if (process.argv.indexOf('--suppress-node-version-warning') === -1 || (process.argv[2] === 'migrate' && process.argv[3] === '--')) {
   const majorNodeVersion = parseInt(process.version.split('.')[0].substring(1), 10)
-  const versionIsWithinRecommendation = [16, 18, 20].includes(majorNodeVersion)
+  const versionIsWithinRecommendation = [16, 18, 20, 22].includes(majorNodeVersion)
   if (!versionIsWithinRecommendation) {
     const nodeVersionIsTooOldToUse = majorNodeVersion < 14
-    const updateOrDownload = majorNodeVersion < 20 ? 'update to' : 'download'
+    const updateOrDownload = majorNodeVersion < 22 ? 'update to' : 'download'
     const printLn = nodeVersionIsTooOldToUse ? console.error.bind(console) : console.warn.bind(console)
     const additionalText = nodeVersionIsTooOldToUse ? '' : ' Some features may not work with your version.'
 
     printLn('\nYou\'re using Node', process.version)
-    printLn('The GOV.UK Prototype Kit only supports Node v16, v18 and v20.' + additionalText + '\n')
-    printLn('You can', updateOrDownload, 'Node v20 at https://nodejs.org/en/download\n')
+    printLn('The GOV.UK Prototype Kit only supports Node v16, v18, v20 and v22.' + additionalText + '\n')
+    printLn('You can', updateOrDownload, 'Node v22 at https://nodejs.org/en/download\n')
 
     if (nodeVersionIsTooOldToUse) {
       process.exit(0)


### PR DESCRIPTION
`package.json` already allowed to run on Node 22, but `bin/cli.js` would log a warning if you used that version, so updates to allow Node 22 as well.

Also updates the tests to ensure things work OK on Node 22.

## Thoughts

Pretty much followed the changes in [this commit](https://github.com/alphagov/govuk-prototype-kit/commit/4eb6041f7574b58626efe2a66fb8d8dd4d990cf5), except for:
- `package.json` and `npm-shrinkwrap.json` which already allowed 22
- `lib/plugins/plugin-validator.spec.js` which didn't need updating

To ease the maintenance in the future, we may want to look into updating `bin/cli.js` to allow any LTS after Node 22 (ie. even numbers after Node 22). We'd need to get some understanding on whether Node may suddenly remove features which may break the kit, as well as figure how to test against these new versions, so it felt like a completely separate piece of work. It might be something that could be looked at when [Node LTS becomes 24](https://nodejs.org/en/about/previous-releases).

Note that we also cannot remove older versions of Node as it would be a breaking change. We may want to look at this in the future to avoid ever expanding the versions of Node supported.

Works towards solving #2415 