### PR TITLE
Use `json` and `urlencoded` middlewares from Express

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#2563: Bump Immutable to 3.8.4 & 5.1.9](https://github.com/alphagov/govuk-prototype-kit/pull/2563)
 - [#2564: Remove `marked` from dependencies](https://github.com/alphagov/govuk-prototype-kit/pull/2564)
 - [#2564: Remove dependency on `del`](https://github.com/alphagov/govuk-prototype-kit/pull/2570)
+- [#2574: Use json and urlencoded middlewares from Express](https://github.com/alphagov/govuk-prototype-kit/pull/2574)
 
 ## 13.20.3
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@inquirer/confirm": "^5.1.15",
         "ansi-colors": "^4.1.3",
-        "body-parser": "^1.20.2",
         "browser-sync": "^3.0.2",
         "chokidar": "^3.6.0",
         "cookie-parser": "^1.4.6",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
   "dependencies": {
     "@inquirer/confirm": "^5.1.15",
     "ansi-colors": "^4.1.3",
-    "body-parser": "^1.20.2",
     "browser-sync": "^3.0.2",
     "chokidar": "^3.6.0",
     "cookie-parser": "^1.4.6",

--- a/server.js
+++ b/server.js
@@ -4,7 +4,6 @@ const path = require('path')
 const url = require('url')
 
 // npm dependencies
-const bodyParser = require('body-parser')
 const cookieParser = require('cookie-parser')
 const dotenv = require('dotenv')
 const express = require('express')
@@ -120,8 +119,8 @@ app.use('/public', express.static(path.join(projectDir, '.tmp', 'public')))
 app.use('/public', express.static(path.join(projectDir, 'app', 'assets')))
 
 // Support for parsing data in POSTs
-app.use(bodyParser.json())
-app.use(bodyParser.urlencoded({
+app.use(express.json())
+app.use(express.urlencoded({
   extended: true
 }))
 


### PR DESCRIPTION
Express forwards the `json` and `urlencoded` middlewares of `body-parser` as part of its API, so we can use them from `express` rather than have our own dependency on `body-parser`.

This'll avoid us to manage the `body-parser` dependency ourselves and having to update it when we [update Express](https://github.com/alphagov/govuk-prototype-kit/issues/2552).