### PR TITLE
Allow update dependency graph workflow to be manually run

### DIFF
--- a/.github/workflows/update-dependency-graph.yaml
+++ b/.github/workflows/update-dependency-graph.yaml
@@ -16,6 +16,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   update-dependency-graph:


### PR DESCRIPTION
The [first attempt to add this workflow][1] failed because the actions permissions did not allow the action to run, and there's no way to re-run it so I need an excuse to update the main branch again 😉 

It would also be useful to be able to manually trigger the workflow using workflow_dispatch.

[1]: https://github.com/alphagov/govuk-prototype-kit/actions/runs/20776120525