### PR TITLE
Apply new brand to new prototypes

### DIFF
--- a/prototype-starter/app/config.json
+++ b/prototype-starter/app/config.json
@@ -1,3 +1,8 @@
 {
-  "serviceName": "Service name goes here"
+  "serviceName": "Service name goes here",
+  "plugins": {
+    "govuk-frontend": {
+      "rebrand": true
+    }
+  }
 }

--- a/prototype-starter/app/views/layouts/main.html
+++ b/prototype-starter/app/views/layouts/main.html
@@ -4,3 +4,12 @@ https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
 #}
 
 {% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}
+
+{% block header %}
+
+    {{ govukHeader() }}
+    {{ govukServiceNavigation({
+        serviceName: serviceName
+    })}}
+
+{% endblock %}


### PR DESCRIPTION
Make changes to the starter files so new prototypes will have the new brand, and use the recommended new approach to header and service name.

This does not affect any existing prototype so not a breaking change.

New prototypes would look like this:

<img width="1088" alt="prototype home page with new brand, service name is not in header but in service navigation" src="https://github.com/user-attachments/assets/880ac4be-906c-45f7-93da-e11b7ae5e142" />
