### PR TITLE
Internal releases & check dependencies are installed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "govuk-prototype-kit",
-  "version": "14.0.0-internal.0",
+  "version": "14.0.0-internal.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-prototype-kit",
-      "version": "14.0.0-internal.0",
+      "version": "14.0.0-internal.1",
       "bundleDependencies": [
         "ansi-colors",
         "browser-sync",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "govuk-prototype-kit",
-  "version": "14.0.0-internal.1",
+  "version": "14.0.0-internal.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-prototype-kit",
-      "version": "14.0.0-internal.1",
+      "version": "14.0.0-internal.2",
       "bundleDependencies": [
         "ansi-colors",
         "browser-sync",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "govuk-prototype-kit",
-  "version": "13.20.4",
+  "version": "14.0.0-internal.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-prototype-kit",
-      "version": "13.20.4",
+      "version": "14.0.0-internal.0",
       "bundleDependencies": [
         "ansi-colors",
         "browser-sync",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-prototype-kit",
   "description": "Rapidly create HTML prototypes of GOV.UK services",
-  "version": "13.20.4",
+  "version": "14.0.0-internal.0",
   "engines": {
     "node": ">= 22.x"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-prototype-kit",
   "description": "Rapidly create HTML prototypes of GOV.UK services",
-  "version": "14.0.0-internal.0",
+  "version": "14.0.0-internal.1",
   "engines": {
     "node": ">= 22.x"
   },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "start:test:heroku": "cross-env USE_AUTH=false USE_HTTPS=false node scripts/create-prototype-and-run 'npx --yes heroku@10 local --port 3000'",
     "lint": "standard . bin/cli scripts/utils/create-release-pr scripts/create-prototype-and-run.js scripts/generate-known-version-hashes.js",
     "lint:fix": "npm run lint -- --fix",
+    "prepack": "npm ls --all",
     "rapidtest": "jest --bail",
     "cypress:run": "cypress run",
     "cypress:open": "cypress open",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-prototype-kit",
   "description": "Rapidly create HTML prototypes of GOV.UK services",
-  "version": "14.0.0-internal.1",
+  "version": "14.0.0-internal.2",
   "engines": {
     "node": ">= 22.x"
   },


### PR DESCRIPTION
Thought we may want to merge the internal releases we made from the `spike-bundling` branch so that `main` ends up with the whole history of our releases.

More importantly, though, the PR includes a commit to ensure publishing fails if a dependency is not installed inside the project's `node_modules`. If we don't want the tags with the pre-releases, we need to at least carry this one over to `spike-bundling.