### PR TITLE
Bump supported Node version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false  # continue other tests if one test in matrix fails
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
         os: [macos-latest, windows-latest, ubuntu-latest]
 
     name: Test kit on Node v${{ matrix.node-version }} (${{ matrix.os }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Breaking changes
+
+#### Update Node.js
+
+You can no longer run the GOV.UK Prototype Kit on versions of Node.js older than version 22. These versions are no longer maintained, which means they no longer get security fixes.
+
+If you currently use an older version of Node.js, you'll need to update it before you update your prototype. We recommend you update to the latest LTS (long term support) version of Node.js.
+
+You can find more information in the [install guide for your operating system](https://prototype-kit.service.gov.uk/docs/install/requirements).
+
+- [#2578: Bump supported Node version](https://github.com/alphagov/govuk-prototype-kit/pull/2578)
+
 ## 13.20.4
 
 ### Fixes

--- a/bin/cli
+++ b/bin/cli
@@ -2,20 +2,13 @@
 
 if (process.argv.indexOf('--suppress-node-version-warning') === -1 || (process.argv[2] === 'migrate' && process.argv[3] === '--')) {
   const majorNodeVersion = parseInt(process.version.split('.')[0].substring(1), 10)
-  const versionIsWithinRecommendation = [16, 18, 20, 22, 24].includes(majorNodeVersion)
-  if (!versionIsWithinRecommendation) {
-    const nodeVersionIsTooOldToUse = majorNodeVersion < 14
-    const updateOrDownload = majorNodeVersion < 24 ? 'update to' : 'download'
-    const printLn = nodeVersionIsTooOldToUse ? console.error.bind(console) : console.warn.bind(console)
-    const additionalText = nodeVersionIsTooOldToUse ? '' : ' Some features may not work with your version.'
-
-    printLn('\nYou\'re using Node', process.version)
-    printLn('The GOV.UK Prototype Kit only supports Node v16, v18, v20, v22 and v24.' + additionalText + '\n')
-    printLn('You can', updateOrDownload, 'Node v24 at https://nodejs.org/en/download\n')
-
-    if (nodeVersionIsTooOldToUse) {
-      process.exit(0)
-    }
+  // Everything at or above the minimum in engines (the maintenance LTS) is supported
+  const minimumSupportedMajorVersion = parseInt(require('../package.json').engines.node.match(/\d+/)[0], 10)
+  if (majorNodeVersion < minimumSupportedMajorVersion) {
+    console.error('\nYou\'re using Node', process.version)
+    console.error('The GOV.UK Prototype Kit only supports Node v' + minimumSupportedMajorVersion + ' or later.\n')
+    console.error('You can update Node at https://nodejs.org/en/download\n')
+    process.exit(0)
   }
 }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -47,7 +47,7 @@
         "wait-on": "^7.0.1"
       },
       "engines": {
-        "node": "^16.x || ^18.x || >= 20.x"
+        "node": ">= 22.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Rapidly create HTML prototypes of GOV.UK services",
   "version": "13.20.4",
   "engines": {
-    "node": "^16.x || ^18.x || >= 20.x"
+    "node": ">= 22.x"
   },
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Breaking.

We're moving to support only non-EOL versions of Node. Currently that's 22, 24 and 26.

I'm not explicitly calling out those versions in `engines`, since I think it's reasonable to assume that anybody using odd-numbered releases are power users who'll upgrade promptly. The test suites do explicitly use them.