### PR TITLE
Replace windows-latest with windows-2022

### DIFF
--- a/.github/workflows/test-acceptance.yaml
+++ b/.github/workflows/test-acceptance.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false  # continue other tests if one test in matrix fails
       matrix:
         node-version: [22.x]
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest, windows-2022, ubuntu-latest]
         type: [smoke, plugins, styles, dev, prod, errors]
 
     name: Acceptance ${{ matrix.type }} test kit on Node v${{ matrix.node-version }} (${{ matrix.os }})


### PR DESCRIPTION
See [this comment](https://github.com/alphagov/govuk-prototype-kit/pull/2479#issuecomment-3612584273) for more details.

At some point we should try to get up to windows-2025 but in the interim this should resolve those acceptance failures we're seeing.

Something I could also do here is also change the other instance of `windows-latest` in the test workflow. These are working fine however and the failures are only in the acceptance test space. This deserves a proper look eventually but in the interest of keeping things clean I propose we do the minimum for now.