### PR TITLE
Add BSD-3-Clause to license allowlist

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -17,4 +17,4 @@ jobs:
         uses: actions/dependency-review-action@v5
         with:
           vulnerability-check: false
-          allow-licenses: Apache-2.0, BSD-2-Clause, MIT, ISC
+          allow-licenses: Apache-2.0, BSD-2-Clause, BSD-3-Clause, MIT, ISC


### PR DESCRIPTION
BSD-3-Clause adds the following clause to the already allowed BSD-2-Clause:

> Neither the name of the [organization] nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.