### PR TITLE
Move releasing into github actions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,70 @@
+name: 'RELEASE: Build release'
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New version number eg: 5.3.1'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build-release:
+    name: Build release
+    runs-on: Ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup Node
+        uses: actions/setup-node@v6.3.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate version
+        uses: actions/github-script@v8.0.0
+        with:
+          script: |
+            const { validateVersion } = await import('${{ github.workspace }}/scripts/github-actions/changelog-release-helper.mjs')
+            const kitPackage = await import('${{ github.workspace }}/package.json', { with: { type: 'json' }})
+
+            validateVersion('${{ inputs.version }}', kitPackage.default.version)
+
+      - name: Update CHANGELOG
+        uses: actions/github-script@v8.0.0
+        with:
+          script: |
+            const { updateChangelog } = await import('${{ github.workspace }}/scripts/github-actions/changelog-release-helper.mjs')
+
+            updateChangelog('${{ inputs.version }}')
+
+      - name: Update package version
+        run: npm version --no-git-tag-version --workspace govuk-frontend ${{ inputs.version }}
+
+      - name: Generate release notes
+        uses: actions/github-script@v8.0.0
+        with:
+          script: |
+            const { generateReleaseNotes } = await import('${{ github.workspace }}/scripts/github-actions/changelog-release-helper.mjs')
+
+            generateReleaseNotes('${{ inputs.version }}', { actor: '${{ github.actor }}', runId: '${{ github.run_id }}' })
+
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.CI_PAT }}
+        run: |
+          git config --global user.name '${{ github.actor }}'
+          git config --global user.email '${{ github.actor }}@digital.cabinet-office.gov.uk'
+          git add .
+          git commit -m "Release ${{ inputs.version }}"
+          git checkout -b release-${{ inputs.version }}
+          git push -u origin release-${{ inputs.version }}
+          gh pr create --base main --head release-${{ inputs.version }} --title "Release ${{ inputs.version }}" --body-file "release-notes-body"

--- a/.github/workflows/publish-release-to-github.yaml
+++ b/.github/workflows/publish-release-to-github.yaml
@@ -1,0 +1,71 @@
+name: 'RELEASE: GitHub release'
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-release-to-github:
+    name: Publish release to GitHub
+    runs-on: Ubuntu-22.04
+    permissions:
+      contents: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup Node
+        uses: actions/setup-node@v6.3.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Set up Git
+        run: |
+          git config user.name '${{ github.actor }}'
+          git config user.email '${{ github.actor }}@users.noreply.github.com'
+      
+      - name: Create GitHub tag
+        id: create-github-tag
+        run: |
+          PACKAGE_VERSION=$(npm run version --silent)
+          TAG="v${PACKAGE_VERSION}"
+
+          if [ $(git tag -l "$TAG") ]; then
+            echo "⚠️ Tag $TAG already exists. Please delete $TAG via the GitHub UI and re-run this workflow"
+            exit 1
+          else
+            echo "🗒 Tagging repo using tag version: $TAG ..."
+            git tag -a $TAG -m "GOV.UK Prototype Kit release $TAG"
+            git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} --tags
+            echo "🗒 Tag $TAG created and pushed to remote."
+            echo "GH_TAG=${TAG}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create GitHub archive
+        run: git archive -o ./release-${{ steps.create-github-tag.outputs.GH_TAG }}.zip HEAD:dist
+
+      - name: Generate release notes
+        uses: actions/github-script@v8.0.0
+        with:
+          script: |
+            const { generateReleaseNotes } = await import('${{ github.workspace }}/scripts/github-actions/changelog-release-helper.mjs')
+
+            await generateReleaseNotes('${{ steps.create-github-tag.outputs.GH_TAG }}')
+
+      - name: Create GitHub release
+        run: |
+          GH_TAG=${{ steps.create-github-tag.outputs.GH_TAG }}
+          RELEASE_NAME="GOV.UK Prototype Kit $GH_TAG"
+          RELEASE_BODY=$(cat release-notes-body)
+
+          if gh release view "$GH_TAG" > /dev/null 2>&1; then
+            echo "⚠️ Release $GH_TAG already exists. Please delete the release and tag via the GitHub UI and re-run this workflow"
+            exit 1
+          else
+            gh release create "$GH_TAG" ./release-"${GH_TAG}".zip --title "${RELEASE_NAME}" --notes "$RELEASE_BODY"
+          fi

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -1,0 +1,27 @@
+name: 'RELEASE: npm publish'
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup Node
+        uses: actions/setup-node@v6.3.0
+        with:
+          node-version-file: .nvmrc
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish to npm
+        run: npx clean-publish --before-script scripts/clean-publish-before-script.sh

