### PR TITLE
Remove `ansi-colors`

### DIFF
--- a/__tests__/spec/plugin-validator.js
+++ b/__tests__/spec/plugin-validator.js
@@ -3,7 +3,7 @@
 const path = require('path')
 const cliPath = path.join(__dirname, '..', '..', 'bin', 'cli')
 const { exec } = require('child_process')
-const ansiColors = require('ansi-colors')
+const { styleText } = require('node:util')
 
 function runShellCommand (fixtureDirectoryName) {
   const fixtureProjectDirectory = path.join(__dirname, '..', 'fixtures', 'mockPlugins', fixtureDirectoryName)
@@ -33,7 +33,7 @@ describe('plugin-validator', () => {
 Config file exists, validating contents.
 Validating whether config paths meet criteria.
 
-${ansiColors.green('The plugin config is valid.')}
+${styleText('green', 'The plugin config is valid.')}
 
 `)
   })
@@ -43,15 +43,15 @@ ${ansiColors.green('The plugin config is valid.')}
 
     expect(result.exitCode).toEqual(100)
     expect(result.stderr).toEqual(`
-${ansiColors.red('Error: In section sass, the path \'/sass/_step-by-step-navigation.scss\' does not exist')}
-${ansiColors.red('Error: In section sass, the path \'/sass/_step-by-step-navigation-header.scss\' does not exist')}
-${ansiColors.red('Error: In section sass, the path \'/sass/_step-by-step-navigation-related.scss\' does not exist')}
-${ansiColors.red('Error: In section scripts, the path \'javascripts/step-by-step-navigation.js\' does not start with a \'/\'')}
-${ansiColors.red('Error: In section scripts, the path \'javascripts/step-by-step-polyfills.js\' does not start with a \'/\'')}
-${ansiColors.red('Error: In section scripts, the path \'javascripts/modules/foo-module-one.js\' does not start with a \'/\'')}
-${ansiColors.red('Error: In section templates, the path \'/templates/step-by-step-navigation.html\' does not exist')}
-${ansiColors.red('Error: In section templates, the path \'/templates/start-with-step-by-step.html\' does not exist')}
-${ansiColors.red('Error: The nunjucks file \'za-bar.njk\' does not exist')}
+${styleText('red', 'Error: In section sass, the path \'/sass/_step-by-step-navigation.scss\' does not exist')}
+${styleText('red', 'Error: In section sass, the path \'/sass/_step-by-step-navigation-header.scss\' does not exist')}
+${styleText('red', 'Error: In section sass, the path \'/sass/_step-by-step-navigation-related.scss\' does not exist')}
+${styleText('red', 'Error: In section scripts, the path \'javascripts/step-by-step-navigation.js\' does not start with a \'/\'')}
+${styleText('red', 'Error: In section scripts, the path \'javascripts/step-by-step-polyfills.js\' does not start with a \'/\'')}
+${styleText('red', 'Error: In section scripts, the path \'javascripts/modules/foo-module-one.js\' does not start with a \'/\'')}
+${styleText('red', 'Error: In section templates, the path \'/templates/step-by-step-navigation.html\' does not exist')}
+${styleText('red', 'Error: In section templates, the path \'/templates/start-with-step-by-step.html\' does not exist')}
+${styleText('red', 'Error: The nunjucks file \'za-bar.njk\' does not exist')}
 
 `)
   })
@@ -61,7 +61,7 @@ ${ansiColors.red('Error: The nunjucks file \'za-bar.njk\' does not exist')}
 
     expect(result.exitCode).toEqual(100)
     expect(result.stderr).toEqual(`
-${ansiColors.red('Error: The following invalid keys exist in your config: scss,unknown-key')}
+${styleText('red', 'Error: The following invalid keys exist in your config: scss,unknown-key')}
 
 `)
   })
@@ -71,7 +71,7 @@ ${ansiColors.red('Error: The following invalid keys exist in your config: scss,u
 
     expect(result.exitCode).toEqual(100)
     expect(result.stderr).toEqual(`
-${ansiColors.red('Error: The plugin does not have a govuk-prototype-kit.config.json file, all plugins must have this file to be valid.')}
+${styleText('red', 'Error: The plugin does not have a govuk-prototype-kit.config.json file, all plugins must have this file to be valid.')}
 
 `)
   })
@@ -81,7 +81,7 @@ ${ansiColors.red('Error: The plugin does not have a govuk-prototype-kit.config.j
 
     expect(result.exitCode).toEqual(100)
     expect(result.stderr).toEqual(`
-${ansiColors.red('Error: Your govuk-prototype-kit.config.json file is not valid json.')}
+${styleText('red', 'Error: Your govuk-prototype-kit.config.json file is not valid json.')}
 
 `)
   })
@@ -91,7 +91,7 @@ ${ansiColors.red('Error: Your govuk-prototype-kit.config.json file is not valid 
 
     expect(result.exitCode).toEqual(100)
     expect(result.stderr).toEqual(`
-${ansiColors.red('Error: There are no contents in your govuk-prototype.config file!')}
+${styleText('red', 'Error: There are no contents in your govuk-prototype.config file!')}
 
 `)
   })

--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -3,7 +3,7 @@ const path = require('path')
 
 // npm dependencies
 const chokidar = require('chokidar')
-const colour = require('ansi-colors')
+const { styleText } = require('node:util')
 const fse = require('fs-extra')
 const nodemon = require('nodemon')
 let nodemonInstance
@@ -94,7 +94,7 @@ function runNodemon (port) {
   }
   // Warn about npm install on crash
   const onCrash = () => {
-    console.log(colour.cyan('[nodemon] For missing modules try running `npm install`'))
+    console.log(styleText('cyan', '[nodemon] For missing modules try running `npm install`'))
   }
 
   const onQuit = () => {

--- a/lib/plugins/plugin-validator.js
+++ b/lib/plugins/plugin-validator.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const path = require('path')
 
 const fse = require('fs-extra')
-const ansiColors = require('ansi-colors')
+const { styleText } = require('node:util')
 
 const errors = []
 
@@ -290,12 +290,12 @@ async function validatePlugin (executionPath, argv) {
   })
   if (!errors.length) {
     console.log()
-    console.log(ansiColors.green('The plugin config is valid.'))
+    console.log(styleText('green', 'The plugin config is valid.'))
     console.log()
   } else {
     process.exitCode = 100
     console.error()
-    errors.forEach(err => console.error(ansiColors.red(`Error: ${err}`)))
+    errors.forEach(err => console.error(styleText('red', `Error: ${err}`)))
     console.error()
   }
 }

--- a/lib/plugins/plugin-validator.spec.js
+++ b/lib/plugins/plugin-validator.spec.js
@@ -1,7 +1,7 @@
 const { validatePluginDependency, clearErrors, getErrors, validateMeta, validatePlugin } = require('./plugin-validator')
 const { mockFileSystem } = require('../../__tests__/utils/mock-file-system')
 const path = require('path')
-const ansiColors = require('ansi-colors')
+const { styleText } = require('node:util')
 
 describe('plugin-validator', () => {
   let testScope = {}
@@ -10,7 +10,7 @@ describe('plugin-validator', () => {
     'Config file exists, validating contents.',
     'Validating whether config paths meet criteria.'
   ]
-  const validSuccessMessages = phaseOneSuccessMessages.concat([ansiColors.green('The plugin config is valid.')])
+  const validSuccessMessages = phaseOneSuccessMessages.concat([styleText('green', 'The plugin config is valid.')])
 
   beforeEach(() => {
     // Polyfill process.exitCode property for Node.js < v20
@@ -61,7 +61,7 @@ describe('plugin-validator', () => {
         myExample: ['abc']
       }))
       await validatePlugin(testScope.mockFileSystemRoot)
-      expect(testScope.errLogs).toEqual([ansiColors.red('Error: The following invalid keys exist in your config: myExample')])
+      expect(testScope.errLogs).toEqual([styleText('red', 'Error: The following invalid keys exist in your config: myExample')])
       expect(testScope.stdLogs).toEqual(phaseOneSuccessMessages)
       expect(testScope.exitCodeSetterSpy).toHaveBeenCalledWith(100)
     })

--- a/lib/utils/errorModel.js
+++ b/lib/utils/errorModel.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const { verboseLog } = require('./verboseLogger')
 const { flagError } = require('../sync-changes')
-const { unstyle } = require('ansi-colors')
+const { stripVTControlCharacters: unstyle } = require('node:util')
 
 function getSourcecode (filePath, errorLineNumber, maxLines) {
   try {

--- a/migrator/reporter.js
+++ b/migrator/reporter.js
@@ -1,18 +1,18 @@
 // npm dependencies
-const c = require('ansi-colors')
+const { styleText } = require('node:util')
 
 // local dependencies
 const logger = require('./logger')
 
 async function reportSuccess (tag) {
   const message = `Succeeded [${tag}]`
-  console.log(c.green(message))
+  console.log(styleText('green', message))
   await logger.log(message)
 }
 
 async function reportFailure (tag, link) {
   const message = `Failed [${tag}]${link ? ` - documentation for the manual process is here: ${link}` : ''}`
-  console.warn(c.yellow(message))
+  console.warn(styleText('yellow', message))
   await logger.log(message)
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "govuk-prototype-kit",
       "version": "14.0.0-internal.2",
       "bundleDependencies": [
-        "ansi-colors",
         "browser-sync",
         "chokidar",
         "cookie-parser",
@@ -27,7 +26,6 @@
         "tar-stream"
       ],
       "dependencies": {
-        "ansi-colors": "^4.1.3",
         "browser-sync": "^3.0.2",
         "chokidar": "^3.6.0",
         "cookie-parser": "^1.4.6",
@@ -2126,15 +2124,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "inBundle": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/ansi-escapes": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "test": "npm run test:unit && npm run test:integration && npm run lint"
   },
   "dependencies": {
-    "ansi-colors": "^4.1.3",
     "browser-sync": "^3.0.2",
     "chokidar": "^3.6.0",
     "cookie-parser": "^1.4.6",


### PR DESCRIPTION
Since Node 20, we have access to [`util.styleText`](https://nodejs.org/api/util.html#utilstyletextformat-text-options).

And [`stripVTControlCharacters`](https://nodejs.org/api/util.html#utilstripvtcontrolcharactersstr) in Node 16.

Replace `ansi-colors` with these built-in methods.