### PR TITLE
Replace `@inquirer/confirm` with Node's built in `readline`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ You can find more information in the [install guide for your operating system](h
 - [#2564: Remove `marked` from dependencies](https://github.com/alphagov/govuk-prototype-kit/pull/2564)
 - [#2564: Remove dependency on `del`](https://github.com/alphagov/govuk-prototype-kit/pull/2570)
 - [#2574: Use json and urlencoded middlewares from Express](https://github.com/alphagov/govuk-prototype-kit/pull/2574)
+- [#2569: Replace @inquirer/confirm with Node's built in readline](https://github.com/alphagov/govuk-prototype-kit/pull/2569)
 
 ## 13.20.3
 

--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -41,7 +41,7 @@ async function runDevServer () {
     startupError = err
   }
 
-  const port = await (new Promise((resolve) => utils.findAvailablePort(resolve)))
+  const port = await utils.findAvailablePort()
 
   await runNodemon(port)
   watchAfterStarting()

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,11 +1,10 @@
 // core dependencies
 const crypto = require('crypto')
-const fs = require('fs')
-const fsp = fs.promises
+const { existsSync, lstatSync, readdirSync } = require('fs')
+const { readdir, stat, readFile, writeFile } = require('fs/promises')
 const path = require('path')
 const readline = require('readline/promises')
 const semver = require('semver')
-const { existsSync } = require('fs')
 
 // npm dependencies
 const portScanner = require('portscanner')
@@ -44,7 +43,7 @@ function addNunjucksFilters (env) {
   filters.setEnvironment(env)
   const additionalFilters = []
   const filtersPath = path.join(appDir, 'filters.js')
-  if (fs.existsSync(filtersPath)) {
+  if (existsSync(filtersPath)) {
     additionalFilters.push(filtersPath)
   }
   runWhenFiltersEnvIsAvailable(() => {
@@ -59,7 +58,7 @@ function addNunjucksFunctions (env) {
   functions.setEnvironment(env)
   const additionalFunctions = []
   const functionsPath = path.join(appDir, 'functions.js')
-  if (fs.existsSync(functionsPath)) {
+  if (existsSync(functionsPath)) {
     additionalFunctions.push(functionsPath)
   }
   runWhenFunctionsEnvIsAvailable(() => {
@@ -71,7 +70,7 @@ function addNunjucksFunctions (env) {
 function addRouters (app) {
   routes.setApp(app)
   const routesPath = path.join(appDir, 'routes.js')
-  if (fs.existsSync(routesPath)) {
+  if (existsSync(routesPath)) {
     require(routesPath)
   }
 }
@@ -204,7 +203,7 @@ function sleep (ms) {
 
 async function waitUntilFileExists (filename, timeout) {
   await sleep(500)
-  const fileExists = fs.existsSync(filename)
+  const fileExists = existsSync(filename)
   if (!fileExists) {
     if (timeout > 0) {
       return waitUntilFileExists(filename, timeout - 500)
@@ -241,9 +240,9 @@ function recursiveDirectoryContentsSync (baseDir) {
     if (!existsSync(fullPath)) {
       return []
     }
-    const dirContents = fs.readdirSync(fullPath)
+    const dirContents = readdirSync(fullPath)
     return dirContents.map(item => {
-      const lstat = fs.lstatSync(path.join(fullPath, item))
+      const lstat = lstatSync(path.join(fullPath, item))
       const isDir = lstat.isDirectory()
       const itemPath = path.join(dir, item)
       if (isDir) {
@@ -257,18 +256,18 @@ function recursiveDirectoryContentsSync (baseDir) {
 }
 
 async function searchAndReplaceFiles (dir, searchText, replaceText, extensions) {
-  const files = await fsp.readdir(dir)
+  const files = await readdir(dir)
   const modifiedFiles = await asyncSeriesMap(files, async file => {
     const filePath = path.join(dir, file)
-    const fileStat = await fsp.stat(filePath)
+    const fileStat = await stat(filePath)
 
     if (fileStat.isDirectory()) {
       return await searchAndReplaceFiles(filePath, searchText, replaceText, extensions)
     } else if (extensions.some(extension => file.endsWith(extension))) {
-      let fileContent = await fsp.readFile(filePath, 'utf8')
+      let fileContent = await readFile(filePath, 'utf8')
       if (fileContent.includes(searchText)) {
         fileContent = fileContent.replace(new RegExp(searchText, 'g'), replaceText)
-        await fsp.writeFile(filePath, fileContent)
+        await writeFile(filePath, fileContent)
         return filePath
       }
     }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -3,11 +3,11 @@ const crypto = require('crypto')
 const fs = require('fs')
 const fsp = fs.promises
 const path = require('path')
+const readline = require('readline/promises')
 const semver = require('semver')
 const { existsSync } = require('fs')
 
 // npm dependencies
-const { default: confirm } = require('@inquirer/confirm')
 const portScanner = require('portscanner')
 
 // local dependencies
@@ -76,41 +76,67 @@ function addRouters (app) {
   }
 }
 
+// Ask a yes/no question in the terminal. 'y'/'yes' answers yes, 'n'/'no'
+// answers no, an empty answer resolves to `defaultAnswer`, and anything else
+// re-asks the question.
+async function confirm (message, defaultAnswer = true) {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+  })
+  // On Ctrl+C readline with no SIGINT listener just closes the interface:
+  // no signal is raised and the process only exits if the event loop is
+  // empty, so exit explicitly and predictably
+  rl.on('SIGINT', () => {
+    rl.close()
+    console.log('')
+    process.exit(130) // conventional exit code for SIGINT (128 + 2)
+  })
+  const hint = defaultAnswer ? '(Y/n)' : '(y/N)'
+  try {
+    let result
+    while (result === undefined) {
+      const answer = (await rl.question(`${message} ${hint} `)).trim().toLowerCase()
+      if (answer === '') {
+        result = defaultAnswer
+      } else if (answer === 'y' || answer === 'yes') {
+        result = true
+      } else if (answer === 'n' || answer === 'no') {
+        result = false
+      }
+      // Unrecognised answer - ask again
+    }
+    return result
+  } finally {
+    rl.close()
+  }
+}
+
 // Find an available port to run the server on
-function findAvailablePort (callback) {
-  let port = config.port
+async function findAvailablePort () {
+  const port = config.port
 
   console.log('')
 
   // Check port is free, else offer to change
-  portScanner.findAPortNotInUse(port, port + 50, '127.0.0.1', (error, availablePort) => {
-    if (error) { throw error }
-    if (port === availablePort) {
-      // Port is free, return it via the callback
-      callback(port)
-    } else {
-      // Port in use - offer to change to available port
-      console.error('ERROR: Port ' + port + ' in use - you may have another prototype running.\n')
+  const availablePort = await portScanner.findAPortNotInUse(port, port + 50, '127.0.0.1')
+  if (port === availablePort) {
+    return port
+  }
 
-      // Ask user if they want to change port
-      confirm({
-        message: 'Change to an available port?'
-      }).then(changePort => {
-        if (changePort) {
-          // User answers yes
-          port = availablePort
+  // Port in use - offer to change to available port
+  console.error('ERROR: Port ' + port + ' in use - you may have another prototype running.\n')
 
-          console.log('Changed to port ' + port)
-          console.log('')
+  const changePort = await confirm('Change to an available port?')
+  if (!changePort) {
+    // User answers no - exit
+    process.exit(0)
+  }
 
-          callback(port)
-        } else {
-          // User answers no - exit
-          process.exit(0)
-        }
-      })
-    }
-  })
+  console.log('Changed to port ' + availablePort)
+  console.log('')
+
+  return availablePort
 }
 
 // Redirect HTTP requests to HTTPS

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8,7 +8,6 @@
       "name": "govuk-prototype-kit",
       "version": "13.20.4",
       "dependencies": {
-        "@inquirer/confirm": "^5.1.15",
         "ansi-colors": "^4.1.3",
         "browser-sync": "^3.0.2",
         "chokidar": "^3.6.0",
@@ -851,106 +850,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
       "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
       "dev": true
-    },
-    "node_modules/@inquirer/confirm": {
-      "version": "5.1.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.15.tgz",
-      "integrity": "sha512-SwHMGa8Z47LawQN0rog0sT+6JpiL0B7eW9p1Bb7iCeKDGTI5Ez25TSc2l8kw52VV7hA4sX/C78CGkMrKXfuspA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/type": "^3.0.8"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/core": {
-      "version": "10.1.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
-      "integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/figures": "^1.0.13",
-        "@inquirer/type": "^3.0.8",
-        "ansi-escapes": "^4.3.2",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
-        "signal-exit": "^4.1.0",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@inquirer/figures": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
-      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/type": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
-      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -2213,6 +2112,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -2227,6 +2127,7 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -3365,15 +3266,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/cliui": {
@@ -8526,15 +8418,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "node_modules/mute-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -11806,18 +11689,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/yoctocolors-cjs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     }
   },
   "dependencies": {
@@ -12398,58 +12269,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
       "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
       "dev": true
-    },
-    "@inquirer/confirm": {
-      "version": "5.1.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.15.tgz",
-      "integrity": "sha512-SwHMGa8Z47LawQN0rog0sT+6JpiL0B7eW9p1Bb7iCeKDGTI5Ez25TSc2l8kw52VV7hA4sX/C78CGkMrKXfuspA==",
-      "requires": {
-        "@inquirer/core": "^10.1.15",
-        "@inquirer/type": "^3.0.8"
-      }
-    },
-    "@inquirer/core": {
-      "version": "10.1.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
-      "integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
-      "requires": {
-        "@inquirer/figures": "^1.0.13",
-        "@inquirer/type": "^3.0.8",
-        "ansi-escapes": "^4.3.2",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
-        "signal-exit": "^4.1.0",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "dependencies": {
-        "signal-exit": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        }
-      }
-    },
-    "@inquirer/figures": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
-      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw=="
-    },
-    "@inquirer/type": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
-      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
-      "requires": {}
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -13333,6 +13152,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
       "requires": {
         "type-fest": "^0.21.3"
       },
@@ -13340,7 +13160,8 @@
         "type-fest": {
           "version": "0.21.3",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+          "dev": true
         }
       }
     },
@@ -14144,11 +13965,6 @@
         "slice-ansi": "^3.0.0",
         "string-width": "^4.2.0"
       }
-    },
-    "cli-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="
     },
     "cliui": {
       "version": "7.0.4",
@@ -17847,11 +17663,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "mute-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -20193,11 +20004,6 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
-    },
-    "yoctocolors-cjs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "test": "npm run test:unit && npm run test:integration && npm run lint"
   },
   "dependencies": {
-    "@inquirer/confirm": "^5.1.15",
     "ansi-colors": "^4.1.3",
     "browser-sync": "^3.0.2",
     "chokidar": "^3.6.0",


### PR DESCRIPTION
The `@inquirer/confirm` behaviour is quite permissive:

https://github.com/SBoudrias/Inquirer.js/blob/df341a8094bde7687225143bb0b4cf932846be4f/packages/confirm/src/index.ts#L20-L25

Anything that begins with `n` is `false`, and anything else is `true`. This was tightened up in a later version.

The implementation in this pull request has been made a bit stricter:

- `y` or `yes` (case-insensitive): `true`
- `n` or `no` (case-insensitive): `false`
- empty string: `<defaultAnswer>` (which defaults to `true`)
- any other key: re-prompt

`@inquirer/confirm` also allows `tab` to switch between answers, but I think that's overcomplicating our use case.

`readline` emits the `close` event on ctrl+c unless there's an explicit `SIGINT` listener, so there's a (almost nonexistent in this particular case) chance that a process could stay open. Hence the `SIGINT` check in the function.