--- a/scripts/github-actions/changelog-release-helper.mjs
+++ b/scripts/github-actions/changelog-release-helper.mjs
@@ -1,0 +1,243 @@
+import { readFileSync, writeFileSync } from 'fs'
+
+import semver from 'semver'
+
+const processingErrorMessage =
+  'There was a problem processing information from the changelog. This likely means that there is an issue with the changelog content itself. Please check it and try running this task again.'
+
+/**
+ * Validate a new version of the GOV.UK Prototype Kit
+ *
+ * Throws an error if any of the following are true:
+ *
+ * - The version can't be processed by semver and we therefore presume it isn't
+ * a valid semver
+ * - The version is less than the current version
+ * - The version increments the current version by more than one possible
+ * increment, eg: going from 3.1.0 to 5.0.0, 3.3.0 or 3.1.2
+ *
+ * @param {string} newVersion - New version to validate
+ * @param {string} previousVersion - Previous version to compare to
+ */
+export function validateVersion (newVersion, previousVersion) {
+  if (!semver.valid(newVersion)) {
+    throw new Error(
+      `New version number ${newVersion} could not be processed by Semver. Please ensure you are providing a valid semantic version`
+    )
+  }
+
+  const previousReleaseNumber = semver.valid(previousVersion)
+
+  if (!previousReleaseNumber) {
+    throw new Error(
+      `Previous version number ${previousVersion} could not be processed by Semver. Please ensure a valid version is being passed to the script via the govuk-frontend package.json package.`
+    )
+  }
+
+  // Check the new version against the old version. Firstly a quick check that
+  // the new one isn't less than the old one
+  if (semver.lte(newVersion, previousReleaseNumber)) {
+    throw new Error(
+      `New version number ${newVersion} is less than or equal to the most recent version (${previousReleaseNumber}). Please provide a newer version number`
+    )
+  }
+
+  // Get the version diff keyword (major, minor, patch plus prerelease versions
+  // of those 3 and prerelease for differences between prereleases) which we can
+  // use to help with validating the new version
+  const versionDiff = semver.diff(newVersion, previousReleaseNumber)
+  const identifier = versionIsAPrerelease(newVersion)
+    ? getPrereleaseIdentifier(newVersion)
+    : undefined
+
+  if (!versionDiff) {
+    throw new Error(
+      'Could not determine difference between new and previous versions. Please check the version number you provided and the changelog content'
+    )
+  }
+
+  // Check if the new version increments from the old version by one for
+  // its change type (major, minor, patch) and throws an error if it doesn't.
+  // Eg: if the current version is 4.3.12:
+  // - 4.3.13, 4.4.0 and 5.0.0 are valid
+  // - 4.3.14, 4.5.0, 6.0.0 and above for all aren't valid
+  const correctIncrement = semver.inc(
+    previousReleaseNumber,
+    versionDiff,
+    false,
+    identifier
+  )
+
+  if (!semver.satisfies(newVersion, `<=${correctIncrement}`)) {
+    throw new Error(
+      `New version number ${newVersion} is incrementing more than one for its increment type (${versionDiff}). Please provide a version number than only increments by one from the current version. In this case, it's likely that your new version number should be: ${correctIncrement}`
+    )
+  }
+
+  console.log('No errors noted in the new version. We can proceed!')
+}
+
+/**
+ * Update the changelog with a new version heading
+ *
+ * Inserts a new heading between the 'Unreleased' heading and the most recent
+ * content
+ *
+ * @param {string} newVersion - New version to add to the changelog. We presume
+ *   that this is a valid version as this function is always run after validateVersion
+ *   has passed.
+ */
+export function updateChangelog (newVersion) {
+  const changelogLines = getChangelogLines()
+  const startIndex =
+    getChangelogLineIndexes(changelogLines)[0]
+
+  changelogLines.splice(startIndex + 1, 0, '', `## ${newVersion}`)
+  writeFileSync('./CHANGELOG.md', changelogLines.join('\n'))
+}
+
+/**
+ * Generates release notes from the most recent changelog
+ *
+ * Creates a text file 'release-notes-body' from the content between either the
+ * release heading passed to it by newVersion or the 'Unreleased' heading and the
+ * following release heading if newVersion is tagged as internal
+ *
+ * @param {string} newVersion - Version used to find start point for release notes
+ * @param {object} [options] - Release notes options
+ * @param {string} [options.actor] - Github username of user who ran workflow
+ * @param {string} [options.runId] - ID of Build release workflow to reference
+ */
+export function generateReleaseNotes (newVersion, options) {
+  // Get the identifier from the version if there is one as we'll use this to
+  // change what we pass to getChangelogLineIndexes if the version has an
+  // 'internal' tag
+  const identifier = versionIsAPrerelease(newVersion)
+    ? getPrereleaseIdentifier(newVersion)
+    : undefined
+  const changelogLines = getChangelogLines()
+  const [startIndex, previousReleaseLineIndex] = getChangelogLineIndexes(
+    changelogLines,
+    identifier === 'internal' ? undefined : newVersion
+  )
+
+  const releaseNotes = changelogLines
+    .slice(startIndex + 1, previousReleaseLineIndex - 1)
+    .map((line) =>
+      line.replace(/^\s+/, '').startsWith('##')
+        ? line.replace(/^\s+/, '').substring(1)
+        : line
+    )
+
+  if (options && options.actor && options.runId) {
+    releaseNotes.push('')
+    releaseNotes.push(
+      `Pull request generated on behalf of @${options.actor} by [run ${options.runId}](https://github.com/alphagov/govuk-prototype-kit/actions/runs/${options.runId}) of the [Build release workflow](https://github.com/alphagov/govuk-prototype-kit/actions/workflows/build-release.yml)`
+    )
+  }
+
+  writeFileSync('./release-notes-body', releaseNotes.join('\n'))
+}
+
+/**
+ * Get the changelog and split it into an array separated by lines
+ *
+ * @returns {Array<string>} - Changelog split into an array by lines
+ */
+function getChangelogLines () {
+  return readFileSync('./CHANGELOG.md', 'utf8').split('\n')
+}
+
+/**
+ * Gets the start and end headings in the changelog for processing by the
+ * exported functions
+ *
+ * @param {Array<string>} changelogLines - Produced from getChangelogLines
+ * @param {string|undefined} heading - Optional query to look for heading
+ *   where the first index is pulled from eg: 'Unreleased'
+ * @returns {Array<number>} - Indexes in the changelog identifying start and end lines
+ */
+function getChangelogLineIndexes (changelogLines, heading = undefined) {
+  // Build regex for finding the correct heading in the changelog
+  // If a heading hasn't been passed to the function, use 'Unreleased'
+  const defaultHeadingRegex = '\\d+\\.\\d+\\.\\d+(-.+\\.\\d+)?'
+  const headingRegex = heading
+    ? heading.replaceAll('.', '\\.')
+    : 'Unreleased'
+
+  const startIndex = findIndexOfFirstMatchingLine(
+    changelogLines,
+    buildHeadingRegexQuery(headingRegex)
+  )
+
+  if (startIndex === -1) {
+    throw new Error(processingErrorMessage)
+  }
+
+  const endIndex = findIndexOfFirstMatchingLine(
+    changelogLines,
+    buildHeadingRegexQuery(defaultHeadingRegex),
+    startIndex + 1
+  )
+
+  if (endIndex === -1) {
+    throw new Error(processingErrorMessage)
+  }
+
+  return [startIndex, endIndex]
+}
+
+/**
+ * Builds the search query for headings when getting indexes in the changelog
+ *
+ * @param {string} identifier - Either the semantic version or 'Unreleased'
+ * @returns {RegExp} - Complete heading regex including hashes and release type formatting
+ */
+function buildHeadingRegexQuery (identifier) {
+  return new RegExp(`^\\s*#+\\s+v?${identifier}\\s*(\\(.+\\))?$`, 'i')
+}
+
+/**
+ * Get the first matching line in the changelog that matches the passed regex
+ *
+ * @param {Array<string>} changelogLines - Produced from getChangelogLines
+ * @param {RegExp} regExp - Regular Expression to match against
+ * @param {number} offset - Offset from start of the changelogLines array
+ * @returns {number} - Index in changeLogLines or -1 if we can't locate the index
+ */
+function findIndexOfFirstMatchingLine (changelogLines, regExp, offset = 0) {
+  const foundIndex = changelogLines
+    .slice(offset)
+    .map((x, index) => (x.match(regExp) ? index : undefined))
+    .filter((x) => x !== undefined)
+    .at(0)
+  return foundIndex ? foundIndex + offset : -1
+}
+
+/**
+ * Checks if a version string is a pre-release or not
+ *
+ * Returns true only if a semver is a pre-release with an identifier and an
+ * identifier base, eg:
+ *
+ * - 4.0.0 - false
+ * - 4.0.0-beta false
+ * - 4.0.0-0 false
+ * - 4.0.0.beta.0 true
+ *
+ * @param {string} version
+ * @returns {boolean} - If the passed version is a pre-release or not
+ */
+function versionIsAPrerelease (version) {
+  return /^\d+\.\d+\.\d+-\D+\.\d+$/i.test(version)
+}
+
+/**
+ * Get the identifier and identifier base of a pre-release semver
+ *
+ * @param {string} version
+ * @returns {string} - the identifier of the pre-release
+ */
+function getPrereleaseIdentifier (version) {
+  return version.substring(version.indexOf('-') + 1, version.lastIndexOf('.'))
+}

