### PR TITLE
Preparing for release 13.17.0 (automated).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 13.17.0
+
 ### New features
 
 - [#2434: Apply brand updates manage prototype pages](https://github.com/alphagov/govuk-prototype-kit/pull/2434)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "govuk-prototype-kit",
-  "version": "13.16.2",
+  "version": "13.17.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-prototype-kit",
-      "version": "13.16.2",
+      "version": "13.17.0",
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "body-parser": "^1.20.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-prototype-kit",
   "description": "Rapidly create HTML prototypes of GOV.UK services",
-  "version": "13.16.2",
+  "version": "13.17.0",
   "engines": {
     "node": "^16.x || ^18.x || >= 20.x"
   },


### PR DESCRIPTION

### New features

- [#2434: Apply brand updates manage prototype pages](https://github.com/alphagov/govuk-prototype-kit/pull/2434)
- [#2443: Add support for Node 22](https://github.com/alphagov/govuk-prototype-kit/pull/2443)
- [#2439: Replace custom nav on management pages with service navigation](https://github.com/alphagov/govuk-prototype-kit/pull/2439)

### Fixes

- [#2408: Fix kit version update link](https://github.com/alphagov/govuk-prototype-kit/pull/2408)
- [#2420: Fixing the default homepage](https://github.com/alphagov/govuk-prototype-kit/pull/2420)
- [#2425: Fix open redirect vuln in login page](https://github.com/alphagov/govuk-prototype-kit/pull/2425)
- [#2437: Fix version logic for showing whether a plugin has updates](https://github.com/alphagov/govuk-prototype-kit/pull/2437)
- [#2442: Avoid warnings in the console when Sass files get compiled](https://github.com/alphagov/govuk-prototype-kit/pull/2442)
- [#2413: Update dependencies to resolve npm audit warnings](https://github.com/alphagov/govuk-prototype-kit/pull/2413)
- [#2417: Causing an error when session-data-defaults is malformed](https://github.com/alphagov/govuk-prototype-kit/pull/2417)