### PR TITLE
Improve flakey action tests

### DIFF
--- a/cypress/e2e/plugins/plugin-utils.js
+++ b/cypress/e2e/plugins/plugin-utils.js
@@ -11,6 +11,8 @@ const panelProcessingQuery = '[aria-live="polite"] #panel-processing'
 const panelCompleteQuery = '[aria-live="polite"] #panel-complete'
 const panelErrorQuery = '[aria-live="polite"] #panel-error'
 
+const processingTimeout = 20000 // 20s
+
 function getTemplateLink (type, packageName, path) {
   const queryString = `?package=${urlencode(packageName)}&template=${urlencode(path)}`
   return `${manageTemplatesPagePath}/${type}${queryString}`
@@ -135,25 +137,20 @@ function performPluginAction (action, plugin, pluginName) {
       .contains(pluginName)
   }
 
-  const processingText = `${action === 'update' ? 'Updat' : action}ing ...`
-
-  cy.get(panelCompleteQuery, { timeout: 20000 })
-    .should('not.be.visible')
-  cy.get(panelErrorQuery)
-    .should('not.be.visible')
-  cy.get(panelProcessingQuery)
-    .should('be.visible')
-    .contains(capitalize(processingText))
-
   cy.task('log', `The ${plugin} plugin is ${action === 'update' ? 'updat' : action}ing`)
 
-  cy.get(panelProcessingQuery, { timeout: 20000 })
+  // Wait for processing to complete
+  cy.get(panelProcessingQuery, { timeout: processingTimeout })
     .should('not.be.visible')
-  cy.get(panelErrorQuery)
-    .should('not.be.visible')
+
+  // When processing is complete should show a complete status
   cy.get(panelCompleteQuery)
     .should('be.visible')
     .contains(`${capitalize(action)} complete`)
+
+  // And not an error status
+  cy.get(panelErrorQuery)
+    .should('not.be.visible')
 
   cy.task('log', `The ${plugin} plugin ${action} has completed`)
 
@@ -169,25 +166,21 @@ function performPluginAction (action, plugin, pluginName) {
 function failAction (action) {
   cy.get('#plugin-action-button').click()
 
-  cy.get(panelCompleteQuery, { timeout: 20000 })
+  // Wait for processing to complete
+  cy.get(panelProcessingQuery, { timeout: processingTimeout })
     .should('not.be.visible')
-  cy.get(panelErrorQuery)
-    .should('not.be.visible')
-  cy.get(panelProcessingQuery)
-    .should('be.visible')
-    .contains(`${capitalize(action === 'update' ? 'Updat' : action)}ing ...`)
 
-  cy.get(panelProcessingQuery)
-    .should('not.be.visible')
-  cy.get(panelCompleteQuery)
-    .should('not.be.visible')
+  // When processing is complete should show an error status
   cy.get(panelErrorQuery)
     .should('be.visible')
-
   cy.get(`${panelErrorQuery} .govuk-panel__title`)
     .contains(`There was a problem ${action === 'update' ? 'Updat' : action}ing`)
   cy.get(`${panelErrorQuery} a`)
     .contains('Please contact support')
+
+  // And not a complete status
+  cy.get(panelCompleteQuery)
+    .should('not.be.visible')
 }
 
 module.exports = {

--- a/cypress/e2e/plugins/plugin-utils.js
+++ b/cypress/e2e/plugins/plugin-utils.js
@@ -137,15 +137,13 @@ function performPluginAction (action, plugin, pluginName) {
 
   const processingText = `${action === 'update' ? 'Updat' : action}ing ...`
 
-  if (Cypress.env('skipPluginActionInterimStep') !== 'true') {
-    cy.get(panelCompleteQuery, { timeout: 20000 })
-      .should('not.be.visible')
-    cy.get(panelErrorQuery)
-      .should('not.be.visible')
-    cy.get(panelProcessingQuery)
-      .should('be.visible')
-      .contains(capitalize(processingText))
-  }
+  cy.get(panelCompleteQuery, { timeout: 20000 })
+    .should('not.be.visible')
+  cy.get(panelErrorQuery)
+    .should('not.be.visible')
+  cy.get(panelProcessingQuery)
+    .should('be.visible')
+    .contains(capitalize(processingText))
 
   cy.task('log', `The ${plugin} plugin is ${action === 'update' ? 'updat' : action}ing`)
 
@@ -171,15 +169,13 @@ function performPluginAction (action, plugin, pluginName) {
 function failAction (action) {
   cy.get('#plugin-action-button').click()
 
-  if (Cypress.env('skipPluginActionInterimStep') !== 'true') {
-    cy.get(panelCompleteQuery, { timeout: 20000 })
-      .should('not.be.visible')
-    cy.get(panelErrorQuery)
-      .should('not.be.visible')
-    cy.get(panelProcessingQuery)
-      .should('be.visible')
-      .contains(`${capitalize(action === 'update' ? 'Updat' : action)}ing ...`)
-  }
+  cy.get(panelCompleteQuery, { timeout: 20000 })
+    .should('not.be.visible')
+  cy.get(panelErrorQuery)
+    .should('not.be.visible')
+  cy.get(panelProcessingQuery)
+    .should('be.visible')
+    .contains(`${capitalize(action === 'update' ? 'Updat' : action)}ing ...`)
 
   cy.get(panelProcessingQuery)
     .should('not.be.visible')

--- a/cypress/events/index.js
+++ b/cypress/events/index.js
@@ -67,7 +67,6 @@ module.exports = function setupNodeEvents (on, config) {
     .filter(password => !!password)
   config.env.projectFolder = path.resolve(process.env.KIT_TEST_DIR || process.cwd())
   config.env.tempFolder = path.join(__dirname, '..', 'temp')
-  config.env.skipPluginActionInterimStep = process.env.SKIP_PLUGIN_ACTION_INTERIM_STEP
 
   const packagePath = path.join(config.env.projectFolder, 'package.json')
   const packageContent = fs.readFileSync(packagePath, 'utf8')


### PR DESCRIPTION
When starting an action a request is sent to the server and then a processing message is shown to the user so they know something is happening e.g. "Installing...".

This could take a short or long amount of time.

In some tests the requests complete so quickly that cypress doesnt see a processing step at all... but the tests expect there to be one to check...

Adjust the tests so we wait until the processing message has gone and then continue.

Note that these tests that are flakey were guarded with `skipPluginActionInterimStep` so that a previous developer could skip them on their local machine, so hopefully these adjustments mean they work in both local and CI.