### PR TITLE
Add MOJ Frontend to known-plugins.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ You can find more information in the [install guide for your operating system](h
 
 - [#2578: Bump supported Node version](https://github.com/alphagov/govuk-prototype-kit/pull/2578)
 
+### New features
+
+#### MOJ Frontend is available as a plugin
+
+You can now install [MOJ Frontend](https://github.com/ministryofjustice/moj-frontend) from the 'Manage prototype' pages in your browser, so you can use MOJ Design System components in your prototype.
+
+- [#2478: Add MOJ Frontend to known-plugins.json](https://github.com/alphagov/govuk-prototype-kit/pull/2478)
+
 ## 13.20.4
 
 ### Fixes

--- a/known-plugins.json
+++ b/known-plugins.json
@@ -5,6 +5,7 @@
       "@govuk-prototype-kit/common-templates",
       "@govuk-prototype-kit/step-by-step",
       "@govuk-prototype-kit/task-list",
+      "@ministryofjustice/frontend",
       "hmrc-frontend",
       "jquery",
       "notifications-node-client"


### PR DESCRIPTION
Could we please have MOJ Frontend in the list of known plugins? This would make it easier for MOJ prototype kit users to get up and running using the kit and our design system components. Thanks.