### PR TITLE
[SPIKE] Test pinning transitive deps with overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,42 +7,24 @@
     "": {
       "name": "govuk-prototype-kit",
       "version": "14.0.0-internal.2",
-      "bundleDependencies": [
-        "browser-sync",
-        "chokidar",
-        "cookie-parser",
-        "cross-spawn",
-        "csrf-csrf",
-        "express",
-        "express-session",
-        "fs-extra",
-        "govuk-frontend",
-        "lodash",
-        "nodemon",
-        "nunjucks",
-        "portscanner",
-        "sass",
-        "semver",
-        "tar-stream"
-      ],
       "license": "MIT",
       "dependencies": {
-        "browser-sync": "^3.0.2",
-        "chokidar": "^3.6.0",
-        "cookie-parser": "^1.4.6",
-        "cross-spawn": "^7.0.3",
-        "csrf-csrf": "^4.0.3",
-        "express": "^5.2.1",
-        "express-session": "^1.19.0",
-        "fs-extra": "^11.4.0",
+        "browser-sync": "3.0.4",
+        "chokidar": "3.6.0",
+        "cookie-parser": "1.4.7",
+        "cross-spawn": "7.0.6",
+        "csrf-csrf": "4.0.3",
+        "express": "5.2.1",
+        "express-session": "1.19.0",
+        "fs-extra": "11.4.0",
         "govuk-frontend": "5.11.0",
-        "lodash": "^4.17.23",
-        "nodemon": "^3.1.14",
-        "nunjucks": "^3.2.4",
-        "portscanner": "^2.2.0",
-        "sass": "^1.103.1",
-        "semver": "^7.8.5",
-        "tar-stream": "^3.2.1"
+        "lodash": "4.18.1",
+        "nodemon": "3.1.14",
+        "nunjucks": "3.2.4",
+        "portscanner": "2.2.0",
+        "sass": "1.103.1",
+        "semver": "7.8.5",
+        "tar-stream": "3.2.1"
       },
       "bin": {
         "govuk-prototype-kit": "bin/cli"
@@ -1767,7 +1749,6 @@
       "integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
       "devOptional": true,
       "hasInstallScript": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "detect-libc": "^2.0.3",
@@ -1804,7 +1785,6 @@
       "cpu": [
         "arm64"
       ],
-      "inBundle": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1825,7 +1805,6 @@
       "cpu": [
         "arm64"
       ],
-      "inBundle": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1846,7 +1825,6 @@
       "cpu": [
         "x64"
       ],
-      "inBundle": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1867,7 +1845,6 @@
       "cpu": [
         "x64"
       ],
-      "inBundle": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1888,7 +1865,6 @@
       "cpu": [
         "arm"
       ],
-      "inBundle": true,
       "libc": [
         "glibc"
       ],
@@ -1912,7 +1888,6 @@
       "cpu": [
         "arm"
       ],
-      "inBundle": true,
       "libc": [
         "musl"
       ],
@@ -1936,7 +1911,6 @@
       "cpu": [
         "arm64"
       ],
-      "inBundle": true,
       "libc": [
         "glibc"
       ],
@@ -1960,7 +1934,6 @@
       "cpu": [
         "arm64"
       ],
-      "inBundle": true,
       "libc": [
         "musl"
       ],
@@ -1984,7 +1957,6 @@
       "cpu": [
         "x64"
       ],
-      "inBundle": true,
       "libc": [
         "glibc"
       ],
@@ -2008,7 +1980,6 @@
       "cpu": [
         "x64"
       ],
-      "inBundle": true,
       "libc": [
         "musl"
       ],
@@ -2032,7 +2003,6 @@
       "cpu": [
         "arm64"
       ],
-      "inBundle": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2053,7 +2023,6 @@
       "cpu": [
         "x64"
       ],
-      "inBundle": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2072,7 +2041,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
       "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "devOptional": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2135,8 +2103,7 @@
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
-      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
-      "inBundle": true
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -2205,7 +2172,6 @@
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
       "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -2266,7 +2232,6 @@
       "version": "22.17.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.2.tgz",
       "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2315,7 +2280,6 @@
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -2836,20 +2800,17 @@
     "node_modules/a-sync-waterfall": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
-      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
-      "inBundle": true
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "inBundle": true
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "inBundle": true,
       "dependencies": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
@@ -2964,7 +2925,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "inBundle": true,
       "engines": {
         "node": ">=8"
       }
@@ -2973,7 +2933,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "inBundle": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2988,7 +2947,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -3203,8 +3161,7 @@
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "inBundle": true
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "node_modules/asn1": {
       "version": "0.2.6",
@@ -3230,7 +3187,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
       "integrity": "sha512-p4jj6Fws4Iy2m0iCmI2am2ZNZCgbdgE+P8F/8csmn2vx7ixXrO2zGcuNsD46X5uZSVecmkEy/M06X2vG8KD6dQ==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -3321,7 +3277,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
       "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-      "inBundle": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -3434,14 +3389,12 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "inBundle": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/bare-events": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.2.tgz",
       "integrity": "sha512-AIPKioV7/Y/8KfZ3AAhjPJxLLbY49S64Ym5DakZlUg75qQiTgUq9hEJoEwa4eUezPUlXRy/i5NpsKvo9jgKmoA==",
-      "inBundle": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "bare-abort-controller": "*"
@@ -3456,7 +3409,6 @@
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.8.1.tgz",
       "integrity": "sha512-N1nnXdHZAOSstz0XiHikGS4HGMH4CnSwhqWdGQQMqqdvp4Jybm9sE3R1WVnpWVd4SFkc8ryPDBLViNLwiEqECg==",
-      "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -3481,14 +3433,12 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.2.tgz",
       "integrity": "sha512-ZyKbsuuqK6Ag0K8pX6V5Txq6XeJRvY+wXucnFGRjiyVYP9YWDpIQugk/b+enRYrEYBJaqLzghRQpXPMR7341Nw==",
-      "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/bare-stream": {
       "version": "2.13.4",
       "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.4.tgz",
       "integrity": "sha512-PcrQ8lVLbiJscNm1Kez+Yp4Gy4AHGcN1lzwjvf5NybWen7VvEgUfyfnXYJ2zNqWnzOfCb1Abq6lH8ti0syQszA==",
-      "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.8.1",
@@ -3516,7 +3466,6 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.5.2.tgz",
       "integrity": "sha512-L13PCJzKG8RGvx8V1/DdMi12ERhC3tprr7/8a94BxpmnRsFqxh5XZNdhtMxu5HPkRshYOOWRGY8lDP7ZhpG9Cg==",
-      "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0"
@@ -3546,7 +3495,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
       "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": "^4.5.0 || >= 5.9"
@@ -3568,8 +3516,7 @@
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
-      "inBundle": true
+      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -3585,7 +3532,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "inBundle": true,
       "engines": {
         "node": ">=8"
       }
@@ -3606,7 +3552,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -3631,7 +3576,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
       "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3645,7 +3589,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3663,7 +3606,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3673,7 +3615,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -3694,7 +3635,6 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -3711,21 +3651,18 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "inBundle": true,
       "license": "ISC"
     },
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/body-parser/node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -3738,7 +3675,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -3754,7 +3690,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3770,7 +3705,6 @@
       "version": "1.1.18",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
       "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3781,7 +3715,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -3794,7 +3727,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-3.0.4.tgz",
       "integrity": "sha512-mcYOIy4BW6sWSEnTSBjQwWsnbx2btZX78ajTTjdNfyC/EqQVcIe0nQR6894RNAMtvlfAnLaH9L2ka97zpvgenA==",
-      "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "browser-sync-client": "^3.0.4",
@@ -3837,7 +3769,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-3.0.4.tgz",
       "integrity": "sha512-+ew5ubXzGRKVjquBL3u6najS40TG7GxCdyBll0qSRc/n+JRV9gb/yDdRL1IAgRHqjnJTdqeBKKIQabjvjRSYRQ==",
-      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "etag": "1.8.1",
@@ -3852,7 +3783,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-3.0.4.tgz",
       "integrity": "sha512-5Po3YARCZ/8yQHFzvrSjn8+hBUF7ZWac39SHsy8Tls+7tE62iq6pYWxpVU6aOOMAGD21RwFQhQeqmJPf70kHEQ==",
-      "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "async-each-series": "0.1.1",
@@ -3868,7 +3798,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
       "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
-      "inBundle": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^3.0.0",
@@ -3879,7 +3808,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
       "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
-      "inBundle": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3921,8 +3849,7 @@
     "node_modules/bs-recipes": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
-      "integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU=",
-      "inBundle": true
+      "integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU="
     },
     "node_modules/bser": {
       "version": "2.1.1",
@@ -3971,7 +3898,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "inBundle": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -4009,7 +3935,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4023,7 +3948,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4087,7 +4011,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "inBundle": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4165,7 +4088,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "inBundle": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -4350,7 +4272,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -4383,7 +4304,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "inBundle": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4394,8 +4314,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "inBundle": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -4431,7 +4350,6 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/common-tags": {
@@ -4456,14 +4374,12 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "inBundle": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/connect": {
       "version": "3.6.6",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
       "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
-      "inBundle": true,
       "dependencies": {
         "debug": "2.6.9",
         "finalhandler": "1.1.0",
@@ -4478,7 +4394,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
       "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
@@ -4488,7 +4403,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4502,7 +4416,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4519,7 +4432,6 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4529,7 +4441,6 @@
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
       "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "cookie": "0.7.2",
@@ -4542,8 +4453,7 @@
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-      "inBundle": true
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "node_modules/cookiejar": {
       "version": "2.1.4",
@@ -4563,7 +4473,6 @@
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -4595,7 +4504,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4610,7 +4518,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/csrf-csrf/-/csrf-csrf-4.0.3.tgz",
       "integrity": "sha512-DaygOzelL4Qo1pHwI9LPyZL+X2456/OzpT596kNeZGiTSqKVDOk/9PPJ+FjzZacjMUEusOHw3WJKe1RW4iUhrw==",
-      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "http-errors": "^2.0.0"
@@ -4930,7 +4837,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "inBundle": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -5021,7 +4927,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-      "inBundle": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5030,7 +4935,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8",
@@ -5042,7 +4946,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "devOptional": true,
-      "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5062,7 +4965,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
       "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA=",
-      "inBundle": true,
       "bin": {
         "dev-ip": "lib/dev-ip.js"
       },
@@ -5165,7 +5067,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -5187,7 +5088,6 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.4.tgz",
       "integrity": "sha512-8cAwm6md1YTiPpOvDULYJL4ZS6WfM5/cTeVVh4JsvyYZAoqlRVUpHL9Gr5Fy7HA6xcSZicUia3DeAgO3Us8E+Q==",
-      "inBundle": true,
       "dependencies": {
         "lodash": "^4.17.10"
       },
@@ -5199,7 +5099,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-4.1.0.tgz",
       "integrity": "sha512-+mn7lRm+Zf1UT/YaH8WXtpU6PIV2iOjzP6jgKoiaq/VNrjYKp+OHZGe2znaLgDeFkw8cL9ffuaUm+nNnzcYyGw==",
-      "inBundle": true,
       "dependencies": {
         "chalk": "4.1.2"
       },
@@ -5221,8 +5120,7 @@
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "inBundle": true
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.425",
@@ -5247,14 +5145,12 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "inBundle": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-      "inBundle": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5299,7 +5195,6 @@
       "version": "6.6.9",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
       "integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.12",
@@ -5321,7 +5216,6 @@
       "version": "6.6.6",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
       "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -5335,7 +5229,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5353,14 +5246,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
       "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -5370,7 +5261,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5388,7 +5278,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/entities": {
@@ -5517,7 +5406,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5527,7 +5415,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5572,7 +5459,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -5635,7 +5521,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5644,8 +5529,7 @@
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "inBundle": true
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "node_modules/escape-string-regexp": {
       "version": "2.0.0",
@@ -6408,7 +6292,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-      "inBundle": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6422,14 +6305,12 @@
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "inBundle": true
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "node_modules/events-universal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
       "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
-      "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
@@ -6514,7 +6395,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
@@ -6558,7 +6438,6 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
       "integrity": "sha512-0csaMkGq+vaiZTmSMMGkfdCOabYv192VbytFypcvI0MANrp+4i/7yEkJ0sbAEhycQjntaKGzYfjfXQyVb7BHMA==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "cookie": "~0.7.2",
@@ -6581,14 +6460,12 @@
     "node_modules/express-session/node_modules/cookie-signature": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "inBundle": true
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="
     },
     "node_modules/express-session/node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "inBundle": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -6597,7 +6474,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -6611,7 +6487,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
@@ -6621,7 +6496,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6639,7 +6513,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6649,7 +6522,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6659,7 +6531,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -6681,7 +6552,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6691,7 +6561,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -6712,14 +6581,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "inBundle": true,
       "license": "ISC"
     },
     "node_modules/express/node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6729,7 +6596,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -6746,14 +6612,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/express/node_modules/negotiator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
       "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "content-type": "^2.1.0"
@@ -6770,7 +6634,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
       "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6784,7 +6647,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -6797,7 +6659,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -6824,7 +6685,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -6844,7 +6704,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6877,7 +6736,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -6950,7 +6808,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -6963,7 +6820,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
       "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
-      "inBundle": true,
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.1",
@@ -6981,7 +6837,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-      "inBundle": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -7030,7 +6885,6 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
@@ -7136,7 +6990,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "inBundle": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -7145,7 +6998,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-      "inBundle": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -7154,7 +7006,6 @@
       "version": "11.4.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
       "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -7169,7 +7020,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "inBundle": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -7185,7 +7035,6 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "hasInstallScript": true,
-      "inBundle": true,
       "optional": true,
       "os": [
         "darwin"
@@ -7198,7 +7047,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "inBundle": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7261,7 +7109,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "inBundle": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -7283,7 +7130,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7318,7 +7164,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -7406,7 +7251,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "inBundle": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -7509,7 +7353,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7522,7 +7365,6 @@
       "version": "5.11.0",
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.0.tgz",
       "integrity": "sha512-RYZDEF1J6nVw5XauQGH+91qplExgHUXfXII7dtIme6I4u3eSvU59yZ0/EFKEwRgTslSqlhJODOnAi5rnQFU5Gw==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
@@ -7532,7 +7374,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "inBundle": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -7558,7 +7399,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "inBundle": true,
       "engines": {
         "node": ">=4"
       }
@@ -7596,7 +7436,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7652,7 +7491,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -7718,7 +7556,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "inBundle": true,
       "dependencies": {
         "depd": "2.0.0",
         "inherits": "2.0.4",
@@ -7734,7 +7571,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "inBundle": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -7742,14 +7578,12 @@
     "node_modules/http-errors/node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "inBundle": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/http-errors/node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "inBundle": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -7758,7 +7592,6 @@
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
       "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "inBundle": true,
       "dependencies": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
@@ -7881,7 +7714,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "inBundle": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -7921,14 +7753,12 @@
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
-      "inBundle": true
+      "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk="
     },
     "node_modules/immutable": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.4.tgz",
-      "integrity": "sha512-ZQv17KolYrYmsDoDB8N67zhIKsNi9mGYlk96y/yuxyAqJB2hLzSGSM7k/sB0/ZvO4kx27U9+fBeD/XlLGh/uXQ==",
-      "inBundle": true,
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz",
+      "integrity": "sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8001,8 +7831,7 @@
     "node_modules/inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "inBundle": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "node_modules/ini": {
       "version": "2.0.0",
@@ -8032,7 +7861,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "inBundle": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -8101,7 +7929,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "inBundle": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -8210,7 +8037,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8235,7 +8061,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "inBundle": true,
       "engines": {
         "node": ">=8"
       }
@@ -8274,7 +8099,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "inBundle": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -8328,7 +8152,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -8338,7 +8161,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
       "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
-      "inBundle": true,
       "dependencies": {
         "lodash.isfinite": "^3.3.2"
       }
@@ -8380,7 +8202,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/is-regex": {
@@ -8563,7 +8384,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-      "inBundle": true,
       "engines": {
         "node": ">=4"
       }
@@ -8578,8 +8398,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "inBundle": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "node_modules/isstream": {
       "version": "0.1.2",
@@ -9642,7 +9461,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "inBundle": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -9654,7 +9472,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "inBundle": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -9724,8 +9541,7 @@
     "node_modules/limiter": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
-      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==",
-      "inBundle": true
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -9898,14 +9714,12 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/lodash.isfinite": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
-      "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M=",
-      "inBundle": true
+      "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -10131,7 +9945,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10141,7 +9954,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
       "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -10155,7 +9967,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10193,7 +10004,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -10207,7 +10017,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "inBundle": true,
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
@@ -10220,7 +10029,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "inBundle": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -10229,7 +10037,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "inBundle": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -10263,7 +10070,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -10295,14 +10101,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
       "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==",
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "inBundle": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
@@ -10330,7 +10134,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "inBundle": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -10340,7 +10143,6 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "devOptional": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-exports-info": {
@@ -10393,7 +10195,6 @@
       "version": "3.1.14",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
       "integrity": "sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.2",
@@ -10422,7 +10223,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -10432,7 +10232,6 @@
       "version": "5.0.9",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
       "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -10445,7 +10244,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "inBundle": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -10462,7 +10260,6 @@
       "version": "10.2.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
       "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.8"
@@ -10477,14 +10274,12 @@
     "node_modules/nodemon/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "inBundle": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nodemon/node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "inBundle": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -10496,7 +10291,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-      "inBundle": true,
       "dependencies": {
         "abbrev": "1"
       },
@@ -10511,7 +10305,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10544,7 +10337,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
       "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
-      "inBundle": true,
       "dependencies": {
         "a-sync-waterfall": "^1.0.0",
         "asap": "^2.0.3",
@@ -10569,7 +10361,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-      "inBundle": true,
       "engines": {
         "node": ">= 6"
       }
@@ -10585,7 +10376,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10594,7 +10384,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10703,7 +10492,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "inBundle": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -10715,7 +10503,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
       "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -10725,7 +10512,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "inBundle": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -10749,7 +10535,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
       "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
-      "inBundle": true,
       "dependencies": {
         "is-wsl": "^1.1.0"
       },
@@ -10926,7 +10711,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "inBundle": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -10953,7 +10737,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "inBundle": true,
       "engines": {
         "node": ">=8"
       }
@@ -10995,7 +10778,6 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "inBundle": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -11035,7 +10817,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -11144,7 +10925,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
       "integrity": "sha512-IFroCz/59Lqa2uBvzK3bKDbDDIEaAY8XJ1jFxcLWTqosrsc32//P4VuSB2vZXoHiHqOmx8B5L5hnKOxL/7FlPw==",
-      "inBundle": true,
       "dependencies": {
         "async": "^2.6.0",
         "is-number-like": "^1.0.3"
@@ -11158,7 +10938,6 @@
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
       "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "inBundle": true,
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -11247,7 +11026,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "inBundle": true,
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -11265,8 +11043,7 @@
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
-      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
-      "inBundle": true
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -11309,7 +11086,6 @@
       "version": "6.16.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
       "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
-      "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",
@@ -11346,7 +11122,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
       "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs=",
-      "inBundle": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -11355,7 +11130,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "inBundle": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -11364,7 +11138,6 @@
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
       "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -11380,7 +11153,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -11390,7 +11162,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -11411,14 +11182,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "inBundle": true,
       "license": "ISC"
     },
     "node_modules/raw-body/node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -11434,7 +11203,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "inBundle": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -11511,7 +11279,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11519,8 +11286,7 @@
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "inBundle": true
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -11566,7 +11332,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
       "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
-      "inBundle": true,
       "dependencies": {
         "debug": "^2.2.0",
         "minimatch": "^3.0.2"
@@ -11677,7 +11442,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -11694,7 +11458,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -11712,7 +11475,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -11722,7 +11484,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/rrweb-cssom": {
@@ -11758,8 +11519,7 @@
     "node_modules/rx": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
-      "inBundle": true
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
@@ -11809,7 +11569,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/safe-push-apply": {
@@ -11850,14 +11609,12 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "inBundle": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
       "version": "1.103.1",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.103.1.tgz",
       "integrity": "sha512-9icZURbP51S6S0QGoyaeqk9uB06GNWxsFYWfH5RgpFgqK5FA8tJcM3AdVxrZEVJ7dz+L87nG95gBKf4VuaMHGw==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -11878,7 +11635,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^5.0.0"
@@ -11894,14 +11650,12 @@
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
       "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/sass/node_modules/readdirp": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
       "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -11928,7 +11682,6 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "inBundle": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -11941,7 +11694,6 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.1.tgz",
       "integrity": "sha512-p4rRk4f23ynFEfcD9LA0xRYngj+IyGiEYyqqOak8kaN0TvNmuxC2dcVeBn62GpCeR2CpWqyHCNScTP91QbAVFg==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -11966,7 +11718,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -11976,7 +11727,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -11986,14 +11736,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/send/node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -12006,7 +11754,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -12016,7 +11763,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
-      "inBundle": true,
       "dependencies": {
         "accepts": "~1.3.4",
         "batch": "0.6.1",
@@ -12034,7 +11780,6 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-      "inBundle": true,
       "dependencies": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -12048,14 +11793,12 @@
     "node_modules/serve-index/node_modules/setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-      "inBundle": true
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "node_modules/serve-static": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
       "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "~2.0.0",
@@ -12071,7 +11814,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -12081,7 +11823,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -12091,14 +11832,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/serve-static/node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -12111,7 +11850,6 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
       "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -12136,7 +11874,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -12146,7 +11883,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -12156,7 +11892,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
       "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
-      "inBundle": true,
       "license": "ISC"
     },
     "node_modules/set-function-length": {
@@ -12211,14 +11946,12 @@
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "inBundle": true
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "inBundle": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -12230,7 +11963,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "inBundle": true,
       "engines": {
         "node": ">=8"
       }
@@ -12239,7 +11971,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -12259,7 +11990,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -12276,7 +12006,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -12295,7 +12024,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -12321,7 +12049,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
       "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
-      "inBundle": true,
       "dependencies": {
         "semver": "^7.5.3"
       },
@@ -12388,7 +12115,6 @@
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
       "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.4",
@@ -12407,7 +12133,6 @@
       "version": "2.5.8",
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
       "integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "debug": "~4.4.1",
@@ -12418,7 +12143,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -12436,14 +12160,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/socket.io-client": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
       "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -12459,7 +12181,6 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -12477,14 +12198,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/socket.io-parser": {
       "version": "4.2.7",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
       "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -12498,7 +12217,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -12516,14 +12234,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/socket.io/node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "inBundle": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -12539,14 +12255,12 @@
     "node_modules/socket.io/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "inBundle": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "inBundle": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12718,7 +12432,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-      "inBundle": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -12741,7 +12454,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
       "integrity": "sha512-889+B9vN9dq7/vLbGyuHeZ6/ctf5sNuGWsDy89uNxkFTAgzy0eK7+w5fL3KLNRTkLle7EgZGvHUphZW0Q26MnQ==",
-      "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "commander": "^2.2.0",
@@ -12758,7 +12470,6 @@
       "version": "2.28.1",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.1.tgz",
       "integrity": "sha512-zEzXb0s5Cds7tqMH6rhZ05lcJydCWiQPEwiNngVqzsxCc962vLY4Uw+mW7od8kDH258k2Uz/JrOkdIAAhSh9VA==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
@@ -12784,7 +12495,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "inBundle": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -12913,7 +12623,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "inBundle": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -13054,7 +12763,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "inBundle": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -13066,7 +12774,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "inBundle": true,
       "engines": {
         "node": ">=8"
       }
@@ -13137,7 +12844,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.1.tgz",
       "integrity": "sha512-nqsEO8zLZJvrOMdEwkA0QdCLFbetHMn95Zqu4fKwX+hkaTWJPZZOrxx/PwtxoK0MMGQmBQNRW3CPs8IFYQz4cQ==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
@@ -13150,7 +12856,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
       "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "streamx": "^2.12.5"
@@ -13293,7 +12998,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
       "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
-      "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
@@ -13345,7 +13049,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -13358,7 +13061,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "inBundle": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -13367,7 +13069,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
       "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
-      "inBundle": true,
       "dependencies": {
         "nopt": "~1.0.10"
       },
@@ -13528,7 +13229,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "content-type": "^2.0.0",
@@ -13547,7 +13247,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
       "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -13561,7 +13260,6 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -13571,7 +13269,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -13690,7 +13387,6 @@
           "url": "https://paypal.me/faisalman"
         }
       ],
-      "inBundle": true,
       "engines": {
         "node": "*"
       }
@@ -13699,7 +13395,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
       "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
-      "inBundle": true,
       "dependencies": {
         "random-bytes": "~1.0.0"
       },
@@ -13729,8 +13424,7 @@
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
-      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
-      "inBundle": true
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA=="
     },
     "node_modules/undici": {
       "version": "7.29.0",
@@ -13746,14 +13440,12 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "inBundle": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -13762,7 +13454,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-      "inBundle": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -13858,7 +13549,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-      "inBundle": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -13882,7 +13572,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-      "inBundle": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -14009,7 +13698,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "inBundle": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -14113,7 +13801,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -14149,8 +13836,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "inBundle": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/write-file-atomic": {
       "version": "5.0.1",
@@ -14183,7 +13869,6 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -14232,7 +13917,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
       "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
-      "inBundle": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -14241,7 +13925,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "inBundle": true,
       "engines": {
         "node": ">=10"
       }
@@ -14257,7 +13940,6 @@
       "version": "17.7.3",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
       "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -14276,7 +13958,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "inBundle": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "server.js",
     "start.js"
   ],
-  "bundleDependencies": true,
   "scripts": {
     "tmp-kit": "mkdir -p $TMPDIR/govuk-prototype-kit-playground && cd $TMPDIR/govuk-prototype-kit-playground && rm -Rf ./* && govuk-prototype-kit create --version local . && npm run dev",
     "start": "echo 'This project cannot be started, in order to test this project please create a prototype kit using the cli.'",
@@ -73,22 +72,22 @@
     "test": "npm run test:unit && npm run test:integration && npm run lint"
   },
   "dependencies": {
-    "browser-sync": "^3.0.2",
-    "chokidar": "^3.6.0",
-    "cookie-parser": "^1.4.6",
-    "cross-spawn": "^7.0.3",
-    "csrf-csrf": "^4.0.3",
-    "express": "^5.2.1",
-    "express-session": "^1.19.0",
-    "fs-extra": "^11.4.0",
+    "browser-sync": "3.0.4",
+    "chokidar": "3.6.0",
+    "cookie-parser": "1.4.7",
+    "cross-spawn": "7.0.6",
+    "csrf-csrf": "4.0.3",
+    "express": "5.2.1",
+    "express-session": "1.19.0",
+    "fs-extra": "11.4.0",
     "govuk-frontend": "5.11.0",
-    "lodash": "^4.17.23",
-    "nodemon": "^3.1.14",
-    "nunjucks": "^3.2.4",
-    "portscanner": "^2.2.0",
-    "sass": "^1.103.1",
-    "semver": "^7.8.5",
-    "tar-stream": "^3.2.1"
+    "lodash": "4.18.1",
+    "nodemon": "3.1.14",
+    "nunjucks": "3.2.4",
+    "portscanner": "2.2.0",
+    "sass": "1.103.1",
+    "semver": "7.8.5",
+    "tar-stream": "3.2.1"
   },
   "devDependencies": {
     "cheerio": "^1.2.0",
@@ -130,5 +129,649 @@
   },
   "allowScripts": {
     "cypress@16.0.0": true
+  },
+  "overrides": {
+    "browser-sync@3.0.4": {
+      "browser-sync-client": "3.0.4",
+      "browser-sync-client@3.0.4": {
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "mitt": "1.2.0"
+      },
+      "browser-sync-ui": "3.0.4",
+      "browser-sync-ui@3.0.4": {
+        "async-each-series": "0.1.1",
+        "chalk": "4.1.2",
+        "connect-history-api-fallback": "1.6.0",
+        "immutable": "3.8.3",
+        "server-destroy": "1.0.1",
+        "socket.io-client": "4.8.1",
+        "socket.io-client@4.8.1": {
+          "@socket.io/component-emitter": "3.1.0",
+          "debug": "4.3.7",
+          "debug@4.3.7": {
+            "ms": "2.1.3"
+          },
+          "engine.io-client": "6.6.6",
+          "engine.io-client@6.6.6": {
+            "@socket.io/component-emitter": "3.1.0",
+            "debug": "4.4.3",
+            "debug@4.4.3": {
+              "ms": "2.1.3"
+            },
+            "engine.io-parser": "5.2.3",
+            "ws": "8.21.0",
+            "xmlhttprequest-ssl": "2.1.2"
+          },
+          "socket.io-parser": "4.2.7"
+        },
+        "stream-throttle": "0.1.3",
+        "stream-throttle@0.1.3": {
+          "commander": "2.20.3",
+          "limiter": "1.1.5"
+        }
+      },
+      "bs-recipes": "1.3.4",
+      "chalk": "4.1.2",
+      "chalk@4.1.2": {
+        "ansi-styles": "4.3.0",
+        "ansi-styles@4.3.0": {
+          "color-convert": "2.0.1",
+          "color-convert@2.0.1": {
+            "color-name": "1.1.4"
+          }
+        },
+        "supports-color": "7.2.0",
+        "supports-color@7.2.0": {
+          "has-flag": "4.0.0"
+        }
+      },
+      "chokidar": "3.6.0",
+      "connect-history-api-fallback": "1.6.0",
+      "connect": "3.6.6",
+      "connect@3.6.6": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.0",
+        "finalhandler@1.1.0": {
+          "debug": "2.6.9",
+          "encodeurl": "1.0.2",
+          "escape-html": "1.0.3",
+          "on-finished": "2.3.0",
+          "on-finished@2.3.0": {
+            "ee-first": "1.1.1"
+          },
+          "parseurl": "1.3.3",
+          "statuses": "1.3.1",
+          "unpipe": "1.0.0"
+        },
+        "parseurl": "1.3.3",
+        "utils-merge": "1.0.1"
+      },
+      "dev-ip": "1.0.1",
+      "easy-extender": "2.3.4",
+      "easy-extender@2.3.4": {
+        "lodash": "4.18.1"
+      },
+      "eazy-logger": "4.1.0",
+      "eazy-logger@4.1.0": {
+        "chalk": "4.1.2"
+      },
+      "etag": "1.8.1",
+      "fresh": "0.5.2",
+      "fs-extra": "3.0.1",
+      "fs-extra@3.0.1": {
+        "graceful-fs": "4.2.11",
+        "jsonfile": "3.0.1",
+        "jsonfile@3.0.1": {
+          "graceful-fs": "4.2.11"
+        },
+        "universalify": "0.1.2"
+      },
+      "http-proxy": "1.18.1",
+      "http-proxy@1.18.1": {
+        "eventemitter3": "4.0.7",
+        "follow-redirects": "1.16.0",
+        "requires-port": "1.0.0"
+      },
+      "immutable": "3.8.3",
+      "micromatch": "4.0.8",
+      "micromatch@4.0.8": {
+        "braces": "3.0.3",
+        "picomatch": "2.3.2"
+      },
+      "opn": "5.3.0",
+      "opn@5.3.0": {
+        "is-wsl": "1.1.0"
+      },
+      "portscanner": "2.2.0",
+      "raw-body": "2.5.3",
+      "raw-body@2.5.3": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.1",
+        "http-errors@2.0.1": {
+          "depd": "2.0.0",
+          "inherits": "2.0.4",
+          "setprototypeof": "1.2.0",
+          "statuses": "2.0.2",
+          "toidentifier": "1.0.1"
+        },
+        "iconv-lite": "0.4.24",
+        "iconv-lite@0.4.24": {
+          "safer-buffer": "2.1.2"
+        },
+        "unpipe": "1.0.0"
+      },
+      "resp-modifier": "6.0.2",
+      "resp-modifier@6.0.2": {
+        "debug": "2.6.9",
+        "minimatch": "3.1.5",
+        "minimatch@3.1.5": {
+          "brace-expansion": "1.1.18",
+          "brace-expansion@1.1.18": {
+            "balanced-match": "1.0.2",
+            "concat-map": "0.0.1"
+          }
+        }
+      },
+      "rx": "4.1.0",
+      "send": "0.19.1",
+      "send@0.19.1": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "2.0.0",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "on-finished@2.4.1": {
+          "ee-first": "1.1.1"
+        },
+        "range-parser": "1.2.1",
+        "statuses": "2.0.1"
+      },
+      "serve-index": "1.9.1",
+      "serve-index@1.9.1": {
+        "accepts": "1.3.8",
+        "accepts@1.3.8": {
+          "mime-types": "2.1.35",
+          "negotiator": "0.6.3"
+        },
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "1.0.3",
+        "http-errors": "1.6.3",
+        "http-errors@1.6.3": {
+          "depd": "1.1.2",
+          "inherits": "2.0.3",
+          "setprototypeof": "1.1.0",
+          "statuses": "1.5.0"
+        },
+        "mime-types": "2.1.35",
+        "mime-types@2.1.35": {
+          "mime-db": "1.52.0"
+        },
+        "parseurl": "1.3.3"
+      },
+      "serve-static": "1.16.2",
+      "serve-static@1.16.2": {
+        "encodeurl": "2.0.0",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.3",
+        "send": "0.19.0",
+        "send@0.19.0": {
+          "debug": "2.6.9",
+          "depd": "2.0.0",
+          "destroy": "1.2.0",
+          "encodeurl": "1.0.2",
+          "escape-html": "1.0.3",
+          "etag": "1.8.1",
+          "fresh": "0.5.2",
+          "http-errors": "2.0.0",
+          "mime": "1.6.0",
+          "ms": "2.1.3",
+          "on-finished": "2.4.1",
+          "on-finished@2.4.1": {
+            "ee-first": "1.1.1"
+          },
+          "range-parser": "1.2.1",
+          "statuses": "2.0.1"
+        }
+      },
+      "server-destroy": "1.0.1",
+      "socket.io": "4.8.1",
+      "socket.io@4.8.1": {
+        "accepts": "1.3.8",
+        "base64id": "2.0.0",
+        "cors": "2.8.5",
+        "cors@2.8.5": {
+          "object-assign": "4.1.1",
+          "vary": "1.1.2"
+        },
+        "debug": "4.3.4",
+        "debug@4.3.4": {
+          "ms": "2.1.2"
+        },
+        "engine.io": "6.6.9",
+        "engine.io@6.6.9": {
+          "@types/cors": "2.8.19",
+          "@types/cors@2.8.19": {
+            "@types/node": "22.17.2"
+          },
+          "@types/node": "22.17.2",
+          "@types/ws": "8.18.1",
+          "@types/ws@8.18.1": {
+            "@types/node": "22.17.2"
+          },
+          "accepts": "1.3.8",
+          "base64id": "2.0.0",
+          "cookie": "0.7.2",
+          "cors": "2.8.5",
+          "debug": "4.4.3",
+          "debug@4.4.3": {
+            "ms": "2.1.3"
+          },
+          "engine.io-parser": "5.2.3",
+          "ws": "8.21.0"
+        },
+        "socket.io-adapter": "2.5.8",
+        "socket.io-adapter@2.5.8": {
+          "debug": "4.4.3",
+          "debug@4.4.3": {
+            "ms": "2.1.3"
+          },
+          "ws": "8.21.0"
+        },
+        "socket.io-parser": "4.2.7",
+        "socket.io-parser@4.2.7": {
+          "@socket.io/component-emitter": "3.1.0",
+          "debug": "4.4.3",
+          "debug@4.4.3": {
+            "ms": "2.1.3"
+          }
+        }
+      },
+      "ua-parser-js": "1.0.35",
+      "yargs": "17.7.3",
+      "yargs@17.7.3": {
+        "cliui": "8.0.1",
+        "cliui@8.0.1": {
+          "string-width": "4.2.3",
+          "strip-ansi": "6.0.1",
+          "wrap-ansi": "7.0.0",
+          "wrap-ansi@7.0.0": {
+            "ansi-styles": "4.3.0",
+            "string-width": "4.2.3",
+            "strip-ansi": "6.0.1"
+          }
+        },
+        "escalade": "3.2.0",
+        "get-caller-file": "2.0.5",
+        "require-directory": "2.1.1",
+        "string-width": "4.2.3",
+        "string-width@4.2.3": {
+          "emoji-regex": "8.0.0",
+          "is-fullwidth-code-point": "3.0.0",
+          "strip-ansi": "6.0.1"
+        },
+        "y18n": "5.0.8",
+        "yargs-parser": "21.1.1"
+      }
+    },
+    "chokidar@3.6.0": {
+      "anymatch": "3.1.3",
+      "anymatch@3.1.3": {
+        "normalize-path": "3.0.0",
+        "picomatch": "2.3.2"
+      },
+      "braces": "3.0.3",
+      "braces@3.0.3": {
+        "fill-range": "7.1.1",
+        "fill-range@7.1.1": {
+          "to-regex-range": "5.0.1",
+          "to-regex-range@5.0.1": {
+            "is-number": "7.0.0"
+          }
+        }
+      },
+      "fsevents": "2.3.2",
+      "glob-parent": "5.1.2",
+      "glob-parent@5.1.2": {
+        "is-glob": "4.0.3"
+      },
+      "is-binary-path": "2.1.0",
+      "is-binary-path@2.1.0": {
+        "binary-extensions": "2.2.0"
+      },
+      "is-glob": "4.0.3",
+      "is-glob@4.0.3": {
+        "is-extglob": "2.1.1"
+      },
+      "normalize-path": "3.0.0",
+      "readdirp": "3.6.0",
+      "readdirp@3.6.0": {
+        "picomatch": "2.3.2"
+      }
+    },
+    "cookie-parser@1.4.7": {
+      "cookie-signature": "1.0.6",
+      "cookie": "0.7.2"
+    },
+    "cross-spawn@7.0.6": {
+      "path-key": "3.1.1",
+      "shebang-command": "2.0.0",
+      "shebang-command@2.0.0": {
+        "shebang-regex": "3.0.0"
+      },
+      "which": "2.0.2",
+      "which@2.0.2": {
+        "isexe": "2.0.0"
+      }
+    },
+    "csrf-csrf@4.0.3": {
+      "http-errors": "2.0.0",
+      "http-errors@2.0.0": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      }
+    },
+    "express@5.2.1": {
+      "accepts": "2.0.0",
+      "accepts@2.0.0": {
+        "mime-types": "3.0.2",
+        "negotiator": "1.1.0",
+        "negotiator@1.1.0": {
+          "content-type": "2.1.0"
+        }
+      },
+      "body-parser": "2.3.0",
+      "body-parser@2.3.0": {
+        "bytes": "3.1.2",
+        "content-type": "2.1.0",
+        "debug": "4.4.3",
+        "debug@4.4.3": {
+          "ms": "2.1.3"
+        },
+        "http-errors": "2.0.1",
+        "http-errors@2.0.1": {
+          "depd": "2.0.0",
+          "inherits": "2.0.4",
+          "setprototypeof": "1.2.0",
+          "statuses": "2.0.2",
+          "toidentifier": "1.0.1"
+        },
+        "iconv-lite": "0.7.3",
+        "iconv-lite@0.7.3": {
+          "safer-buffer": "2.1.2"
+        },
+        "on-finished": "2.4.1",
+        "on-finished@2.4.1": {
+          "ee-first": "1.1.1"
+        },
+        "qs": "6.16.0",
+        "raw-body": "3.0.2",
+        "raw-body@3.0.2": {
+          "bytes": "3.1.2",
+          "http-errors": "2.0.1",
+          "iconv-lite": "0.7.3",
+          "unpipe": "1.0.0"
+        },
+        "type-is": "2.1.0"
+      },
+      "content-disposition": "1.1.0",
+      "content-type": "1.0.5",
+      "cookie-signature": "1.2.2",
+      "cookie": "0.7.2",
+      "debug": "4.4.3",
+      "debug@4.4.3": {
+        "ms": "2.1.3"
+      },
+      "depd": "2.0.0",
+      "encodeurl": "2.0.0",
+      "escape-html": "1.0.3",
+      "etag": "1.8.1",
+      "finalhandler": "2.1.1",
+      "finalhandler@2.1.1": {
+        "debug": "4.4.3",
+        "encodeurl": "2.0.0",
+        "escape-html": "1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "1.3.3",
+        "statuses": "2.0.2"
+      },
+      "fresh": "2.0.0",
+      "http-errors": "2.0.1",
+      "http-errors@2.0.1": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.2",
+        "toidentifier": "1.0.1"
+      },
+      "merge-descriptors": "2.0.0",
+      "mime-types": "3.0.2",
+      "mime-types@3.0.2": {
+        "mime-db": "1.54.0"
+      },
+      "on-finished": "2.4.1",
+      "on-finished@2.4.1": {
+        "ee-first": "1.1.1"
+      },
+      "once": "1.4.0",
+      "once@1.4.0": {
+        "wrappy": "1.0.2"
+      },
+      "parseurl": "1.3.3",
+      "proxy-addr": "2.0.7",
+      "proxy-addr@2.0.7": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "qs": "6.16.0",
+      "qs@6.16.0": {
+        "es-define-property": "1.0.1",
+        "side-channel": "1.1.1",
+        "side-channel@1.1.1": {
+          "es-errors": "1.3.0",
+          "object-inspect": "1.13.4",
+          "side-channel-list": "1.0.1",
+          "side-channel-list@1.0.1": {
+            "es-errors": "1.3.0",
+            "object-inspect": "1.13.4"
+          },
+          "side-channel-map": "1.0.1",
+          "side-channel-map@1.0.1": {
+            "call-bound": "1.0.4",
+            "es-errors": "1.3.0",
+            "get-intrinsic": "1.3.0",
+            "object-inspect": "1.13.4"
+          },
+          "side-channel-weakmap": "1.0.2",
+          "side-channel-weakmap@1.0.2": {
+            "call-bound": "1.0.4",
+            "es-errors": "1.3.0",
+            "get-intrinsic": "1.3.0",
+            "object-inspect": "1.13.4",
+            "side-channel-map": "1.0.1"
+          }
+        }
+      },
+      "range-parser": "1.2.1",
+      "router": "2.2.0",
+      "router@2.2.0": {
+        "debug": "4.4.3",
+        "debug@4.4.3": {
+          "ms": "2.1.3"
+        },
+        "depd": "2.0.0",
+        "is-promise": "4.0.0",
+        "parseurl": "1.3.3",
+        "path-to-regexp": "8.4.2"
+      },
+      "send": "1.2.1",
+      "send@1.2.1": {
+        "debug": "4.4.3",
+        "encodeurl": "2.0.0",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "2.0.0",
+        "http-errors": "2.0.1",
+        "mime-types": "3.0.2",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "1.2.1",
+        "statuses": "2.0.2"
+      },
+      "serve-static": "2.2.1",
+      "serve-static@2.2.1": {
+        "encodeurl": "2.0.0",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.3",
+        "send": "1.2.1"
+      },
+      "statuses": "2.0.2",
+      "type-is": "2.1.0",
+      "type-is@2.1.0": {
+        "content-type": "2.1.0",
+        "media-typer": "1.1.1",
+        "mime-types": "3.0.2",
+        "mime-types@3.0.2": {
+          "mime-db": "1.54.0"
+        }
+      },
+      "vary": "1.1.2"
+    },
+    "express-session@1.19.0": {
+      "cookie-signature": "1.0.7",
+      "cookie": "0.7.2",
+      "debug": "2.6.9",
+      "debug@2.6.9": {
+        "ms": "2.0.0"
+      },
+      "depd": "2.0.0",
+      "on-headers": "1.1.0",
+      "parseurl": "1.3.3",
+      "safe-buffer": "5.2.1",
+      "uid-safe": "2.1.5",
+      "uid-safe@2.1.5": {
+        "random-bytes": "1.0.0"
+      }
+    },
+    "fs-extra@11.4.0": {
+      "graceful-fs": "4.2.11",
+      "jsonfile": "6.1.0",
+      "jsonfile@6.1.0": {
+        "graceful-fs": "4.2.11",
+        "universalify": "2.0.0"
+      },
+      "universalify": "2.0.0"
+    },
+    "nodemon@3.1.14": {
+      "chokidar": "3.6.0",
+      "debug": "4.3.4",
+      "debug@4.3.4": {
+        "ms": "2.1.2"
+      },
+      "ignore-by-default": "1.0.1",
+      "minimatch": "10.2.6",
+      "minimatch@10.2.6": {
+        "brace-expansion": "5.0.9",
+        "brace-expansion@5.0.9": {
+          "balanced-match": "4.0.4"
+        }
+      },
+      "pstree.remy": "1.1.8",
+      "semver": "7.8.5",
+      "simple-update-notifier": "2.0.0",
+      "simple-update-notifier@2.0.0": {
+        "semver": "7.8.5"
+      },
+      "supports-color": "5.5.0",
+      "supports-color@5.5.0": {
+        "has-flag": "3.0.0"
+      },
+      "touch": "3.1.0",
+      "touch@3.1.0": {
+        "nopt": "1.0.10",
+        "nopt@1.0.10": {
+          "abbrev": "1.1.1"
+        }
+      },
+      "undefsafe": "2.0.5"
+    },
+    "nunjucks@3.2.4": {
+      "a-sync-waterfall": "1.0.1",
+      "asap": "2.0.6",
+      "chokidar": "3.6.0",
+      "commander": "5.1.0"
+    },
+    "portscanner@2.2.0": {
+      "async": "2.6.4",
+      "async@2.6.4": {
+        "lodash": "4.18.1"
+      },
+      "is-number-like": "1.0.8",
+      "is-number-like@1.0.8": {
+        "lodash.isfinite": "3.3.2"
+      }
+    },
+    "sass@1.103.1": {
+      "@parcel/watcher": "2.6.0",
+      "@parcel/watcher@2.6.0": {
+        "@parcel/watcher-darwin-arm64": "2.6.0",
+        "detect-libc": "2.1.2",
+        "is-glob": "4.0.3",
+        "node-addon-api": "7.1.1",
+        "picomatch": "4.0.7"
+      },
+      "chokidar": "5.0.0",
+      "chokidar@5.0.0": {
+        "readdirp": "5.1.1"
+      },
+      "immutable": "5.1.9",
+      "source-map-js": "1.0.2"
+    },
+    "tar-stream@3.2.1": {
+      "b4a": "1.8.1",
+      "bare-fs": "4.8.1",
+      "bare-fs@4.8.1": {
+        "bare-events": "2.9.2",
+        "bare-path": "3.1.2",
+        "bare-stream": "2.13.4",
+        "bare-stream@2.13.4": {
+          "b4a": "1.8.1",
+          "bare-events": "2.9.2",
+          "streamx": "2.28.1",
+          "teex": "1.0.1",
+          "teex@1.0.1": {
+            "streamx": "2.28.1"
+          }
+        },
+        "bare-url": "2.5.2",
+        "bare-url@2.5.2": {
+          "bare-path": "3.1.2"
+        },
+        "fast-fifo": "1.3.2"
+      },
+      "fast-fifo": "1.3.2",
+      "streamx": "2.28.1",
+      "streamx@2.28.1": {
+        "events-universal": "1.0.1",
+        "events-universal@1.0.1": {
+          "bare-events": "2.9.2"
+        },
+        "fast-fifo": "1.3.2",
+        "text-decoder": "1.2.7",
+        "text-decoder@1.2.7": {
+          "b4a": "1.8.1"
+        }
+      }
+    }
   }
 }

--- a/scripts/shrinkwrap-with-overrides.js
+++ b/scripts/shrinkwrap-with-overrides.js
@@ -1,0 +1,66 @@
+#! /usr/bin/env node
+const { promisify } = require('node:util');
+const exec = promisify(require('node:child_process').exec);
+const _ = require('lodash');
+const { writeFile, readFile } = require('node:fs/promises');
+const { writeFileSync } = require('node:fs');
+
+;(async () => {    
+    // Get the list of installed dependencies. Unfortunately `--omit` excludes transitive dependencies
+    // so we need to use `--all`
+    const {stdout} = await exec('npm ls --all --json')
+
+    const installedDependencies = JSON.parse(stdout).dependencies;
+
+    // Get the list of of non-dev dependencies for the Kit
+    const package = JSON.parse(await readFile('package.json'), {encoding: 'utf-8'})
+
+    for (const dependencyName of Object.keys(package.dependencies)) {
+        const installedDependency = installedDependencies[dependencyName];
+        // Update the direct dependency
+        pinDirectDependency(package, dependencyName, installedDependency.version)
+        // Traverse the transitive dependencies to create overrides
+        traverse([{
+            name: dependencyName,
+            ...installedDependency
+        }], 'dependencies', (dependencyPath) => {
+            // TODO: We can be more clever in grouping dependencies
+            pinTransitiveDependency(package,dependencyPath)
+        })
+    }
+
+    await writeFile('package.json', JSON.stringify(package, null, 2), {encoding: 'utf-8'})
+})()
+
+function pinDirectDependency(package, dependencyName, version) {
+    console.log(`Pinning ${dependencyName} at ${version}`)
+    _.set(package,`dependencies.${dependencyName}`, version);
+}
+
+function pinTransitiveDependency(package,dependencyPath) {
+    const dependency = dependencyPath.pop();
+
+    if (!dependency.version) return;
+
+    const ancestors = dependencyPath.map(({name, version}) => `["${name}@${version}"]`);
+    ancestors.push(`["${dependency.name}"]`)
+    console.log(`overrides${ancestors.join('')}`,dependency.version )
+    _.set(package, `overrides${ancestors.join('')}`, dependency.version)
+}
+
+function traverse(ancestors, property, callback) {
+    const toTraverse = ancestors.at(-1)[property];
+    // Stop traversing if there's no property on the object
+    if (!toTraverse) {
+        return;
+    }
+    
+    for(const [name, metadata] of Object.entries(toTraverse)) {
+        if (metadata){
+            const metadataWithName = {name, ...metadata};
+            callback([...ancestors, metadataWithName]);
+            traverse([...ancestors, metadataWithName], property, callback)
+        }
+    }
+}
+


### PR DESCRIPTION
Pinning dependencies in the package's `package.json` file using exact version for the dependencies only affects the direct dependencies (looks like we're already pinning GOV.UK Frontend to 5.11, likely by mistake).

This spike explored whether we can use `overrides` in the `package.json` to extend the pinning to all dependencies, not just the direct ones. Unfortunately, npm installs newer versions despite overrides setting exact version numbers.

## Protocol

- the `immutable` (transitive dependency of `browser-sync`) has been downgraded from 3.8.4 to 3.8.3. We'll know overrides worked as intended if a created kit installs 3.8.3 despite 3.8.4 being available on npm and matching `browser-sync`'s dependency requirements
- a new `scripts/shrinkwrap-with-overrides.js` modifies the project's `package.json` to set exact versions on the direct dependencies and add `overrides` for the transitive dependencies. It'd likely need a little optimisation in the `overrides` set up to flatten its content.
- the result of running the script is pushed on that branch so we can test installing pointing npm at this branch. In practice, we'd run the script on `prepack` to pin the dependencies before publishing and run `git checkout package.json` on `postpack` to revert it.
- creating a new prototype can be achieved with the following command:
  ```
  npx govuk-prototype-kit@alphagov/govuk-prototype-kit#aedd3b5 create --version alphagov/govuk-prototype-kit#aedd3b5 <OPTIONAL_FOLDER_FOR_THE_PROTOTYPE>
  ```

Immutable being installed at version 3.8.4 in the created prototype showed that overrides do not pin transitive dependencies.

The [`pin-with-overrides-hoist-immutable`](https://github.com/alphagov/govuk-prototype-kit/compare/pin-with-overrides...pin-with-overrides-hoist-immutable) tested if having `immutable` at the root of `overrides` rather than nested inside the packages that depend on it changes anything. It unfortunately doesn't 😔  