### PR TITLE
Remove dependency on `require-dir`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [#2539: Remove dependency on `sync-request`](https://github.com/alphagov/govuk-prototype-kit/pull/2539)
+- [#2540: Remove dependency on `require-dir`](https://github.com/alphagov/govuk-prototype-kit/pull/2540)
 
 ## 13.20.1
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -27,7 +27,6 @@
         "nodemon": "^3.0.3",
         "nunjucks": "^3.2.4",
         "portscanner": "^2.2.0",
-        "require-dir": "^1.2.0",
         "sass": "^1.89.2",
         "semver": "^7.7.2",
         "tar-stream": "^3.1.7",
@@ -9904,14 +9903,6 @@
         "throttleit": "^1.0.0"
       }
     },
-    "node_modules/require-dir": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/require-dir/-/require-dir-1.2.0.tgz",
-      "integrity": "sha512-LY85DTSu+heYgDqq/mK+7zFHWkttVNRXC9NKcKGyuGLdlsfbjEPrIEYdCVrx6hqnJb+xSu3Lzaoo8VnmOhhjNA==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -19268,11 +19259,6 @@
       "requires": {
         "throttleit": "^1.0.0"
       }
-    },
-    "require-dir": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/require-dir/-/require-dir-1.2.0.tgz",
-      "integrity": "sha512-LY85DTSu+heYgDqq/mK+7zFHWkttVNRXC9NKcKGyuGLdlsfbjEPrIEYdCVrx6hqnJb+xSu3Lzaoo8VnmOhhjNA=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "nodemon": "^3.0.3",
     "nunjucks": "^3.2.4",
     "portscanner": "^2.2.0",
-    "require-dir": "^1.2.0",
     "sass": "^1.89.2",
     "semver": "^7.7.2",
     "tar-stream": "^3.1.7",


### PR DESCRIPTION
There are no imports of `require-dir` in the codebase.

As far as I can tell `require-dir` was previously used as part of our Gulp setup in two places:

- start.js, added in https://github.com/alphagov/govuk-prototype-kit/commit/09122d5f1efb59c342861ecb94bfb02074587ed8 before being removed in https://github.com/alphagov/govuk-prototype-kit/commit/a4f3250a0d72131666a35f2723edf6615f625ee5
- gulpfile.js, added in https://github.com/alphagov/govuk-prototype-kit/commit/b3bcb98e9b356aafeed21b2018f74c60c99009b7 before being removed in https://github.com/alphagov/govuk-prototype-kit/commit/6b00c53c094102a6cf98159f300578f31759ef40

I think this dependency is no longer needed and could have been removed in https://github.com/alphagov/govuk-prototype-kit/pull/1324.