### PR TITLE
Use service nav for govuk branded templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New features
+
+- [#2466: Use service nav for govuk branded templates](https://github.com/alphagov/govuk-prototype-kit/pull/2466)
+
 ## 13.18.1
 
 ### Fixes

--- a/lib/nunjucks/govuk-prototype-kit/layouts/govuk-branded.njk
+++ b/lib/nunjucks/govuk-prototype-kit/layouts/govuk-branded.njk
@@ -1,4 +1,5 @@
 {%- set assetPath = assetPath | default('/plugin-assets/govuk-frontend' + govukFrontend.assetPath) -%}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
 
 {% extends "govuk/template.njk" %}
 
@@ -16,9 +17,11 @@
 {% block header %}
   {{ govukHeader({
     homepageUrl: "/",
-    serviceName: serviceName,
-    serviceUrl: "/",
     containerClasses: "govuk-width-container"
+  }) }}
+  {{ govukServiceNavigation({
+    serviceName: serviceName,
+    serviceUrl: '/'
   }) }}
 {% endblock %}
 


### PR DESCRIPTION
What it says on the tin.

Addresses a small part of https://github.com/alphagov/govuk-frontend/issues/5786