### PR TITLE
Remove `marked` from dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - [#2563: Bump Immutable to 3.8.4 & 5.1.9](https://github.com/alphagov/govuk-prototype-kit/pull/2563)
+- [#2564: Remove `marked` from dependencies](https://github.com/alphagov/govuk-prototype-kit/pull/2564)
 
 ## 13.20.3
 

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -9,7 +9,6 @@ const { existsSync } = require('fs')
 // npm dependencies
 const { default: confirm } = require('@inquirer/confirm')
 const portScanner = require('portscanner')
-const { marked } = require('marked')
 
 // local dependencies
 const config = require('../config').getConfig()
@@ -21,20 +20,6 @@ const { appDir, projectDir } = require('./paths')
 const { asyncSeriesMap } = require('./asyncSeriesMap')
 const { runWhenEnvIsAvailable: runWhenFiltersEnvIsAvailable } = require('../filters/api')
 const { runWhenEnvIsAvailable: runWhenFunctionsEnvIsAvailable } = require('../functions/api')
-
-// Tweak the Markdown renderer
-const defaultMarkedRenderer = marked.defaults.renderer || new marked.Renderer()
-
-marked.use({
-  renderer: {
-    code (code, infostring, escaped) {
-      let rawHtml = defaultMarkedRenderer.code(code, infostring, escaped)
-      // Add a tabindex to the <pre> element, to allow keyboard focus / scrolling
-      rawHtml = rawHtml.replace('<pre>', '<pre tabindex="0">')
-      return rawHtml
-    }
-  }
-})
 
 /**
  * Application scripts passed into `plugins.getAppConfig()` where

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -23,7 +23,6 @@
         "fs-extra": "^11.2.0",
         "govuk-frontend": "5.11.0",
         "lodash": "^4.17.23",
-        "marked": "^4.3.0",
         "nodemon": "^3.0.3",
         "nunjucks": "^3.2.4",
         "portscanner": "^2.2.0",
@@ -8628,17 +8627,6 @@
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
-    },
-    "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -18227,11 +18215,6 @@
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
-    },
-    "marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
     },
     "math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "fs-extra": "^11.2.0",
     "govuk-frontend": "5.11.0",
     "lodash": "^4.17.23",
-    "marked": "^4.3.0",
     "nodemon": "^3.0.3",
     "nunjucks": "^3.2.4",
     "portscanner": "^2.2.0",


### PR DESCRIPTION
We stopped actually using `marked` as of https://github.com/alphagov/govuk-prototype-kit/commit/bbba94d5ff1a8ab6ce0d32ac7dec7651ae4b1e3d#diff-5dfe38baf287dcf756a17c2dd63483781b53bf4b669e10efdd01e74bcd8e780a, even though we still configure it.

This is a non-breaking change - users would have to have specifically fished around inside govuk-prototype-kit to use it:

`const { marked } = require('govuk-prototype-kit/node_modules/marked')`