### PR TITLE
Remove unused download code from tests

### DIFF
--- a/cypress/events/index.js
+++ b/cypress/events/index.js
@@ -18,8 +18,6 @@ const path = require('path')
 
 // npm dependencies
 const waitOn = require('wait-on')
-const extract = require('extract-zip')
-const https = require('https')
 
 // local dependencies
 const { starterDir } = require('../../lib/utils/paths')
@@ -38,23 +36,6 @@ const createFolderForFile = async (filepath) => {
     })
   }
 }
-
-const validateExtractedVersion = async fullFilename => {
-  // Retrieve the name and version from the package.json from the extracted zip file
-  const extractFolder = path.resolve(fullFilename.substring(0, fullFilename.lastIndexOf('.zip')))
-  log(`validating extract => ${extractFolder}`)
-  const data = fs.readFileSync(path.join(extractFolder, 'package.json'))
-  const { name, version } = JSON.parse(data)
-  // Retrieve the directory name of the extracted files
-  const separator = (extractFolder.indexOf('/') > -1) ? '/' : '\\'
-  const dirname = extractFolder.substring(extractFolder.lastIndexOf(separator) + 1)
-  // Make sure they match
-  if (`${name}-${version}` !== dirname) {
-    throw new Error(`Extracted folder ${extractFolder} contains wrong version in package.json >> ${name}-${version}`)
-  }
-}
-
-const downloadsFolder = path.resolve('cypress', 'downloads')
 
 module.exports = function setupNodeEvents (on, config) {
   // `on` is used to hook into various events Cypress emits
@@ -135,48 +116,6 @@ module.exports = function setupNodeEvents (on, config) {
     .then(() => sleep(timeout))
     .catch((err) => err.code !== 'ENOENT' ? err : null
     )
-
-  const deleteFolder = (folder, timeout = 0) => fsp.rmdir(folder, { recursive: true })
-    .then(() => sleep(timeout))
-    .catch((err) => err.code !== 'ENOENT' ? err : null
-    )
-
-  const download = async (url, zipFile) => {
-    return new Promise((resolve, reject) => {
-      log(`downloading => ${url}`)
-      const request = https.get(url, response => {
-        if (response.statusCode === 200) {
-          const filename = path.join(downloadsFolder, zipFile)
-          log(`writing => ${filename}`)
-          const file = fs.createWriteStream(filename, { flags: 'wx' })
-          file.on('finish', () => resolve(filename))
-          file.on('error', (err) => {
-            file.close()
-            fs.unlink(downloadsFolder, () => {
-              log(`writing => ${filename} => ${err.message}`)
-              reject(err.message)
-            }) // Delete temp file
-          })
-          response.pipe(file)
-        } else if (response.statusCode === 302 || response.statusCode === 301) {
-          // Recursively follow redirects, only a 200 will resolve.
-          const { location } = response.headers
-          if (!zipFile && location.endsWith('.zip')) {
-            const uri = new URL(location)
-            zipFile = uri.pathname.split('/').pop()
-          }
-          return download(location, zipFile).then((filename) =>
-            resolve(filename))
-        } else {
-          reject(new Error(`Server responded with ${response.statusCode}: ${response.statusMessage}`))
-        }
-      })
-
-      request.on('error', err => {
-        reject(err.message)
-      })
-    })
-  }
 
   const getPathFromProjectRoot = (...all) => path.join(...[config.expose.projectFolder].concat(all))
   const pathToPackageFile = packageName => getPathFromProjectRoot('node_modules', packageName, 'package.json')
@@ -344,24 +283,9 @@ module.exports = function setupNodeEvents (on, config) {
       .then((text) => fsp.writeFile(filename, text.toString()))
       .then(makeSureCypressCanInterpretTheResult),
 
-    download: async ({ filename }) => {
-      log(`deleting folder => ${downloadsFolder}`)
-      return deleteFolder(downloadsFolder, 2000)
-        .then(() => fsp.mkdir(downloadsFolder, { recursive: true }))
-        .then(() => download(filename))
-        .then((fullFilename) => {
-          log(`extracting => ${fullFilename}`)
-          return extract(fullFilename, { dir: downloadsFolder })
-            .then(() => {
-              return validateExtractedVersion(fullFilename)
-            })
-        })
-        .then(makeSureCypressCanInterpretTheResult)
-    },
-
     addToConfigJson: (additionalConfig) => {
-      log(`Adding config JSON => ${downloadsFolder}`)
       const appConfigPath = path.join(config.expose.projectFolder, 'app', 'config.json')
+      log(`Adding config JSON => ${appConfigPath}`)
       return fse.readJson(appConfigPath)
         .then(existingConfig => Object.assign({}, existingConfig, additionalConfig))
         .then(newConfig => fse.writeJson(appConfigPath, newConfig))

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -65,22 +65,6 @@ Cypress.Commands.add('waitForResource', (name, options = {}) => {
   )
 })
 
-Cypress.Commands.add(
-  'download',
-  { prevSubject: true },
-  (subject) => {
-    return cy.get(subject)
-      .invoke('attr', 'href')
-      .then((filename) => {
-        cy.url().then((uri) => {
-          const url = new URL(uri)
-          cy.task('log', `Downloading ${url.origin}${filename}`)
-          cy.task('download', { filename: `${url.origin}${filename}` })
-        })
-      })
-  }
-)
-
 // ***********************************************
 // This example commands.js shows you how to
 // create various custom commands and overwrite

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,6 @@
         "cypress": "^16.0.0",
         "eslint-plugin-cypress": "^2.15.1",
         "eslint-plugin-jest": "^27.9.0",
-        "extract-zip": "^2.0.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "standard": "^17.1.2",
@@ -1855,16 +1854,6 @@
       "integrity": "sha512-5qcvofLPbfjmBfKaLfj/+f+Sbd6pN4zl7w7VSVI5uz7m9QZTuB2aZAa2uo1wHFBNN2x6g/SoTkXmd8mQnQF2Cw==",
       "dev": true
     },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.53.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.53.0.tgz",
@@ -3185,15 +3174,6 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -6243,49 +6223,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/extract-zip/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/extract-zip/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
     "node_modules/extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -6359,15 +6296,6 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-      "dev": true,
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -13356,16 +13284,6 @@
       "inBundle": true,
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-      "dev": true,
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "cypress": "^16.0.0",
     "eslint-plugin-cypress": "^2.15.1",
     "eslint-plugin-jest": "^27.9.0",
-    "extract-zip": "^2.0.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "standard": "^17.1.2",


### PR DESCRIPTION
It looks like the download task was previously used to download the kit from the docs website and check that it extracted to the expected version.

This was removed in e070684, but the Cypress download task that was only used in that test was missed.

Remove the download task, function and any other functions defined in the cypress/events/index.js that were only used as part of the download function.

Update a log statement in `addToConfigJson` which references the downloads folder in what I can only assume is a mistake – instead log out the path where the config will be written.

Uninstall extract-zip, which was only required for this task.