### PR TITLE
Replace links to the website get-in-touch page to contact

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Get in touch another way
-    url: https://design-system.service.gov.uk/get-in-touch/
+    url: https://design-system.service.gov.uk/contact/
     about: Find out how to get in touch via email or Slack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -672,7 +672,7 @@ If you're not using Nunjucks macros, remove the `tabindex` attribute from the er
 
 This change was introduced in [pull request #2491: Prevent error summary from being refocused after it has been initially focused on page load](https://github.com/alphagov/govuk-frontend/pull/2491).
 
-If you need help with the Prototype Kit, [contact the GOV.UK Prototype team](https://design-system.service.gov.uk/get-in-touch/).
+If you need help with the Prototype Kit, [contact the GOV.UK Prototype team](https://design-system.service.gov.uk/contact/).
 
 ## 12.0.0 (Breaking release)
 
@@ -712,7 +712,7 @@ This was added in [#1120: Preserve query string when redirecting POSTs to GETs](
 
 - [#1155: Replace `keypather` package with `lodash.get`](https://github.com/alphagov/govuk-prototype-kit/pull/1155)
 
-If you need help with the Prototype Kit, [contact the GOV.UK Prototype team](https://design-system.service.gov.uk/get-in-touch/).
+If you need help with the Prototype Kit, [contact the GOV.UK Prototype team](https://design-system.service.gov.uk/contact/).
 
 
 
@@ -755,7 +755,7 @@ We have updated the Notify client library to version 5.1.0. This may break exist
 
 ### Breaking change pull requests
 
-- [Pull request #925: Upgrade Notify client library from 4.7.2 to 5.1.0](https://github.com/alphagov/govuk-prototype-kit/pull/925). This may break existing prototypes which are using the Notify client. If you have any issues, please [contact the GOV.UK Prototype Kit team](https://design-system.service.gov.uk/get-in-touch/).
+- [Pull request #925: Upgrade Notify client library from 4.7.2 to 5.1.0](https://github.com/alphagov/govuk-prototype-kit/pull/925). This may break existing prototypes which are using the Notify client. If you have any issues, please [contact the GOV.UK Prototype Kit team](https://design-system.service.gov.uk/contact/).
 - [Pull request #1127: Update to Node 16 and drop support for Node 10](https://github.com/alphagov/govuk-prototype-kit/pull/1127)
 
 ### Fixes
@@ -1017,7 +1017,7 @@ You must follow our [guidance on updating your version of the Prototype Kit](htt
 
 If you need help updating or installing the Prototype Kit, you can:
 
-- [contact the GOV.UK Design System team](https://design-system.service.gov.uk/get-in-touch/)
+- [contact the GOV.UK Design System team](https://design-system.service.gov.uk/contact/)
 - talk to a developer on your team
 
 ### Breaking changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution guidelines
 
-**The GOV.UK Prototype Kit is currently maintained by the [GOV.UK Design System team](https://design-system.service.gov.uk/get-in-touch/). 
+**The GOV.UK Prototype Kit is currently maintained by the [GOV.UK Design System team](https://design-system.service.gov.uk/contact/). 
 
 [There is only minimal support in place](https://github.com/alphagov/govuk-prototype-kit) so we cannot work on contributions at this time.**
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The Prototype Kit always supports at least the current and previous LTS releases
 
 ## Support
 
-The GOV.UK Prototype Kit is currently maintained by the [GOV.UK Design System team](https://design-system.service.gov.uk/get-in-touch/). There is only [minimal support in place](https://github.com/alphagov/govuk-prototype-kit/issues/2389).
+The GOV.UK Prototype Kit is currently maintained by the [GOV.UK Design System team](https://design-system.service.gov.uk/contact/). There is only [minimal support in place](https://github.com/alphagov/govuk-prototype-kit/issues/2389).
 
 If you’ve got a question, idea or suggestion, share with the community of users on the [#govuk-prototype-kit channel on cross-government Slack](https://ukgovernmentdigital.slack.com/archives/C0647LW4R).
 


### PR DESCRIPTION
Replaces links to `https://design-system.service.gov.uk/get-in-touch/` with `https://design-system.service.gov.uk/contact/`

Doing in response to https://github.com/alphagov/govuk-design-system/pull/5068. This isn't the biggest deal since we redirect but is the neater option.