### PR TITLE
Update to Cypress 16

### DIFF
--- a/cypress/e2e/dev/1-watch-files/watch-config.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-config.cypress.js
@@ -5,7 +5,7 @@ const path = require('path')
 const { waitForApplication, restoreStarterFiles } = require('../../utils')
 
 const appConfigPath = path.join('app', 'config.json')
-const appConfig = path.join(Cypress.env('projectFolder'), appConfigPath)
+const appConfig = path.join(Cypress.expose('projectFolder'), appConfigPath)
 
 const originalText = 'Service name goes here'
 const newText = 'Cypress test'

--- a/cypress/e2e/dev/1-watch-files/watch-filters.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-filters.cypress.js
@@ -1,8 +1,8 @@
 const path = require('path')
 const { waitForApplication, restoreStarterFiles } = require('../../utils')
 
-const appFiltersPath = path.join(Cypress.env('projectFolder'), 'app', 'filters.js')
-const appFiltersViewPath = path.join(Cypress.env('projectFolder'), 'app', 'views', 'filters.html')
+const appFiltersPath = path.join(Cypress.expose('projectFolder'), 'app', 'filters.js')
+const appFiltersViewPath = path.join(Cypress.expose('projectFolder'), 'app', 'views', 'filters.html')
 
 const filtersViewMarkup = `
 {% extends "layouts/main.html" %}

--- a/cypress/e2e/dev/1-watch-files/watch-functions.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-functions.cypress.js
@@ -1,8 +1,8 @@
 const path = require('path')
 const { waitForApplication, restoreStarterFiles } = require('../../utils')
 
-const appFunctionsPath = path.join(Cypress.env('projectFolder'), 'app', 'functions.js')
-const appFiltersViewPath = path.join(Cypress.env('projectFolder'), 'app', 'views', 'functions.html')
+const appFunctionsPath = path.join(Cypress.expose('projectFolder'), 'app', 'functions.js')
+const appFiltersViewPath = path.join(Cypress.expose('projectFolder'), 'app', 'views', 'functions.html')
 
 const functionsViewMarkup = `
 {% extends "layouts/main.html" %}

--- a/cypress/e2e/dev/1-watch-files/watch-images.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-images.cypress.js
@@ -6,13 +6,13 @@ const { waitForApplication, restoreStarterFiles } = require('../../utils')
 
 const imageFile = 'larry-the-cat.jpg'
 const cypressImages = path.join(Cypress.config('fixturesFolder'), 'images')
-const appImages = path.join(Cypress.env('projectFolder'), 'app', 'assets', 'images')
+const appImages = path.join(Cypress.expose('projectFolder'), 'app', 'assets', 'images')
 const publicImages = 'public/images'
 
 const pageFixture = 'larry-the-cat'
 const pageFixtureName = `${pageFixture}.html`
 const pageFixturePath = path.join(Cypress.config('fixturesFolder'), 'views', pageFixtureName)
