### PR TITLE
Replace dotenv with Node's `loadEnvFile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ If your prototype uses [custom routes](https://prototype-kit.service.gov.uk/docs
 
 - [ #2577: Update Express to version 5](https://github.com/alphagov/govuk-prototype-kit/pull/2577)
 
+#### Check you can still access your .env variables
+
+We now use Node.js's built-in `.env` file support instead of the `dotenv` package to load environment variables from the `.env` file in your prototype.
+
+If your prototype uses a `.env` file, check that you can still access its variables in your
+prototype.
+
+- [#2593: Replace dotenv with Node's built-in .env support](https://github.com/alphagov/govuk-prototype-kit/pull/2593)
+
 ### New features
 
 #### MOJ Frontend is available as a plugin

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -14,7 +14,6 @@
         "cookie-parser": "^1.4.6",
         "cross-spawn": "^7.0.3",
         "csrf-csrf": "^2.3.0",
-        "dotenv": "^16.4.5",
         "express": "^5.2.1",
         "express-session": "^1.18.0",
         "fs-extra": "^11.2.0",
@@ -4124,17 +4123,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -14916,11 +14904,6 @@
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3"
       }
-    },
-    "dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="
     },
     "dunder-proto": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "cookie-parser": "^1.4.6",
     "cross-spawn": "^7.0.3",
     "csrf-csrf": "^2.3.0",
-    "dotenv": "^16.4.5",
     "express": "^5.2.1",
     "express-session": "^1.18.0",
     "fs-extra": "^11.2.0",

--- a/server.js
+++ b/server.js
@@ -5,14 +5,20 @@ const url = require('url')
 
 // npm dependencies
 const cookieParser = require('cookie-parser')
-const dotenv = require('dotenv')
 const express = require('express')
 const { expressNunjucks, getNunjucksAppEnv, stopWatchingNunjucks } = require('./lib/nunjucks/nunjucksConfiguration')
 
 // We want users to be able to keep api keys, config variables and other
-// envvars in a `.env` file, run dotenv before other code to make sure those
-// variables are available
-dotenv.config()
+// envvars in a `.env` file, load it before other code to make sure those
+// variables are available. `loadEnvFile` fails if it can't find a .env file
+// so we want to handle that case (since users don't HAVE to have one).
+try {
+  process.loadEnvFile()
+} catch (err) {
+  if (err.code !== 'ENOENT') {
+    throw err
+  }
+}
 
 // Local dependencies
 const { projectDir, packageDir, appViewsDir, finalBackupNunjucksDir } = require('./lib/utils/paths')


### PR DESCRIPTION
As of Node 20, we can use `process.loadEnvFile` to do the same thing as `dotenv.config`.

dotenv has no dependencies, so isn't a huge dependency to get rid of, but getting rid of it is still a reduction in our supply chain.