### PR TITLE
Preparing for release 13.20.2 (automated).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 13.20.2
+
 ### Fixes
 
 - [#2539: Remove dependency on `sync-request`](https://github.com/alphagov/govuk-prototype-kit/pull/2539)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "govuk-prototype-kit",
-  "version": "13.20.1",
+  "version": "13.20.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-prototype-kit",
-      "version": "13.20.1",
+      "version": "13.20.2",
       "dependencies": {
         "@inquirer/confirm": "^5.1.15",
         "ansi-colors": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-prototype-kit",
   "description": "Rapidly create HTML prototypes of GOV.UK services",
-  "version": "13.20.1",
+  "version": "13.20.2",
   "engines": {
     "node": "^16.x || ^18.x || >= 20.x"
   },


### PR DESCRIPTION

### Fixes

- [#2539: Remove dependency on `sync-request`](https://github.com/alphagov/govuk-prototype-kit/pull/2539)
- [#2540: Remove dependency on `require-dir`](https://github.com/alphagov/govuk-prototype-kit/pull/2540)
- [#2543: Update `qs`, `ws`, `body-parser`, `express`, `engine.io`, `engine.io-client` and `socket.io-adapter`](https://github.com/alphagov/govuk-prototype-kit/pull/2543)
- [#2545: Remove usage data tracking](https://github.com/alphagov/govuk-prototype-kit/pull/2545)