### PR TITLE
Update manage prototype header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New features
+
+- [#2452: Update manage prototype header](https://github.com/alphagov/govuk-prototype-kit/pull/2452)
+
 ## 13.17.0
 
 ### New features

--- a/cypress/e2e/dev/5-management-tests/change-service-name.cypress.js
+++ b/cypress/e2e/dev/5-management-tests/change-service-name.cypress.js
@@ -10,7 +10,7 @@ const appConfig = path.join(Cypress.env('projectFolder'), appConfigPath)
 const originalText = 'Service name goes here'
 const newText = 'Cypress test'
 
-const serverNameQuery = 'a.govuk-header__link.govuk-header__service-name, a.govuk-header__link--service-name'
+const serviceNameQuery = '.govuk-service-navigation__service-name'
 
 const managePagePath = '/manage-prototype'
 
@@ -28,7 +28,7 @@ describe('change service name', () => {
 
     cy.task('log', 'Visit the manage prototype page')
 
-    cy.get(serverNameQuery).contains(originalText)
+    cy.get(serviceNameQuery).contains(originalText)
     cy.get('.govuk-prototype-kit-manage-prototype-task-list__item')
       .contains(appConfigPath)
       .get('.govuk-prototype-kit-manage-prototype-task-list__tag').contains('To do')
@@ -37,7 +37,7 @@ describe('change service name', () => {
 
     waitForApplication(managePagePath)
 
-    cy.get(serverNameQuery).contains(newText)
+    cy.get(serviceNameQuery).contains(newText)
     cy.get('.govuk-prototype-kit-manage-prototype-task-list__item')
       .contains(appConfigPath)
       .get('.govuk-prototype-kit-manage-prototype-task-list__tag').contains('Done')

--- a/lib/manage-prototype-handlers.js
+++ b/lib/manage-prototype-handlers.js
@@ -157,16 +157,16 @@ async function pluginCacheMiddleware (req, res, next) {
 
 const managementLinks = [
   {
+    text: 'Manage your prototype',
+    href: '/manage-prototype'
+  },
+  {
     text: 'Templates',
     href: '/manage-prototype/templates'
   },
   {
     text: 'Plugins',
     href: '/manage-prototype/plugins'
-  },
-  {
-    text: 'Go to prototype',
-    href: '/'
   }
 ]
 

--- a/lib/nunjucks/views/manage-prototype/layout.njk
+++ b/lib/nunjucks/views/manage-prototype/layout.njk
@@ -27,11 +27,13 @@
 {% endblock %}
 
 {% block header %}
-  {{ super() }}
+  {{ govukHeader({
+    productName: "Prototype Kit"
+  }) }}
   {%- if links | length %}
     {{ govukServiceNavigation({
-      serviceName: 'Manage your prototype',
-      serviceUrl: '/manage-prototype',
+      serviceName: serviceName,
+      serviceUrl: '/',
       navigation: links
     }) }}
   {% endif -%}


### PR DESCRIPTION
Update Manage your prototype pages to use the new style header and servicename placement.

I'm also suggesting using productName as it makes sense to me to clarify this isn't GOV.UK

These changes do not affect user's prototype pages.

It would be nice (and follow guidance) to have each section in the nav selected on the relevant pages, but I'm not sure how hard that is.

<img width="1070" alt="Manage prototype page with GOV.UK Prototype Kit in header and service name in navigation" src="https://github.com/user-attachments/assets/90c05dcd-c8e0-455d-aa1f-e0470d7b4d79" />