--- a/scripts/github-actions/changelog-release-helper.spec.js
+++ b/scripts/github-actions/changelog-release-helper.spec.js
@@ -1,0 +1,170 @@
+const fs = require('fs')
+
+const {
+  validateVersion,
+  updateChangelog,
+  generateReleaseNotes
+} = require('./changelog-release-helper.mjs')
+
+jest.mock('fs')
+
+describe('Changelog release helper', () => {
+  beforeEach(() => {
+    jest.mocked(fs.readFileSync).mockReturnValue(`
+      ## Unreleased
+
+      ### Fixes
+
+      Bing bong
+
+      ## 3.0.0
+    `)
+  })
+
+  describe('Validate version', () => {
+    it('runs normally if a valid new version is parsed to it', () => {
+      expect(() => validateVersion('3.1.0', '3.0.0')).not.toThrow()
+    })
+
+    it('throws an error if an invalid semver is parsed', () => {
+      expect(() => validateVersion('pizza', '3.0.0')).toThrow(
+        'New version number pizza could not be processed by Semver. Please ensure you are providing a valid semantic version'
+      )
+    })
+
+    it('throws an error if new version is less than old version', () => {
+      expect(() => validateVersion('2.11.0', '3.0.0')).toThrow(
+        'New version number 2.11.0 is less than or equal to the most recent version (3.0.0). Please provide a newer version number'
+      )
+    })
+
+    it('throws an error if the previous version is falsy or invalid', () => {
+      expect(() => validateVersion('3.1.0', 'pizza')).toThrow(
+        'Previous version number pizza could not be processed by Semver. Please ensure a valid version is being passed to the script via the govuk-frontend package.json package.'
+      )
+    })
+
+    it.each([
+      {
+        badVersion: '5.0.0',
+        type: 'major',
+        goodVersion: '4.0.0'
+      },
+      {
+        badVersion: '3.2.0',
+        type: 'minor',
+        goodVersion: '3.1.0'
+      },
+      {
+        badVersion: '3.0.2',
+        type: 'patch',
+        goodVersion: '3.0.1'
+      },
+      {
+        badVersion: '3.0.2-beta.0',
+        type: 'prepatch',
+        goodVersion: '3.0.1-beta.0'
+      },
+      {
+        badVersion: '3.0.2',
+        type: 'patch',
+        goodVersion: '3.0.1',
+        customVersion: '3.0.1-beta.15'
+      }
+    ])(
+      'throws an error if new version is more than one possible `$type` increment',
+      ({ badVersion, type, goodVersion, customVersion }) => {
+        expect(() =>
+          validateVersion(badVersion, customVersion ?? '3.0.0')
+        ).toThrow(
+          `New version number ${badVersion} is incrementing more than one for its increment type (${type}). Please provide a version number than only increments by one from the current version. In this case, it's likely that your new version number should be: ${goodVersion}`
+        )
+      }
+    )
+  })
+
+  describe('Update changelog', () => {
+    it('adds a new heading to the changelog for the new version', () => {
+      updateChangelog('3.1.0')
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        './CHANGELOG.md',
+        expect.stringContaining('## 3.1.0')
+      )
+    })
+  })
+
+  describe('Generate release notes', () => {
+    it('writes release notes from the changelog from the last version heading', () => {
+      jest.mocked(fs.readFileSync).mockReturnValue(`
+        ## Unreleased
+
+        ## v3.1.0 (Feature release)
+
+        ### Fixes
+
+        Bing bong
+
+        ## v3.0.0 (Breaking release)
+      `)
+
+      generateReleaseNotes('3.1.0')
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        './release-notes-body',
+        expect.stringContaining('Bing bong')
+      )
+    })
+
+    it('writes release notes from the changelog from the last version heading if that version is a pre-release', () => {
+      jest.mocked(fs.readFileSync).mockReturnValue(`
+        ## Unreleased
+
+        ## v3.1.0-beta.0 (Feature release)
+
+        ### Fixes
+
+        Bing bong
+
+        ## v3.0.0 (Breaking release)
+      `)
+
+      generateReleaseNotes('3.1.0-beta.0')
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        './release-notes-body',
+        expect.stringContaining('Bing bong')
+      )
+    })
+
+    it('writes release notes from the changelog from the Unreleased heading if the version is internal', () => {
+      generateReleaseNotes('3.1.0-internal.0')
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        './release-notes-body',
+        expect.stringContaining('Bing bong')
+      )
+    })
+
+    it('increases the heading levels from the changelog by one', () => {
+      generateReleaseNotes('Unreleased')
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        './release-notes-body',
+        expect.stringContaining('## Fixes')
+      )
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        './release-notes-body',
+        expect.not.stringContaining('### Fixes')
+      )
+    })
+
+    it('adds a note on the generation workflow if options param provided', () => {
+      generateReleaseNotes('3.1.0-internal.0', {
+        actor: 'bingbong',
+        runId: '12345'
+      })
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        './release-notes-body',
+        expect.stringContaining(
+          'Pull request generated on behalf of @bingbong by [run 12345](https://github.com/alphagov/govuk-frontend/actions/runs/12345) of the [Build release workflow](https://github.com/alphagov/govuk-frontend/actions/workflows/build-release.yml)'
+        )
+      )
+    })
+  })
+})


### PR DESCRIPTION
What it says. This copies Frontend's current strategy of managing releases as a multi-step process in CI rather than doing anything locally. This includes the github workflows themselves plus the helper scripts and their tests, which I've put in /scripts/github-actions

Finishing and validating this means we can delete the (broken) automated release scripts that the kit currently runs off of.

Like Frontend, this splits the process into 3 parts:

- Preparing to publish with a PR
- Publishing to npm
- Creating a github release

This is also missing CI secrets that allow us to run some of these.

## Differences between the kit and Frontend

The kit tends to use simpler changelog titles ie: no 'v' before the version number and no release 'type' after the number eg: "v1.1.1 (fix release)". There's also not precident for the kit to do pre-releases like betas or rc's at the moment. Therefore I've simplified the helper scripts to not include interrogating differences between pre-releases and full releases or building complex titles.

The kit uses [clean publish](https://www.npmjs.com/package/clean-publish) to handle publishing to npm rather than 'manual' publishing like Frontend does. It similarly don't appear to be as concerned with tagging. I've therefore simplified the publish to npm job to follow this release flow.