### PR TITLE
Run `npm run clean-publish` from correct directory

### DIFF
--- a/scripts/utils/create-release-pr
+++ b/scripts/utils/create-release-pr
@@ -50,7 +50,10 @@ async function exec (command, { allowStderr = false, hideStd = false, allowError
 
 function spawnWithTty (command, args = []) {
   return new Promise((resolve, reject) => {
-    const result = cp.spawn(command, args, { stdio: 'inherit' })
+    const result = cp.spawn(command, args, {
+      cwd: projectDir,
+      stdio: 'inherit'
+    })
     result.on('exit', function (code, signal) {
       if (code === 0) {
         resolve()


### PR DESCRIPTION
When publishing a release we’re seeing the `npm run clean-publish` script fail because it’s trying to publish a previously published version.

We think this is because:

1. `scripts/prepare-release` clones a fresh instance of the Prototype Kit to a temp folder and then runs the `/scripts/utils/create-release-pr` script from that, also passing the folder as an argument. The working directory however is still your 'local' copy of the prototype kit.

2. Almost all of the system calls from `/scripts/utils/create-release-pr` use a wrapper function `exec` which sets the working directory to the temp folder (`projectDir`, the argument passed to the script as described in the previous step):

    https://github.com/alphagov/govuk-prototype-kit/blob/4bf9e319b1c9b6dd7cb34103419e7e680b3876e2/scripts/utils/create-release-pr#L17-L20

3. However, `npm run clean-publish` is the only system call in the script to use the separate `spawnWithTty` wrapper function, which _does not_ set the working directory:

    https://github.com/alphagov/govuk-prototype-kit/blob/4bf9e319b1c9b6dd7cb34103419e7e680b3876e2/scripts/utils/create-release-pr#L51-L53

We believe that `npm run clean-publish` therefore runs in the context of your _local_ copy of the Prototype Kit. Your local copy will still exist in the state from before the release script was run, as all of the other commands have operated on the instance of the Prototype Kit in the temp folder.

Update the `spawnWithTty ` wrapper function to set `cwd` to `projectDir` in the same way that `exec` does, in the hope that running the command from the context of the temp folder solves the problem

Unfortunately there are no tests for this functionality and no easy way to manually test it either – we’ll just need to see if the process works the next time we want to release something!🤞🏻

(Hopefully) fixes #2455.