### PR TITLE
Preparing for release 13.18.1 (automated).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 13.18.1
+
 ### Fixes
 
 - [#2462: Update from inquirer 8.2.6 to @inquirer/confirm 5.1.15 to address a vulnerability in tmp](https://github.com/alphagov/govuk-prototype-kit/pull/2462)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "govuk-prototype-kit",
-  "version": "13.18.0",
+  "version": "13.18.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-prototype-kit",
-      "version": "13.18.0",
+      "version": "13.18.1",
       "dependencies": {
         "@inquirer/confirm": "^5.1.15",
         "ansi-colors": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-prototype-kit",
   "description": "Rapidly create HTML prototypes of GOV.UK services",
-  "version": "13.18.0",
+  "version": "13.18.1",
   "engines": {
     "node": "^16.x || ^18.x || >= 20.x"
   },


### PR DESCRIPTION

### Fixes

- [#2462: Update from inquirer 8.2.6 to @inquirer/confirm 5.1.15 to address a vulnerability in tmp](https://github.com/alphagov/govuk-prototype-kit/pull/2462)