### PR TITLE
Pin Node to 24.15.0 in acceptance tests

### DIFF
--- a/.github/workflows/test-acceptance.yaml
+++ b/.github/workflows/test-acceptance.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false  # continue other tests if one test in matrix fails
       matrix:
-        node-version: [24.x]
+        node-version: [24.15.0] # pinned – see cypress-io/cypress#33891
         os: [macos-latest, windows-2022, ubuntu-latest]
         type: [smoke, plugins, styles, dev, prod, errors]
 


### PR DESCRIPTION
`cypress install` is [failing on Windows when run under Node v25.16.0][1].

This has been fixed in Cypress v16.16.0, but we're two major versions behind (v13.6.5), so let's pin Node to v24.15.0 instead.

We should be able to pin this when either:

- a new version of Node 24.x has been released where this regression has been fixed
- we've updated Cypress to v16.16.0 or newer

[1]: https://github.com/cypress-io/cypress/issues/33891#issuecomment-4518453288