### PR TITLE
Add changelog entry for immutable bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- [#2563: Bump Immutable to 3.8.4 & 5.1.9](https://github.com/alphagov/govuk-prototype-kit/pull/2563)
+
 ## 13.20.3
 
 ### Fixes


### PR DESCRIPTION
We missed adding a changelog entry for [this PR](https://github.com/alphagov/govuk-prototype-kit/pull/2563).