### PR TITLE
Disable vulnerability check in review Action

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -16,4 +16,5 @@ jobs:
       - name: Dependency review
         uses: actions/dependency-review-action@v5
         with:
+          vulnerability-check: false
           allow-licenses: Apache-2.0, BSD-2-Clause, MIT, ISC


### PR DESCRIPTION
We're getting some false positives but we could reverse this decision later if we wish to try it again.

In the mean time we have reporting via GitHub and Dependabot.