### PR TITLE
Bump Immutable to 3.8.4 & 5.1.9

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6793,9 +6793,9 @@
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk="
     },
     "node_modules/immutable": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz",
-      "integrity": "sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.4.tgz",
+      "integrity": "sha512-ZQv17KolYrYmsDoDB8N67zhIKsNi9mGYlk96y/yuxyAqJB2hLzSGSM7k/sB0/ZvO4kx27U9+fBeD/XlLGh/uXQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10112,9 +10112,9 @@
       }
     },
     "node_modules/sass/node_modules/immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "license": "MIT"
     },
     "node_modules/sass/node_modules/readdirp": {
@@ -16875,9 +16875,9 @@
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk="
     },
     "immutable": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz",
-      "integrity": "sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg=="
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.4.tgz",
+      "integrity": "sha512-ZQv17KolYrYmsDoDB8N67zhIKsNi9mGYlk96y/yuxyAqJB2hLzSGSM7k/sB0/ZvO4kx27U9+fBeD/XlLGh/uXQ=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -19266,9 +19266,9 @@
           }
         },
         "immutable": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-          "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A=="
+          "version": "5.1.9",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+          "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg=="
         },
         "readdirp": {
           "version": "4.1.2",


### PR DESCRIPTION
Fixes for two vulnerabilities in Immutable ([GHSA-v56q-mh7h-f735](https://github.com/advisories/GHSA-v56q-mh7h-f735) / [CVE-2026-59879](https://github.com/advisories/GHSA-v56q-mh7h-f735)) and ([GHSA-xvcm-6775-5m9r](https://github.com/advisories/GHSA-xvcm-6775-5m9r) / [CVE-2026-59880](https://github.com/advisories/GHSA-xvcm-6775-5m9r)) have been backported to Immutable v3.x which means they can be fixed without Browser-sync needing to do a release.

The advisory database may not know about this yet because these two PRs may still need to be merged: 
- https://github.com/github/advisory-database/pull/9129
- https://github.com/github/advisory-database/pull/9128

But the TL;DR is that updating to Immutable v3.8.4 should (eventually) dismiss those vulnerability alerts.