-const pageAppPath = path.join(Cypress.env('projectFolder'), 'app', 'views', pageFixtureName)
+const pageAppPath = path.join(Cypress.expose('projectFolder'), 'app', 'views', pageFixtureName)
 
 describe('watch image files', () => {
   afterEach(restoreStarterFiles)

--- a/cypress/e2e/dev/1-watch-files/watch-javascripts.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-javascripts.cypress.js
@@ -5,7 +5,7 @@ const path = require('path')
 const { waitForApplication, restoreStarterFiles } = require('../../utils')
 
 const appJsPath = path.join('app', 'assets', 'javascripts', 'application.js')
-const appJs = path.join(Cypress.env('projectFolder'), appJsPath)
+const appJs = path.join(Cypress.expose('projectFolder'), appJsPath)
 
 const heading = 'Test Heading'
 

--- a/cypress/e2e/dev/1-watch-files/watch-routes.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-routes.cypress.js
@@ -7,7 +7,7 @@ const { waitForApplication, restoreStarterFiles } = require('../../utils')
 const appRoutesPath = path.join('app', 'routes.js')
 
 const routesFixture = path.join(Cypress.config('fixturesFolder'), 'routes.js')
-const appRoutes = path.join(Cypress.env('projectFolder'), appRoutesPath)
+const appRoutes = path.join(Cypress.expose('projectFolder'), appRoutesPath)
 const pagePath = '/cypress-test'
 
 describe('watch route file', () => {

--- a/cypress/e2e/dev/1-watch-files/watch-views.cypress.js
+++ b/cypress/e2e/dev/1-watch-files/watch-views.cypress.js
@@ -5,7 +5,7 @@ const path = require('path')
 const { waitForApplication, restoreStarterFiles } = require('../../utils')
 
 const templatesView = path.join(Cypress.config('fixturesFolder'), 'views', 'start.html')
-const appView = path.join(Cypress.env('projectFolder'), 'app', 'views', 'start.html')
+const appView = path.join(Cypress.expose('projectFolder'), 'app', 'views', 'start.html')
 const pagePath = '/start'
 
 describe('watching start page', () => {

--- a/cypress/e2e/dev/2-page-component-tests/checkboxes.cypress.js
+++ b/cypress/e2e/dev/2-page-component-tests/checkboxes.cypress.js
@@ -5,7 +5,7 @@ const path = require('path')
 const { waitForApplication, restoreStarterFiles } = require('../../utils')
 
 const templatesView = path.join(Cypress.config('fixturesFolder'), 'views', 'checkbox-test.html')
-const appView = path.join(Cypress.env('projectFolder'), 'app', 'views', 'checkbox-test.html')
+const appView = path.join(Cypress.expose('projectFolder'), 'app', 'views', 'checkbox-test.html')
 
 const pagePath = '/checkbox-test'
 

--- a/cypress/e2e/dev/3-link-page-tests/link-index-to-start.cypress.js
+++ b/cypress/e2e/dev/3-link-page-tests/link-index-to-start.cypress.js
@@ -7,8 +7,8 @@ const { waitForApplication, copyFile, restoreStarterFiles } = require('../../uti
 const appViewsPath = path.join('app', 'views')
 const indexViewPath = path.join(appViewsPath, 'index.html')
 
-const indexView = path.join(Cypress.env('projectFolder'), indexViewPath)
-const startView = path.join(Cypress.env('projectFolder'), appViewsPath, 'start.html')
+const indexView = path.join(Cypress.expose('projectFolder'), indexViewPath)
+const startView = path.join(Cypress.expose('projectFolder'), appViewsPath, 'start.html')
 const templateStartView = path.join(Cypress.config('fixturesFolder'), 'views', 'start.html')
 
 const commentText = '{% include "govuk-prototype-kit/includes/homepage-bottom.njk" %}'

--- a/cypress/e2e/dev/3-link-page-tests/link-page-utils.js
+++ b/cypress/e2e/dev/3-link-page-tests/link-page-utils.js
@@ -20,7 +20,7 @@ const jugglingBallsComponent = path.join(components, 'juggling-balls-component.h
 const jugglingTrickComponent = path.join(components, 'juggling-trick-component.html')
 const jugglingBallsAnswerComponent = path.join(components, 'juggling-balls-route-component.js')
 
-const appViews = path.join(Cypress.env('projectFolder'), 'app', 'views')
+const appViews = path.join(Cypress.expose('projectFolder'), 'app', 'views')
 const startView = path.join(appViews, 'start.html')
 const jugglingBallsView = path.join(appViews, 'juggling-balls.html')
 const jugglingTrickView = path.join(appViews, 'juggling-trick.html')
@@ -29,9 +29,9 @@ const confirmationView = path.join(appViews, 'confirmation.html')
 const ineligibleView = path.join(appViews, 'ineligible.html')
 
 const appRoutesPath = path.join('app', 'routes.js')
-const appRoutes = path.join(Cypress.env('projectFolder'), appRoutesPath)
+const appRoutes = path.join(Cypress.expose('projectFolder'), appRoutesPath)
 
-const appDataFile = path.join(Cypress.env('projectFolder'), 'app', 'data', 'session-data-defaults.js')
+const appDataFile = path.join(Cypress.expose('projectFolder'), 'app', 'data', 'session-data-defaults.js')
 
 const jugglingBallsPath = '/juggling-balls'
 const jugglingTrickPath = '/juggling-trick'

--- a/cypress/e2e/dev/4-step-by-step-tests/step-by-step-journey.cypress.js
+++ b/cypress/e2e/dev/4-step-by-step-tests/step-by-step-journey.cypress.js
@@ -13,7 +13,7 @@ const {
 
 const plugin = '@govuk-prototype-kit/step-by-step@1'
 
-const projectFolder = Cypress.env('projectFolder')
+const projectFolder = Cypress.expose('projectFolder')
 
 const appViews = path.join(projectFolder, 'app', 'views')
 

--- a/cypress/e2e/dev/5-management-tests/change-service-name.cypress.js
+++ b/cypress/e2e/dev/5-management-tests/change-service-name.cypress.js
@@ -5,7 +5,7 @@ const path = require('path')
 const { waitForApplication, restoreStarterFiles } = require('../../utils')
 
 const appConfigPath = path.join('app', 'config.json')
-const appConfig = path.join(Cypress.env('projectFolder'), appConfigPath)
+const appConfig = path.join(Cypress.expose('projectFolder'), appConfigPath)
 
 const originalText = 'Service name goes here'
 const newText = 'Cypress test'

--- a/cypress/e2e/dev/5-management-tests/clear-data-page.cypress.js
+++ b/cypress/e2e/dev/5-management-tests/clear-data-page.cypress.js
@@ -9,7 +9,7 @@ const {
   waitForApplication, restoreStarterFiles
 } = require('../../utils')
 
-const appViews = path.join(Cypress.env('projectFolder'), 'app', 'views')
+const appViews = path.join(Cypress.expose('projectFolder'), 'app', 'views')
 const templates = path.join(Cypress.config('fixturesFolder'), 'views')
 const components = path.join(Cypress.config('fixturesFolder'), 'components')
 

--- a/cypress/e2e/dev/5-management-tests/edit-home-page.cypress.js
+++ b/cypress/e2e/dev/5-management-tests/edit-home-page.cypress.js
@@ -5,7 +5,7 @@ const path = require('path')
 const { waitForApplication, restoreStarterFiles } = require('../../utils')
 
 const appHomePath = path.join('app', 'views', 'index.html')
-const appHome = path.join(Cypress.env('projectFolder'), appHomePath)
+const appHome = path.join(Cypress.expose('projectFolder'), appHomePath)
 
 const originalText = 'Service name goes here'
 const newText = 'Cypress test service'

--- a/cypress/e2e/dev/5-management-tests/no-autodatastore-on-management-pages.cypress.js
+++ b/cypress/e2e/dev/5-management-tests/no-autodatastore-on-management-pages.cypress.js
@@ -8,7 +8,7 @@ const {
   waitForApplication, restoreStarterFiles
 } = require('../../utils')
 
-const appViews = path.join(Cypress.env('projectFolder'), 'app', 'views')
+const appViews = path.join(Cypress.expose('projectFolder'), 'app', 'views')
 const templates = path.join(Cypress.config('fixturesFolder'), 'views')
 
 const questionTemplate = path.join(templates, 'question.html')

--- a/cypress/e2e/dev/6-layout-tests/default-layout.cypress.js
+++ b/cypress/e2e/dev/6-layout-tests/default-layout.cypress.js
@@ -24,7 +24,7 @@ describe('default-layout', () => {
       comments(doc.head).should('not.contain', backupLayoutComment)
     )
 
-    cy.task('deleteFile', { filename: path.join(Cypress.env('projectFolder'), defaultLayoutFilePath) })
+    cy.task('deleteFile', { filename: path.join(Cypress.expose('projectFolder'), defaultLayoutFilePath) })
 
     cy.visit('/', { failOnStatusCode: false })
     cy.get('body').should('not.contains.text', 'Error: template not found')

--- a/cypress/e2e/dev/6-layout-tests/title-variable.cypress.js
+++ b/cypress/e2e/dev/6-layout-tests/title-variable.cypress.js
@@ -20,7 +20,7 @@ describe('', () => {
     cy.task('log', 'Update index.html using "set pageName" to display customised page title')
 
     cy.task('createFile', {
-      filename: path.join(Cypress.env('projectFolder'), indexFile),
+      filename: path.join(Cypress.expose('projectFolder'), indexFile),
       data: `
     {% extends "layouts/main.html" %}
 
@@ -37,7 +37,7 @@ describe('', () => {
     cy.task('log', 'Update index.html using "block pageTitle" to display overridden page title')
 
     cy.task('createFile', {
-      filename: path.join(Cypress.env('projectFolder'), indexFile),
+      filename: path.join(Cypress.expose('projectFolder'), indexFile),
       data: `
     {% extends "layouts/main.html" %}
 

--- a/cypress/e2e/dev/7-backup-homepage/backup-homepage.cypress.js
+++ b/cypress/e2e/dev/7-backup-homepage/backup-homepage.cypress.js
@@ -13,7 +13,7 @@ describe('backup homepage', () => {
     waitForApplication()
     cy.visit('/')
 
-    cy.task('deleteFile', { filename: path.join(Cypress.env('projectFolder'), homepageFile) })
+    cy.task('deleteFile', { filename: path.join(Cypress.expose('projectFolder'), homepageFile) })
 
     cy.visit('/')
     cy.get('h1').should('contains.text', 'Your prototype homepage is missing')

--- a/cypress/e2e/errors/1-error-page-tests/fatal-error.cypress.js
+++ b/cypress/e2e/errors/1-error-page-tests/fatal-error.cypress.js
@@ -2,7 +2,7 @@ const path = require('path')
 const { restoreStarterFiles } = require('../../utils')
 const completelyBrokenRoutesFixture = path.join(Cypress.config('fixturesFolder'), 'completely-broken-routes.js')
 const appRoutesPath = path.join('app', 'routes.js')
-const appRoutes = path.join(Cypress.env('projectFolder'), appRoutesPath)
+const appRoutes = path.join(Cypress.expose('projectFolder'), appRoutesPath)
 
 const pageName = 'There is an error'
 const contactSupportText = 'Get support'

--- a/cypress/e2e/errors/1-error-page-tests/server-error.cypress.js
+++ b/cypress/e2e/errors/1-error-page-tests/server-error.cypress.js
@@ -2,7 +2,7 @@ const path = require('path')
 const { waitForApplication, restoreStarterFiles } = require('../../utils')
 const routesFixture = path.join(Cypress.config('fixturesFolder'), 'routes.js')
 const appRoutesPath = path.join('app', 'routes.js')
-const appRoutes = path.join(Cypress.env('projectFolder'), appRoutesPath)
+const appRoutes = path.join(Cypress.expose('projectFolder'), appRoutesPath)
 
 const homePageName = 'GOV.UK Prototype Kit'
 const errorPageName = 'There is an error'
@@ -45,7 +45,7 @@ describe('Server Error Test', () => {
   it('shows an error if sass is broken', () => {
     const brokenStylesFixture = path.join(Cypress.config('fixturesFolder'), 'sass', 'broken-styles.scss')
     const appSassPath = path.join('app', 'assets', 'sass', 'application.scss')
-    const appSass = path.join(Cypress.env('projectFolder'), appSassPath)
+    const appSass = path.join(Cypress.expose('projectFolder'), appSassPath)
     const brokenSassText = 'color red'
 
     waitForApplication()
@@ -75,7 +75,7 @@ describe('Server Error Test', () => {
   it('shows an error if session-data-defaults.js is malformed', () => {
     const brokenSessionDataDefaultsFixture = path.join(Cypress.config('fixturesFolder'), 'broken-session-data-defaults.js')
     const appSessionDataDefaultsPath = path.join('app', 'data', 'session-data-defaults.js')
-    const appSessionDataDefaults = path.join(Cypress.env('projectFolder'), appSessionDataDefaultsPath)
+    const appSessionDataDefaults = path.join(Cypress.expose('projectFolder'), appSessionDataDefaultsPath)
 
     waitForApplication()
 

--- a/cypress/e2e/plugins/0-mock-plugin-tests/install-plugin-via-cli-test.cypress.js
+++ b/cypress/e2e/plugins/0-mock-plugin-tests/install-plugin-via-cli-test.cypress.js
@@ -4,7 +4,7 @@ const path = require('path')
 // local dependencies
 const { waitForApplication, installPlugin, createFile, restoreStarterFiles } = require('../../utils')
 
-const appViews = path.join(Cypress.env('projectFolder'), 'app', 'views')
+const appViews = path.join(Cypress.expose('projectFolder'), 'app', 'views')
 const pluginBazView = path.join(appViews, 'plugin-baz.html')
 const fixtures = path.join(Cypress.config('fixturesFolder'))
 const pluginLocation = path.join(fixtures, 'plugins', 'plugin-baz')

--- a/cypress/e2e/plugins/0-mock-plugin-tests/multi-combined-plugin-test.cypress.js
+++ b/cypress/e2e/plugins/0-mock-plugin-tests/multi-combined-plugin-test.cypress.js
@@ -4,7 +4,7 @@ const path = require('path')
 // local dependencies
 const { waitForApplication, restoreStarterFiles } = require('../../utils')
 
-const appViews = path.join(Cypress.env('projectFolder'), 'app', 'views')
+const appViews = path.join(Cypress.expose('projectFolder'), 'app', 'views')
 const pluginFooBarView = path.join(appViews, 'plugin-foo-bar.html')
 
 const WHITE = 'rgb(255, 255, 255)'

--- a/cypress/e2e/plugins/0-mock-plugin-tests/multi-plugin-test.cypress.js
+++ b/cypress/e2e/plugins/0-mock-plugin-tests/multi-plugin-test.cypress.js
@@ -4,7 +4,7 @@ const path = require('path')
 // local dependencies
 const { waitForApplication, restoreStarterFiles } = require('../../utils')
 
-const appViews = path.join(Cypress.env('projectFolder'), 'app', 'views')
+const appViews = path.join(Cypress.expose('projectFolder'), 'app', 'views')
 const pluginFooBarView = path.join(appViews, 'plugin-foo-bar.html')
 
 const WHITE = 'rgb(255, 255, 255)'

--- a/cypress/e2e/plugins/0-mock-plugin-tests/single-plugin-test.cypress.js
+++ b/cypress/e2e/plugins/0-mock-plugin-tests/single-plugin-test.cypress.js
@@ -4,7 +4,7 @@ const path = require('path')
 // local dependencies
 const { waitForApplication, restoreStarterFiles } = require('../../utils')
 
-const appViews = path.join(Cypress.env('projectFolder'), 'app', 'views')
+const appViews = path.join(Cypress.expose('projectFolder'), 'app', 'views')
 const pluginFooView = path.join(appViews, 'plugin-foo.html')
 
 const WHITE = 'rgb(255, 255, 255)'

--- a/cypress/e2e/plugins/1-available-plugins-tests/install-available-plugin.cypress.js
+++ b/cypress/e2e/plugins/1-available-plugins-tests/install-available-plugin.cypress.js
@@ -16,7 +16,7 @@ const {
 } = require('../plugin-utils')
 const { showHideAllLinkQuery, assertVisible, assertHidden } = require('../../step-by-step-utils')
 
-const appViews = path.join(Cypress.env('projectFolder'), 'app', 'views')
+const appViews = path.join(Cypress.expose('projectFolder'), 'app', 'views')
 const plugin = '@govuk-prototype-kit/step-by-step'
 const version1 = '1.0.0'
 const version2 = 'latest'

--- a/cypress/e2e/plugins/1-available-plugins-tests/view-template-with-default-layout.cypress.js
+++ b/cypress/e2e/plugins/1-available-plugins-tests/view-template-with-default-layout.cypress.js
@@ -39,7 +39,7 @@ describe('view template with default layout', () => {
       comments(doc.head).should('not.contain', backupLayoutComment)
     )
 
-    cy.task('deleteFile', { filename: path.join(Cypress.env('projectFolder'), defaultLayoutFilePath) })
+    cy.task('deleteFile', { filename: path.join(Cypress.expose('projectFolder'), defaultLayoutFilePath) })
 
     waitForApplication(manageTemplatesPagePath)
     cy.visit(manageTemplatesPagePath)

--- a/cypress/e2e/plugins/2-prototype-kit-plugin-tests/allow-upgrade-in-url.cypress.js
+++ b/cypress/e2e/plugins/2-prototype-kit-plugin-tests/allow-upgrade-in-url.cypress.js
@@ -5,7 +5,7 @@ const plugin = '@govuk-prototype-kit/task-list'
 const pluginVersion = '1.1.1'
 const originalText = '"dependencies": {'
 const replacementText = `"dependencies": { "${plugin}": "${pluginVersion}",`
-const pkgJsonFile = path.join(Cypress.env('projectFolder'), 'package.json')
+const pkgJsonFile = path.join(Cypress.expose('projectFolder'), 'package.json')
 
 describe('Allow upgrade in URLs', () => {
   after(restoreStarterFiles)
@@ -15,7 +15,7 @@ describe('Allow upgrade in URLs', () => {
 
     log(`Add an old version of ${plugin} within the package.json`)
     replaceInFile(pkgJsonFile, originalText, '', replacementText)
-    cy.exec(`cd ${Cypress.env('projectFolder')} && npm install`)
+    cy.exec(`cd ${cy.env('projectFolder')} && npm install`)
 
     log('Make sure old upgrade URL still works')
     cy.visit(`/manage-prototype/plugins/upgrade?package=${encodeURIComponent(plugin)}`)

--- a/cypress/e2e/plugins/2-prototype-kit-plugin-tests/allow-upgrade-in-url.cypress.js
+++ b/cypress/e2e/plugins/2-prototype-kit-plugin-tests/allow-upgrade-in-url.cypress.js
@@ -15,7 +15,7 @@ describe('Allow upgrade in URLs', () => {
 
     log(`Add an old version of ${plugin} within the package.json`)
     replaceInFile(pkgJsonFile, originalText, '', replacementText)
-    cy.exec(`cd ${cy.env('projectFolder')} && npm install`)
+    cy.task('exec', 'npm install')
 
     log('Make sure old upgrade URL still works')
     cy.visit(`/manage-prototype/plugins/upgrade?package=${encodeURIComponent(plugin)}`)

--- a/cypress/e2e/plugins/2-prototype-kit-plugin-tests/handle-plugin-installation-mismatch.cypress.js
+++ b/cypress/e2e/plugins/2-prototype-kit-plugin-tests/handle-plugin-installation-mismatch.cypress.js
@@ -13,7 +13,7 @@ const plugin = '@govuk-prototype-kit/task-list'
 const pluginVersion = '1.1.1'
 const originalText = '"dependencies": {'
 const replacementText = `"dependencies": { "${plugin}": "${pluginVersion}",`
-const pkgJsonFile = path.join(Cypress.env('projectFolder'), 'package.json')
+const pkgJsonFile = path.join(Cypress.expose('projectFolder'), 'package.json')
 
 describe('Handle a plugin installation mismatch', () => {
   after(restoreStarterFiles)
@@ -28,7 +28,7 @@ describe('Handle a plugin installation mismatch', () => {
     provePluginUninstalled(plugin)
 
     log('Force the plugins to be installed with an npm install')
-    cy.exec(`cd ${Cypress.env('projectFolder')} && npm install`)
+    cy.exec(`cd ${cy.env('projectFolder')} && npm install`)
 
     log(`Make sure ${plugin} is displayed as installed`)
     waitForApplication()

--- a/cypress/e2e/plugins/2-prototype-kit-plugin-tests/handle-plugin-installation-mismatch.cypress.js
+++ b/cypress/e2e/plugins/2-prototype-kit-plugin-tests/handle-plugin-installation-mismatch.cypress.js
@@ -28,7 +28,7 @@ describe('Handle a plugin installation mismatch', () => {
     provePluginUninstalled(plugin)
 
     log('Force the plugins to be installed with an npm install')
-    cy.exec(`cd ${cy.env('projectFolder')} && npm install`)
+    cy.task('exec', 'npm install')
 
     log(`Make sure ${plugin} is displayed as installed`)
     waitForApplication()

--- a/cypress/e2e/plugins/2-prototype-kit-plugin-tests/handle-plugin-update-when-a-dependency-is-now-required.cypress.js
+++ b/cypress/e2e/plugins/2-prototype-kit-plugin-tests/handle-plugin-update-when-a-dependency-is-now-required.cypress.js
@@ -20,7 +20,7 @@ const pluginsPage = '/manage-prototype/plugins'
 const dependencyPlugin = 'govuk-frontend'
 const dependencyPluginName = 'GOV.UK Frontend'
 
-const additionalScssPath = path.join(Cypress.env('projectFolder'), 'app', 'assets', 'sass', 'settings.scss')
+const additionalScssPath = path.join(Cypress.expose('projectFolder'), 'app', 'assets', 'sass', 'settings.scss')
 const additionalScssContents = `
 @mixin govuk-text-colour {
   color: black;

--- a/cypress/e2e/prod/2-management-tests/password-page.cypress.js
+++ b/cypress/e2e/prod/2-management-tests/password-page.cypress.js
@@ -3,13 +3,13 @@ const homePath = '/index'
 const passwordPath = '/manage-prototype/password'
 const errorQuery = 'error=wrong-password'
 const returnURLQuery = `returnURL=${encodeURIComponent(homePath)}`
-const additionalPasswords = Cypress.env('additionalPasswords') || []
+const additionalPasswords = Cypress.expose('additionalPasswords') || []
 
 describe('password page', () => {
   after(restoreStarterFiles)
 
   it('valid password', () => {
-    const password = Cypress.env('password')
+    const password = Cypress.expose('password')
     cy.task('waitUntilAppRestarts')
     cy.visit(homePath)
     cy.url().then(passwordUrl => {

--- a/cypress/e2e/styles/1-watch-styles/watch-custom-styles.cypress.js
+++ b/cypress/e2e/styles/1-watch-styles/watch-custom-styles.cypress.js
@@ -7,13 +7,13 @@ const { waitForApplication, restoreStarterFiles } = require('../../utils')
 const customStylesFixture = 'custom-styles'
 const customStylesFixtureName = `${customStylesFixture}.scss`
 const customStylesFixturePath = path.join(Cypress.config('fixturesFolder'), 'sass', customStylesFixtureName)
-const customStylesAppPath = path.join(Cypress.env('projectFolder'), 'app', 'assets', 'sass', customStylesFixtureName)
+const customStylesAppPath = path.join(Cypress.expose('projectFolder'), 'app', 'assets', 'sass', customStylesFixtureName)
 const customStylesPublicPath = 'public/stylesheets/custom-styles.css'
 
 const pageFixture = 'custom-styles'
 const pageFixtureName = `${pageFixture}.html`
 const pageFixturePath = path.join(Cypress.config('fixturesFolder'), 'views', pageFixtureName)
-const pageAppPath = path.join(Cypress.env('projectFolder'), 'app', 'views', pageFixtureName)
+const pageAppPath = path.join(Cypress.expose('projectFolder'), 'app', 'views', pageFixtureName)
 
 describe('watch custom sass files', () => {
   describe(`sass file ${customStylesFixtureName} should be created and linked within ${pageFixturePath} and accessible from the browser as /${customStylesPublicPath}`, () => {

--- a/cypress/e2e/styles/1-watch-styles/watch-settings-styles.cypress.js
+++ b/cypress/e2e/styles/1-watch-styles/watch-settings-styles.cypress.js
@@ -5,7 +5,7 @@ const path = require('path')
 const { waitForApplication, createFile, deleteFile, replaceInFile, restoreStarterFiles } = require('../../utils')
 
 const appStylesPath = path.join('app', 'assets', 'sass')
-const appStylesFolder = path.join(Cypress.env('projectFolder'), appStylesPath)
+const appStylesFolder = path.join(Cypress.expose('projectFolder'), appStylesPath)
 
 const settingsStyle = path.join(appStylesFolder, 'settings.scss')
 

--- a/cypress/e2e/styles/1-watch-styles/watch-styles.cypress.js
+++ b/cypress/e2e/styles/1-watch-styles/watch-styles.cypress.js
@@ -6,8 +6,8 @@ const { waitForApplication, restoreStarterFiles } = require('../../utils')
 
 const appStylesPath = path.join('app', 'assets', 'sass')
 const appStylesheetPath = path.join(appStylesPath, 'application.scss')
-const appStylesFolder = path.join(Cypress.env('projectFolder'), appStylesPath)
-const appStylesheet = path.join(Cypress.env('projectFolder'), appStylesheetPath)
+const appStylesFolder = path.join(Cypress.expose('projectFolder'), appStylesPath)
+const appStylesheet = path.join(Cypress.expose('projectFolder'), appStylesheetPath)
 
 const cypressTestStyles = 'cypress-test'
 const cypressTestStylePattern = path.join(appStylesFolder, 'patterns', `_${cypressTestStyles}.scss`)

--- a/cypress/e2e/utils.js
+++ b/cypress/e2e/utils.js
@@ -3,7 +3,7 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 const log = (message) => cy.task('log', message)
 
 const authenticate = () => {
-  const password = Cypress.env('password')
+  const password = Cypress.expose('password')
   if (password) {
     log(`Authenticating with ${password}`)
     cy.get('input#password').type(password)
@@ -44,7 +44,7 @@ const restoreStarterFiles = () => {
 
 function uninstallPlugin (plugin) {
   log(`Uninstalling ${plugin}`)
-  cy.exec(`cd ${Cypress.env('projectFolder')} && npm uninstall ${plugin}`)
+  cy.exec(`cd ${cy.env('projectFolder')} && npm uninstall ${plugin}`)
   cy.task('pluginUninstalled', { plugin, timeout: 15000 })
 }
 
@@ -53,7 +53,7 @@ function installPlugin (plugin, version = '') {
     version = '@' + version
   }
   log(`Installing ${plugin}${version}`)
-  cy.exec(`cd ${Cypress.env('projectFolder')} && npm install ${plugin}${version} --save-exact `)
+  cy.exec(`cd ${cy.env('projectFolder')} && npm install ${plugin}${version} --save-exact `)
   if (plugin.startsWith('file:')) {
     plugin = plugin.substring(plugin.lastIndexOf('/') + 1)
   }

--- a/cypress/e2e/utils.js
+++ b/cypress/e2e/utils.js
@@ -44,7 +44,7 @@ const restoreStarterFiles = () => {
 
 function uninstallPlugin (plugin) {
   log(`Uninstalling ${plugin}`)
-  cy.exec(`cd ${cy.env('projectFolder')} && npm uninstall ${plugin}`)
+  cy.task('exec', `npm uninstall ${plugin}`)
   cy.task('pluginUninstalled', { plugin, timeout: 15000 })
 }
 
@@ -53,7 +53,7 @@ function installPlugin (plugin, version = '') {
     version = '@' + version
   }
   log(`Installing ${plugin}${version}`)
-  cy.exec(`cd ${cy.env('projectFolder')} && npm install ${plugin}${version} --save-exact `)
+  cy.task('exec', `npm install ${plugin}${version} --save-exact`)
   if (plugin.startsWith('file:')) {
     plugin = plugin.substring(plugin.lastIndexOf('/') + 1)
   }

--- a/cypress/events/index.js
+++ b/cypress/events/index.js
@@ -377,6 +377,10 @@ module.exports = function setupNodeEvents (on, config) {
     log: (message) => {
       log(message)
       return makeSureCypressCanInterpretTheResult()
+    },
+
+    exec: (command) => {
+      return exec(command, { cwd: config.expose.projectFolder })
     }
   })
 

--- a/cypress/events/index.js
+++ b/cypress/events/index.js
@@ -60,21 +60,21 @@ module.exports = function setupNodeEvents (on, config) {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
 
-  config.env.password = process.env.PASSWORD
-  config.env.additionalPasswords = (process.env.PASSWORD_KEYS || '')
+  config.expose.password = process.env.PASSWORD
+  config.expose.additionalPasswords = (process.env.PASSWORD_KEYS || '')
     .split(',')
     .map(passwordKey => process.env[passwordKey.trim()])
     .filter(password => !!password)
-  config.env.projectFolder = path.resolve(process.env.KIT_TEST_DIR || process.cwd())
-  config.env.tempFolder = path.join(__dirname, '..', 'temp')
+  config.expose.projectFolder = path.resolve(process.env.KIT_TEST_DIR || process.cwd())
+  config.expose.tempFolder = path.join(__dirname, '..', 'temp')
 
-  const packagePath = path.join(config.env.projectFolder, 'package.json')
+  const packagePath = path.join(config.expose.projectFolder, 'package.json')
   const packageContent = fs.readFileSync(packagePath, 'utf8')
   const packageObject = JSON.parse(packageContent)
   const dependencies = packageObject.dependencies || {}
 
   if ('govuk-prototype-kit' in dependencies) {
-    config.env.packageFolder = path.join(config.env.projectFolder, 'node_modules', 'govuk-prototype-kit')
+    config.expose.packageFolder = path.join(config.expose.projectFolder, 'node_modules', 'govuk-prototype-kit')
   }
 
   const waitUntilAppRestarts = (timeout = 20000) => waitOn({
@@ -178,7 +178,7 @@ module.exports = function setupNodeEvents (on, config) {
     })
   }
 
-  const getPathFromProjectRoot = (...all) => path.join(...[config.env.projectFolder].concat(all))
+  const getPathFromProjectRoot = (...all) => path.join(...[config.expose.projectFolder].concat(all))
   const pathToPackageFile = packageName => getPathFromProjectRoot('node_modules', packageName, 'package.json')
 
   const pluginInstalled = async (plugin, version, timeout) => {
@@ -218,8 +218,8 @@ module.exports = function setupNodeEvents (on, config) {
   }
 
   const backupStarterFiles = () => {
-    const projectDir = path.join(config.env.projectFolder)
-    const backupDir = path.join(config.env.tempFolder, 'backupStarterFiles')
+    const projectDir = path.join(config.expose.projectFolder)
+    const backupDir = path.join(config.expose.tempFolder, 'backupStarterFiles')
 
     // Define the filter function
     const filter = (dir) => !dir.includes('node_modules') && !dir.includes('package-lock.json')
@@ -232,15 +232,15 @@ module.exports = function setupNodeEvents (on, config) {
 
   const restoreStarterFiles = async (remainingRetries = 4) => {
     try {
-      const tmpDir = path.join(config.env.projectFolder, '.tmp')
-      const appDir = path.join(config.env.projectFolder, 'app')
+      const tmpDir = path.join(config.expose.projectFolder, '.tmp')
+      const appDir = path.join(config.expose.projectFolder, 'app')
       const appViewsDir = path.join(appDir, 'views')
       const appDataDir = path.join(appDir, 'data')
       const appAssetsDir = path.join(appDir, 'assets')
       const appSassDir = path.join(appAssetsDir, 'sass')
       const appJSDir = path.join(appAssetsDir, 'javascripts')
-      const backupDir = path.join(config.env.tempFolder, 'backupStarterFiles')
-      const projectDir = path.join(config.env.projectFolder)
+      const backupDir = path.join(config.expose.tempFolder, 'backupStarterFiles')
+      const projectDir = path.join(config.expose.projectFolder)
 
       const originalPackageJsonHash = await getFileHash(path.join(backupDir, 'package.json'))
       const currentPackageJsonHash = await getFileHash(path.join(projectDir, 'package.json'))
@@ -259,7 +259,7 @@ module.exports = function setupNodeEvents (on, config) {
       if (originalPackageJsonHash !== currentPackageJsonHash) {
         log('Restoring to starter plugins')
         const command = 'npm prune && npm install'
-        await exec(command, { cwd: config.env.projectFolder })
+        await exec(command, { cwd: config.expose.projectFolder })
         await sleep(1000)
         // To allow for possible SASS recompilation, wait again
         await waitUntilAppRestarts()
@@ -292,7 +292,7 @@ module.exports = function setupNodeEvents (on, config) {
 
     copyFromStarterFiles: ({ starterFilename = undefined, filename }) => {
       const src = path.join(starterDir, starterFilename || filename)
-      const dest = path.join(config.env.projectFolder, filename)
+      const dest = path.join(config.expose.projectFolder, filename)
       return createFolderForFile(dest)
         .then(() => fsp.copyFile(src, dest))
         // The sleep of 2 seconds allows for the file to be copied completely to prevent
@@ -361,7 +361,7 @@ module.exports = function setupNodeEvents (on, config) {
 
     addToConfigJson: (additionalConfig) => {
       log(`Adding config JSON => ${downloadsFolder}`)
-      const appConfigPath = path.join(config.env.projectFolder, 'app', 'config.json')
+      const appConfigPath = path.join(config.expose.projectFolder, 'app', 'config.json')
       return fse.readJson(appConfigPath)
         .then(existingConfig => Object.assign({}, existingConfig, additionalConfig))
         .then(newConfig => fse.writeJson(appConfigPath, newConfig))

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
       "devDependencies": {
         "cheerio": "^1.2.0",
         "cross-env": "^7.0.3",
-        "cypress": "^13.6.5",
+        "cypress": "^16.0.0",
         "eslint-plugin-cypress": "^2.15.1",
         "eslint-plugin-jest": "^27.9.0",
         "extract-zip": "^2.0.1",
@@ -584,20 +584,10 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
     "node_modules/@cypress/request": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.10.tgz",
-      "integrity": "sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-4.0.1.tgz",
+      "integrity": "sha512-y20e+e6dFYkOUUJLVUZTsJRuTiXZaUQ32WD+R/ux/HBybbTx4ge7cNINcua0pU8+SNkKuRbOF12mBmzuzM8n5w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -614,14 +604,13 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "~6.14.1",
+        "qs": "^6.15.2",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^5.0.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^8.3.2"
+        "tunnel-agent": "^0.6.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.17.0"
       }
     },
     "node_modules/@cypress/request/node_modules/tough-cookie": {
@@ -1828,6 +1817,13 @@
       "integrity": "sha512-g7CK9nHdwjK2n0ymT2CW698FuWJRIx+RP6embAzZ2Qi8/ilIrA1Imt2LVSeHUzKvpoi7BhmmQcXz95eS0f2JXw==",
       "dev": true
     },
+    "node_modules/@types/tmp": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
@@ -2126,19 +2122,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -2230,9 +2213,9 @@
       }
     },
     "node_modules/arch": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
-      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-3.0.0.tgz",
+      "integrity": "sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q==",
       "dev": true,
       "funding": [
         {
@@ -2247,7 +2230,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/arg": {
       "version": "5.0.2",
@@ -2455,21 +2439,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
-      "dev": true
-    },
     "node_modules/async-each-series": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
@@ -2526,15 +2495,17 @@
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/aws4": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
-      "dev": true
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/axios": {
       "version": "1.18.1",
@@ -2993,23 +2964,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
-      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "es-define-property": "^1.0.1",
-        "side-channel": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/body-parser/node_modules/raw-body": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
@@ -3267,10 +3221,11 @@
       }
     },
     "node_modules/cachedir": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz",
-      "integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -3367,8 +3322,9 @@
     "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3481,6 +3437,49 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/chrome-remote-interface": {
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.33.3.tgz",
+      "integrity": "sha512-zNnn0prUL86Teru6UCAZ1yU1XeXljHl3gj7OrfPcarEfU62OUU4IujDPdTDW3dAWwRqN3ZMG/Chhkh2gPL/wiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "2.11.x",
+        "ws": "^7.2.0"
+      },
+      "bin": {
+        "chrome-remote-interface": "bin/client.js"
+      }
+    },
+    "node_modules/chrome-remote-interface/node_modules/commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chrome-remote-interface/node_modules/ws": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
@@ -3502,32 +3501,28 @@
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
     },
-    "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "restore-cursor": "^3.1.0"
+        "restore-cursor": "^5.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-table3": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
-      "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "string-width": "^4.2.0"
       },
@@ -3535,23 +3530,70 @@
         "node": "10.* || >= 12.*"
       },
       "optionalDependencies": {
-        "@colors/colors": "1.5.0"
+        "colors": "1.4.0"
       }
     },
     "node_modules/cli-truncate": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "slice-ansi": "^3.0.0",
-        "string-width": "^4.2.0"
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/cliui": {
@@ -3603,7 +3645,19 @@
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -3739,6 +3793,13 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -3870,42 +3931,39 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "13.6.5",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.6.5.tgz",
-      "integrity": "sha512-2NxSDcO2zHw5kTcosc6dzv2zppEqiXrFFhZw5cx/EWrSNZABTzpr/EyvYzGgrWm46o5173JUfuJfDQcaiZZPVQ==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-16.0.0.tgz",
+      "integrity": "sha512-/H3zsayGwIGboFIiLWaXxy6ADmCdWy5QjjDBZgslCvjIgYAf1DkZerwAM7wXMPSpfpQ4w+lGjFlmwneRBpg27g==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
-        "@cypress/request": "^3.0.0",
+        "@cypress/request": "^4.0.0",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
-        "arch": "^2.2.0",
+        "@types/tmp": "^0.2.3",
+        "arch": "^3.0.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
         "buffer": "^5.7.1",
-        "cachedir": "^2.3.0",
+        "cachedir": "^2.4.0",
         "chalk": "^4.1.0",
-        "check-more-types": "^2.24.0",
-        "cli-cursor": "^3.1.0",
-        "cli-table3": "~0.6.1",
+        "chrome-remote-interface": "0.33.3",
+        "ci-info": "^4.1.0",
+        "cli-table3": "0.6.1",
         "commander": "^6.2.1",
         "common-tags": "^1.8.0",
-        "dayjs": "^1.10.4",
+        "dayjs": "^1.11.23",
         "debug": "^4.3.4",
-        "enquirer": "^2.3.6",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",
         "executable": "^4.1.1",
-        "extract-zip": "2.0.1",
-        "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
-        "getos": "^3.2.1",
-        "is-ci": "^3.0.1",
+        "hasha": "5.2.2",
         "is-installed-globally": "~0.4.0",
-        "lazy-ass": "^1.6.0",
-        "listr2": "^3.8.3",
-        "lodash": "^4.17.21",
+        "listr2": "^9.0.5",
+        "lodash": "^4.17.23",
         "log-symbols": "^4.0.0",
         "minimist": "^1.2.8",
         "ospath": "^1.2.2",
@@ -3913,17 +3971,34 @@
         "process": "^0.11.10",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
-        "semver": "^7.5.3",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.1",
+        "systeminformation": "^5.31.1",
+        "tmp": "~0.2.4",
+        "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
-        "yauzl": "^2.10.0"
+        "yauzl": "^3.3.1"
       },
       "bin": {
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+        "node": "^22.0.0 || ^24.0.0 || >=26.0.0"
+      }
+    },
+    "node_modules/cypress/node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cypress/node_modules/commander": {
@@ -4038,6 +4113,19 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/cypress/node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -4120,10 +4208,11 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.9",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.9.tgz",
-      "integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA==",
-      "dev": true
+      "version": "1.11.23",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+      "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -4621,19 +4710,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/enquirer": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
-      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-colors": "^4.1.1",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/entities": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
@@ -4644,6 +4720,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/error-ex": {
@@ -4869,15 +4958,6 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "inBundle": true
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/escodegen": {
       "version": "2.0.0",
@@ -5899,26 +5979,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/express-session/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true
-    },
     "node_modules/express/node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -6119,22 +6179,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/express/node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/express/node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
@@ -6196,7 +6240,8 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
@@ -6323,21 +6368,6 @@
       "dev": true,
       "dependencies": {
         "pend": "~1.2.0"
-      }
-    },
-    "node_modules/figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-entry-cache": {
@@ -6467,6 +6497,7 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
@@ -6643,6 +6674,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -6735,15 +6779,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/getos": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
-      "integrity": "sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==",
-      "dev": true,
-      "dependencies": {
-        "async": "^3.2.0"
       }
     },
     "node_modules/getpass": {
@@ -6933,6 +6968,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasha": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hasha/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/hasown": {
@@ -7260,15 +7322,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -7418,18 +7471,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-ci": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-      "dev": true,
-      "dependencies": {
-        "ci-info": "^3.2.0"
-      },
-      "bin": {
-        "is-ci": "bin.js"
       }
     },
     "node_modules/is-core-module": {
@@ -7789,7 +7830,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
@@ -7875,7 +7917,8 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -8813,7 +8856,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -8930,30 +8974,113 @@
       "dev": true
     },
     "node_modules/listr2": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
-      "integrity": "sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "cli-truncate": "^2.1.0",
-        "colorette": "^2.0.16",
-        "log-update": "^4.0.0",
-        "p-map": "^4.0.0",
-        "rfdc": "^1.3.0",
-        "rxjs": "^7.5.1",
-        "through": "^2.3.8",
-        "wrap-ansi": "^7.0.0"
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
-      "peerDependencies": {
-        "enquirer": ">= 2.3.0 < 3"
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
-      "peerDependenciesMeta": {
-        "enquirer": {
-          "optional": true
-        }
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/load-json-file": {
@@ -9047,52 +9174,157 @@
       }
     },
     "node_modules/log-update": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
-      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-escapes": "^4.3.0",
-        "cli-cursor": "^3.1.0",
-        "slice-ansi": "^4.0.0",
-        "wrap-ansi": "^6.2.0"
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/log-update/node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
-    "node_modules/log-update/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/loose-envify": {
@@ -9253,6 +9485,19 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -9794,21 +10039,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "dev": true,
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -9978,7 +10208,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -10295,13 +10526,14 @@
       ]
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-      "dev": true,
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+      "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -10577,16 +10809,49 @@
       }
     },
     "node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/reusify": {
@@ -10600,10 +10865,11 @@
       }
     },
     "node_modules/rfdc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
-      "dev": true
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -10752,10 +11018,25 @@
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -11289,17 +11570,49 @@
       }
     },
     "node_modules/slice-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/socket.io": {
@@ -12005,6 +12318,33 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "node_modules/systeminformation": {
+      "version": "5.33.9",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.33.9.tgz",
+      "integrity": "sha512-mlE+h4IVAA4F4O6sc8NFpClFvsO6yjQ/uVKTq3kmruYqno2CenyDQhyOqRO7q5sl2FZie9c+R3E7pKOBKPDHCA==",
+      "dev": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32",
+        "freebsd",
+        "openbsd",
+        "netbsd",
+        "sunos",
+        "android"
+      ],
+      "bin": {
+        "systeminformation": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "funding": {
+        "type": "Buy me a coffee",
+        "url": "https://www.buymeacoffee.com/systeminfo"
+      }
+    },
     "node_modules/tar-stream": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.1.tgz",
@@ -12196,6 +12536,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -12261,6 +12611,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -12617,17 +12968,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.3",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz",
@@ -12665,13 +13005,6 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
-    },
-    "node_modules/verror/node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/version-guard": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   "devDependencies": {
     "cheerio": "^1.2.0",
     "cross-env": "^7.0.3",
-    "cypress": "^13.6.5",
+    "cypress": "^16.0.0",
     "eslint-plugin-cypress": "^2.15.1",
     "eslint-plugin-jest": "^27.9.0",
     "extract-zip": "^2.0.1",
@@ -122,5 +122,8 @@
       "/tmp/"
     ],
     "testTimeout": 5000
+  },
+  "allowScripts": {
+    "cypress@16.0.0": true
   }
 }


### PR DESCRIPTION
I [migrated from 13 to 14 to 15 to 16](https://github.com/alphagov/govuk-prototype-kit/pull/2624#issuecomment-5588557467).
14 and 15 I found no breaking changes that impacted us.
16 I found two `cy.exec` and `Cypress.env`...

In theory version 16 is supposed to be faster, it did seem much faster for the tests I tried locally, but I suspect at this point our bottleneck is the destroying and recreation of the app before running each test.

## Cypress.env
Since none of our variables used are sensitive we can use the new `expose` method.

Going forward anything sensitive must use the new `cy.env()` approach instead.

See https://docs.cypress.io/app/references/migration-guide#Migrating-away-from-Cypressenv

## cy.exec()
I think the idea with this is to avoid shell commands generally but:
- the project makes use of `cross-spawn` for doing some shell commands cross operating system
- the command run are meant to simulate a user doing CLI commands so it's appropriate to keep them as such

With this in mind, introduce a more generic exec task helper.

See https://docs.cypress.io/app/references/migration-guide#cyexec-removed