### PR TITLE
Configure Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+
+updates:
+  # Update npm packages
+  - package-ecosystem: npm
+    directory: /
+    open-pull-requests-limit: 15
+
+    schedule:
+      interval: monthly
+      time: '10:30'
+      timezone: 'Europe/London'
+
+    cooldown:
+      default-days: 7
+
+    versioning-strategy: increase
+
+  # Update GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+
+    schedule:
+      interval: monthly
+      time: '10:30'
+      timezone: 'Europe/London'
+
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Sets up dependabot version updates on the same schedule and with the same cooldown as for GOV.UK Frontend. As a starting point, no groups are set up. We can see as time goes if it becomes worth grouping dependencies.

Fixes #2591 