### PR TITLE
Replace uuid with Node's in-built UUID generator

### DIFF
--- a/lib/usage-data.js
+++ b/lib/usage-data.js
@@ -2,11 +2,11 @@
 const fs = require('fs')
 const os = require('os')
 const path = require('path')
+const { randomUUID } = require('node:crypto')
 
 // npm dependencies
 const { default: confirm } = require('@inquirer/confirm')
 const universalAnalytics = require('universal-analytics')
-const { v4: uuidv4 } = require('uuid')
 const ansiColors = require('ansi-colors')
 
 // local dependencies
@@ -66,7 +66,7 @@ function startTracking (usageDataConfig) {
   // https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#cid
 
   if (usageDataConfig.clientId === undefined) {
-    usageDataConfig.clientId = uuidv4()
+    usageDataConfig.clientId = randomUUID()
     module.exports.setUsageDataConfig(usageDataConfig)
   }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -32,8 +32,7 @@
         "semver": "^7.7.2",
         "sync-request": "^6.1.0",
         "tar-stream": "^3.1.7",
-        "universal-analytics": "^0.5.3",
-        "uuid": "^9.0.1"
+        "universal-analytics": "^0.5.3"
       },
       "bin": {
         "govuk-prototype-kit": "bin/cli"
@@ -12009,18 +12008,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.3",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz",
@@ -21006,11 +20993,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
-    },
-    "uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "v8-to-istanbul": {
       "version": "9.1.3",

--- a/package.json
+++ b/package.json
@@ -85,8 +85,7 @@
     "semver": "^7.7.2",
     "sync-request": "^6.1.0",
     "tar-stream": "^3.1.7",
-    "universal-analytics": "^0.5.3",
-    "uuid": "^9.0.1"
+    "universal-analytics": "^0.5.3"
   },
   "devDependencies": {
     "cheerio": "^1.0.0-rc.12",


### PR DESCRIPTION
We're only generating a uuid, and we require Node 20+ to bump to the latest `uuid`, which means we should be able to just use Node's built-in crypto.

We still run tests on Node 16, but the method was added in v15, so that should be fine (ignoring the fact that we probably shouldn't still be running these in v16?)