### PR TITLE
Replace `$govuk-template-background-colour` with direct definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - [#2479: Remove pagination and task list legacy stylesheets](https://github.com/alphagov/govuk-prototype-kit/pull/2479)
 
+### Fixes
+
+- [#2485: Replace `$govuk-template-background-colour` with direct definition](https://github.com/alphagov/govuk-prototype-kit/pull/2485)
+
 ## 13.18.1
 
 ### Fixes

--- a/lib/assets/sass/unbranded.scss
+++ b/lib/assets/sass/unbranded.scss
@@ -6,7 +6,9 @@
 // Override the default GOV.UK Frontend font stack
 $govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
 
-// Override the template background colour, which is normally grey to blend with the GOV.UK footer.
-$govuk-template-background-colour: #ffffff;
-
 @import "prototype";
+
+// Override the template background colour
+.govuk-template, .govuk-template--rebranded {
+  background-color: govuk-colour("white");
+}


### PR DESCRIPTION
Resolves https://github.com/alphagov/govuk-prototype-kit/issues/2476

## To test

1. Either generate a new kit from this branch, attach this branch to a local prototype or run a temporary prototype with `npm run start:dev`
2. Go to the prototype management pages > templates
3. View the 'unbranded' template

The template's background should be all white

## Notes

Is this change breaking? I've listed it for now as a fix, however it does change the behviour of the template. For example, if a user where to create an unbranded page and then redefine `$govuk-template-background-colour` in their template. I'm going to work on the assumption that it isn't unless someone disagrees.