### PR TITLE
Add missing 'Fixes' heading to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Fixes
+
 - [#2539: Remove dependency on `sync-request`](https://github.com/alphagov/govuk-prototype-kit/pull/2539)
 - [#2540: Remove dependency on `require-dir`](https://github.com/alphagov/govuk-prototype-kit/pull/2540)
 - [#2543: Update `qs`, `ws`, `body-parser`, `express`, `engine.io`, `engine.io-client` and `socket.io-adapter`](https://github.com/alphagov/govuk-prototype-kit/pull/2543)


### PR DESCRIPTION
If this heading isn't present then the release script can't work out what type of release we're doing and bails.