### PR TITLE
Fail tests early

### DIFF
--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -22,6 +22,14 @@ require('./commands')
 // When a test fails do not run any more tests within the the current spec file
 afterEach(function () {
   if (this.currentTest.state === 'failed') {
+    console.log("============ STOPPED THE TESTS??? ===============")
+    console.log("============ STOPPED THE TESTS??? ===============")
+    console.log("============ STOPPED THE TESTS??? ===============")
+    console.log("============ STOPPED THE TESTS??? ===============")
+    console.log("============ STOPPED THE TESTS??? ===============")
+    console.log("============ STOPPED THE TESTS??? ===============")
+    console.log("============ STOPPED THE TESTS??? ===============")
+    console.log("============ STOPPED THE TESTS??? ===============")
     Cypress.stop()
   }
 })

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -18,3 +18,10 @@
 
 // Alternatively you can use CommonJS syntax:
 require('./commands')
+
+// When a test fails do not run any more tests within the the current spec file
+afterEach(function () {
+  if (this.currentTest.state === 'failed') {
+    Cypress.stop()
+  }
+})


### PR DESCRIPTION
When we know a test has failed stop the execution as early as possible.

Note this should only stop the current spec file and not the other files in the run, which wont give us as big impact as a feature like "auto cancellation" which is locked behind Cypress Cloud: https://docs.cypress.io/api/cypress-api/stop