### PR TITLE
Preparing for release 13.20.0 (automated).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 13.20.0
+
 ### New features
 
 When you install plugins using the 'Manage prototype' page or install other dependencies using the `npm` command:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "govuk-prototype-kit",
-  "version": "13.19.1",
+  "version": "13.20.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-prototype-kit",
-      "version": "13.19.1",
+      "version": "13.20.0",
       "dependencies": {
         "@inquirer/confirm": "^5.1.15",
         "ansi-colors": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-prototype-kit",
   "description": "Rapidly create HTML prototypes of GOV.UK services",
-  "version": "13.19.1",
+  "version": "13.20.0",
   "engines": {
     "node": "^16.x || ^18.x || >= 20.x"
   },


### PR DESCRIPTION

### New features

When you install plugins using the 'Manage prototype' page or install other dependencies using the `npm` command:
- npm scripts will no longer be run for the installed plugins or dependencies
- you will not be able to install plugins or dependencies using Git references if you're using npm v11.10.0 or later
This only applies to new prototypes created using `npx govuk-prototype-kit@latest create`.
To protect existing prototypes, add the following lines to the `.npmrc` file in your prototype:
```
ignore-scripts=true
allow-git=none
```
We've made these changes to help protect Prototype Kit users against [supply chain attacks](https://ico.org.uk/about-the-ico/research-reports-impact-and-evaluation/research-and-reports/learning-from-the-mistakes-of-others-a-retrospective-review/supply-chain-attacks/), where malicious code is included in a dependency.
It's still possible for dependencies to execute malicious code. Make sure you only install dependencies from trusted sources.
[#2519: Disable npm scripts and installing from git dependencies by default for new prototypes](https://github.com/alphagov/govuk-prototype-kit/pull/2519)

### Fixes

- [#2516: Update immutable](https://github.com/alphagov/govuk-prototype-kit/pull/2516)
- [#2518: Only fetch plugin package info from NPM when needed](https://github.com/alphagov/govuk-prototype-kit/pull/2518) – thanks to @RichardBradley for reporting this issue and contributing a fix
- [#2524: Update brace-expansion, path-to-regexp, picomatch, socket.io-parser, lodash and other dev dependencies](https://github.com/alphagov/govuk-prototype-kit/pull/2524)