### PR TITLE
Add license to lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "semver",
         "tar-stream"
       ],
+      "license": "MIT",
       "dependencies": {
         "browser-sync": "^3.0.2",
         "chokidar": "^3.6.0",


### PR DESCRIPTION
This happens automatically after running `npm install` since 06f2814.

Commit the change so that there are no longer changes to the lockfile when running `npm install`.